### PR TITLE
Make the tests pass by cleaning up some stuff.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,5 @@ Lead
 
 Contributors (chronological)
 ============================
+
+- Josh Johnston `@Trii <https://github.com/Trii>`_

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,8 +7,6 @@ webargs>=0.9.0
 WTForms>=2.0.1
 colander>=1.0
 Flask
-marshmallow
-pyyaml
 
 # testing
 pytest

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,8 @@ webargs>=0.9.0
 WTForms>=2.0.1
 colander>=1.0
 Flask
+marshmallow
+pyyaml
 
 # testing
 pytest

--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -29,11 +29,15 @@ class Path(object):
         invalid = set(iterkeys(operations)) - set(VALID_METHODS)
         # Reject invalid http methods
         if invalid:
-            raise APISpecError('One or more HTTP methods are invalid: {0}'.format(", ".join(invalid)))
+            raise APISpecError(
+                'One or more HTTP methods are invalid: {0}'.format(", ".join(invalid))
+            )
         # Reject invalid operations definitions
         for method, operation in iteritems(operations):
             if len(operation.get('responses', {})) == 0:
-                raise APISpecError('One or more Responses are required for method {0}'.format(method))
+                raise APISpecError(
+                    'One or more Responses are required for method {0}'.format(method)
+                )
         self.operations = operations
 
     def to_dict(self):

--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -96,8 +96,8 @@ class APISpec(object):
         methods = set(iterkeys(path.operations)) & set(iterkeys(self._response_helpers))
         for method in methods:
             responses = path.operations[method]['responses']
-            statii = set(iterkeys(responses)) & set(iterkeys(self._response_helpers[method]))
-            for status_code in statii:
+            statuses = set(iterkeys(responses)) & set(iterkeys(self._response_helpers[method]))
+            for status_code in statuses:
                 for func in self._response_helpers[method][status_code]:
                     responses[status_code].update(
                         func(self, **kwargs)

--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from marshmallow.compat import iteritems
+from marshmallow.compat import iteritems, iterkeys
 from .exceptions import APISpecError, PluginError
 
 VALID_METHODS = [
@@ -25,7 +25,16 @@ class Path(object):
 
     def __init__(self, path=None, operations=None, **kwargs):
         self.path = path
-        self.operations = operations or {}
+        operations = operations or {}
+        invalid = set(iterkeys(operations)) - set(VALID_METHODS)
+        # Reject invalid http methods
+        if invalid:
+            raise APISpecError('One or more HTTP methods are invalid: {0}'.format(", ".join(invalid)))
+        # Reject invalid operations definitions
+        for method, operation in iteritems(operations):
+            if len(operation.get('responses', {})) == 0:
+                raise APISpecError('One or more Responses are required for method {0}'.format(method))
+        self.operations = operations
 
     def to_dict(self):
         if not self.path:
@@ -78,18 +87,17 @@ class APISpec(object):
             if isinstance(ret, Path):
                 path.update(ret)
 
-        # TODO: reduce nesting
-        if path.operations:
-            for method in VALID_METHODS:
-                if method in path.operations:
-                    responses = path.operations[method].get('responses', [])
-                    for status_code, config in iteritems(responses):
-                        if status_code in self._response_helpers[method]:
-                            funcs = self._response_helpers[method][status_code]
-                            for func in funcs:
-                                path.operations[method]['responses'][status_code].update(
-                                    func(self, **kwargs)
-                                )
+        # Process response helpers for any path operations defined.
+        # Rule is that method + http status exist in both operations and helpers
+        methods = set(iterkeys(path.operations)) & set(iterkeys(self._response_helpers))
+        for method in methods:
+            responses = path.operations[method]['responses']
+            statii = set(iterkeys(responses)) & set(iterkeys(self._response_helpers[method]))
+            for status_code in statii:
+                for func in self._response_helpers[method][status_code]:
+                    responses[status_code].update(
+                        func(self, **kwargs)
+                    )
 
         self._paths.update(path.to_dict())
 

--- a/smore/swagger/__init__.py
+++ b/smore/swagger/__init__.py
@@ -40,9 +40,11 @@ FIELD_MAPPING = {
     fields.List: ('array', None),
 }
 
+
 def _get_json_type_for_field(field):
     json_type, fmt = FIELD_MAPPING.get(type(field), ('string', None))
     return json_type, fmt
+
 
 def field2property(field, use_refs=True):
     """Return the JSON Schema property definition given a marshmallow
@@ -75,6 +77,7 @@ def field2property(field, use_refs=True):
         else:
             ret = schema
     return ret
+
 
 def schema2jsonschema(schema_cls):
     """Return the JSON Schema Object for a given marshmallow
@@ -160,15 +163,18 @@ def _get_json_type(pytype):
     json_type, fmt = __type_map__.get(pytype, ('string', None))
     return json_type, fmt
 
+
 def arg2parameter(arg, name=None, default_in='body'):
     """Return the Parameter Object definition for a :class:`webargs.Arg <webargs.core.Arg>`.
 
     https://github.com/wordnik/swagger-spec/blob/master/versions/2.0.md#parameterObject
-
+    :param webargs.core.Arg arg: Webarg
+    :param str name: Field name
+    :param str default_in: Default location to look for ``name``
     :raise: TranslationError if arg object cannot be translated to a Parameter Object schema.
     :rtype: dict, a Parameter Object
     """
-    swagger_target = __target_map__.get(arg.target, default_in)
+    swagger_target = __target_map__.get(arg.location, default_in)
     ret = {
         'in': swagger_target,
         'required': arg.required,
@@ -186,6 +192,7 @@ def arg2parameter(arg, name=None, default_in='body'):
     else:
         ret.update(arg_as_property)
     return ret
+
 
 def arg2property(arg):
     """Return the JSON Schema property definition given a webargs :class:`Arg <webargs.core.Arg>`.
@@ -215,6 +222,7 @@ def arg2property(arg):
     ret.update(arg.metadata)
     return ret
 
+
 def args2parameters(args, default_in='body'):
     """Return an array of Swagger properties given a dictionary of webargs
     :class:`Args <webargs.core.Arg>`.
@@ -224,8 +232,8 @@ def args2parameters(args, default_in='body'):
     Example: ::
 
         args = {
-            'username': Arg(str, target='querystring', description='Username to log in'),
-            'password': Arg(str, target='querystring', description='Password in plain text'),
+            'username': Arg(str, location='querystring', description='Username to log in'),
+            'password': Arg(str, location='querystring', description='Password in plain text'),
         }
         args2parameters(args)
         # [{'required': False, 'type': 'string', 'in': 'query',

--- a/smore/validate/core.py
+++ b/smore/validate/core.py
@@ -24,7 +24,11 @@ else:
         webargs' ``ValidationError`` (if webargs is installed) and marshmallow's
         ``ValidationError`` so that the same validation functions can be used in either library.
         """
-        pass
+
+        def __init__(self, message, field=None, **_):
+            # make the signature compatible with the above impl for when not HAS_WEBARGS
+            super(ValidationError, self).__init__(message, field)
+
 
 class BaseConverter(object):
     """Base converter validator that converts a third-party validators into

--- a/tests/apispec/test_core.py
+++ b/tests/apispec/test_core.py
@@ -175,13 +175,26 @@ class TestPathHelpers:
             view_func={'path': '/pet/{petId}'},
             operations=dict(
                 get=dict(
-                    produces=('application/xml', )
+                    produces=('application/xml', ),
+                    responses={
+                        "200": {
+                            "schema": {'$ref': '#/definitions/Pet'},
+                            'description': 'successful operation'
+                        }
+                    }
                 )
             )
         )
         expected = {
             '/pet/{petId}': {
-                'get': {'produces': ('application/xml', )}
+                'get': {'produces': ('application/xml', ),
+                        'responses': {
+                            "200": {
+                                "schema": {'$ref': '#/definitions/Pet'},
+                                'description': 'successful operation'
+                            }
+                        }
+                }
             }
         }
 

--- a/tests/apispec/test_ext_flask.py
+++ b/tests/apispec/test_ext_flask.py
@@ -35,10 +35,10 @@ class TestPathHelpers:
         def hello():
             return 'hi'
 
-        spec.add_path(view=hello, operations={'get': {'parameters': '..params..'}})
+        spec.add_path(view=hello, operations={'get': {'parameters': '..params..', 'responses': {'200': '..params..'}}})
         assert '/hello' in spec._paths
         assert 'get' in spec._paths['/hello']
-        assert spec._paths['/hello']['get'] == {'parameters': '..params..'}
+        assert spec._paths['/hello']['get'] == {'parameters': '..params..', 'responses': {'200': '..params..'}}
 
     def test_path_with_multiple_methods(self, app, spec):
 
@@ -47,8 +47,8 @@ class TestPathHelpers:
             return 'hi'
 
         spec.add_path(view=hello, operations=dict(
-            get={'description': 'get a greeting'},
-            post={'description': 'post a greeting'}
+            get={'description': 'get a greeting', 'responses': {'200': '..params..'}},
+            post={'description': 'post a greeting', 'responses': {'200': '..params..'}}
         ))
         get_op = spec._paths['/hello']['get']
         post_op = spec._paths['/hello']['post']
@@ -64,10 +64,24 @@ class TestPathHelpers:
             ---
             get:
                 description: get a greeting
+                responses:
+                    200:
+                        description: a pet to be returned
+                        schema:
+                            $ref: #/definitions/Pet
+
             post:
                 description: post a greeting
+                responses:
+                    200:
+                        description:some data
+
             foo:
                 description: not a valid operation
+                responses:
+                    200:
+                        description:
+                            more junk
             """
             return 'hi'
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -6,7 +6,6 @@ from marshmallow import fields, Schema
 from marshmallow.compat import binary_type
 
 from smore import swagger
-from smore.exceptions import SmoreError
 from smore.swagger import arg2parameter, arg2property
 
 
@@ -22,7 +21,7 @@ class TestArgToSwagger:
         (set, 'array'),
     ])
     def test_type_translation(self, pytype, jsontype):
-        arg = Arg(pytype, target='form')
+        arg = Arg(pytype, location='form')
         result = arg2parameter(arg)
         assert result['type'] == jsontype
 
@@ -34,7 +33,7 @@ class TestArgToSwagger:
         ('files', 'formData')
     ])
     def test_target_translation(self, webargs_target, swagger_target):
-        arg = Arg(int, target=webargs_target)
+        arg = Arg(int, location=webargs_target)
         result = arg2parameter(arg)
         assert result['in'] == swagger_target
 
@@ -49,47 +48,47 @@ class TestArgToSwagger:
         arg.target = 'json'
         result = arg2parameter(arg)
         assert result['required'] is True
-        arg2 = Arg(int, target='json')
+        arg2 = Arg(int, location='json')
         result2 = arg2parameter(arg2)
         assert result2['required'] is False
 
     def test_arg_with_description(self):
-        arg = Arg(int, target='form', description='a webargs arg')
+        arg = Arg(int, location='form', description='a webargs arg')
         result = arg2parameter(arg)
         assert result['description'] == arg.metadata['description']
 
     def test_arg_with_format(self):
-        arg = Arg(int, target='form', format='int32')
+        arg = Arg(int, location='form', format='int32')
         result = arg2parameter(arg)
         assert result['format'] == 'int32'
 
     def test_arg_with_default(self):
-        arg = Arg(int, target='form', default=42)
+        arg = Arg(int, location='form', default=42)
         result = arg2parameter(arg)
         assert result['default'] == 42
 
     def test_arg_name_is_body_if_target_is_json(self):
-        arg = Arg(int, target='json')
+        arg = Arg(int, location='json')
         result = arg2parameter(arg)
         assert result['name'] == 'body'
 
     def test_arg_with_name(self):
-        arg = Arg(int, target='form', name='foo')
+        arg = Arg(int, location='form', name='foo')
         res = arg2parameter(arg)
         assert res['name'] == 'foo'
 
     def test_schema_if_json_body(self):
-        arg = Arg(int, target='json')
+        arg = Arg(int, location='json')
         res = arg2parameter(arg)
         assert 'schema' in res
 
     def test_no_schema_if_form_body(self):
-        arg = Arg(int, target='form')
+        arg = Arg(int, location='form')
         res = arg2parameter(arg)
         assert 'schema' not in res
 
     def test_arg2property_with_description(self):
-        arg = Arg(int, target='json', description='status')
+        arg = Arg(int, location='json', description='status')
         res = arg2property(arg)
         assert res['type'] == 'integer'
         assert res['description'] == arg.metadata['description']
@@ -100,7 +99,7 @@ class TestArgToSwagger:
         (binary_type, 'byte'),
     ])
     def test_arg2property_formats(self, pytype, expected_format):
-        arg = Arg(pytype, target='json')
+        arg = Arg(pytype, location='json')
         res = arg2property(arg)
         assert res['format'] == expected_format
 
@@ -116,7 +115,7 @@ class TestArgToSwagger:
         assert res['maxLength'] == 100
 
     def test_arg2swagger_puts_json_arguments_in_schema(self):
-        arg = Arg(int, target='json', description='a count', format='int32')
+        arg = Arg(int, location='json', description='a count', format='int32')
         res = arg2parameter(arg, 'username')
         assert res['name'] == 'body'
         assert 'description' not in res
@@ -127,12 +126,13 @@ class TestArgToSwagger:
         assert schema_props['username']['description'] == arg.metadata['description']
         assert schema_props['username']['format'] == 'int32'
 
+
 class TestWebargsSchemaToSwagger:
 
     def test_args2parameters(self):
         args = {
-            'username': Arg(str, target='querystring',
-                required=False, description='The user name for login'),
+            'username': Arg(str, location='querystring', required=False,
+                            description='The user name for login'),
         }
         result = swagger.args2parameters(args)
         username = result[0]
@@ -144,7 +144,7 @@ class TestWebargsSchemaToSwagger:
 
     def test_arg2parameters_uses_source_for_name(self):
         args = {
-            'neat_header': Arg(str, target='headers', source='X-Neat-Header')
+            'neat_header': Arg(str, location='headers', source='X-Neat-Header')
         }
         result = swagger.args2parameters(args)
         header = result[0]
@@ -271,8 +271,10 @@ class CategorySchema(Schema):
     id = fields.Int()
     name = fields.Str()
 
+
 class PetSchema(Schema):
     category = fields.Nested(CategorySchema)
+
 
 class TestNesting:
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -9,6 +9,7 @@ from webargs import Arg, ValidationError as WebargsValidationError
 
 from smore.validate import ValidationError
 
+
 class TestValidationError:
 
     def test_marshmallow_validation(self):
@@ -42,6 +43,7 @@ class TestValidationError:
 
 from smore.validate.wtforms import from_wtforms, make_converter
 from wtforms.validators import AnyOf, NoneOf, Length
+
 
 class TestWTFormsValidation:
 


### PR DESCRIPTION
I pulled this today to see how I can use it for my current project based off of the notes from #1 as well as the [webapp2 parser](https://github.com/sloria/webargs/pull/36).

Here is my changelog in getting tests to pass:
- Fix up broken unit tests due to `webargs.Arg.target` being renamed to `location`
- Add some PEP8 newlines before classes, minor indentation
- Make the `responses` field required per spec on the [Operation Object](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#operation-object)
- Fix bug in `smore.apispec.core` that was causing some test failures with
- KeyError due to path operations not always matching up with the registered request helpers
- Made a pass at the TODO: nesting in the above fix
- Drank a lot of coffee

Take a look and I'll clean up anything you'd like me to clean. I'm only 75% happy with the nesting fix. It is still a bit too confusing to read.
