### PR TITLE
Initial webapp2 plugin

### DIFF
--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -32,12 +32,6 @@ class Path(object):
             raise APISpecError(
                 'One or more HTTP methods are invalid: {0}'.format(", ".join(invalid))
             )
-        # Reject invalid operations definitions
-        for method, operation in iteritems(operations):
-            if len(operation.get('responses', {})) == 0:
-                raise APISpecError(
-                    'One or more Responses are required for method {0}'.format(method)
-                )
         self.operations = operations
 
     def to_dict(self):

--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from marshmallow.compat import iteritems, iterkeys
+from marshmallow.compat import iterkeys
 from .exceptions import APISpecError, PluginError
 
 VALID_METHODS = [

--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -12,7 +12,7 @@ VALID_METHODS = [
 ]
 
 
-class Path(object):
+class Path(dict):
     """Represents a Swagger Path object.
 
     https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#pathsObject
@@ -27,12 +27,13 @@ class Path(object):
         self.path = path
         operations = operations or {}
         invalid = set(iterkeys(operations)) - set(VALID_METHODS)
-        # Reject invalid http methods
         if invalid:
             raise APISpecError(
                 'One or more HTTP methods are invalid: {0}'.format(", ".join(invalid))
             )
         self.operations = operations
+        kwargs.update(self.operations)
+        super(Path, self).__init__(**kwargs)
 
     def to_dict(self):
         if not self.path:
@@ -41,10 +42,11 @@ class Path(object):
             self.path: self.operations
         }
 
-    def update(self, path):
+    def update(self, path, **kwargs):
         if path.path:
             self.path = path.path
         self.operations.update(path.operations)
+        super(Path, self).update(path.operations)
 
 
 class APISpec(object):
@@ -85,6 +87,8 @@ class APISpec(object):
             if isinstance(ret, Path):
                 path.update(ret)
 
+        if not path.path:
+            raise APISpecError('Path template is not specified')
         # Process response helpers for any path operations defined.
         # Rule is that method + http status exist in both operations and helpers
         methods = set(iterkeys(path.operations)) & set(iterkeys(self._response_helpers))
@@ -97,7 +101,7 @@ class APISpec(object):
                         func(self, **kwargs)
                     )
 
-        self._paths.update(path.to_dict())
+        self._paths.setdefault(path.path, path).update(path)
 
     def definition(self, name, properties=None, enum=None, **kwargs):
         """Add a new definition to the spec.

--- a/smore/ext/webapp2.py
+++ b/smore/ext/webapp2.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+.. module:: webapp2
+   :synopsis: Automatic documentation from your webapp2 project
+
+The :mod:`smore.ext.webapp2 <webapp2>` module generates swagger path objects from your routes
+
+"""
+from __future__ import absolute_import
+
+import webapp2
+from marshmallow.compat import iteritems
+from smore.apispec import Path
+from smore.apispec.exceptions import APISpecError
+from smore.apispec import utils
+
+
+def path_from_route(spec, route, operations=None, **kwargs):
+    """Creates a :class:`smore.apispec.Path` object based off of a :class:`webapp2.Route` and their subclasses
+
+    :param smore.apispec.APISpec spec:
+    :param webapp2.Route route:
+    :param kwargs:
+    :return: The generated :class:`Path <smore.apispec.Path>` object
+    :rtype: smore.apispec.Path
+    """
+    # make sure route.reverse_template is lazy loaded
+    getattr(route, 'regex', None)
+    path = route.reverse_template.replace('%(', '{').replace(')s', '}')
+    methods = route.methods if route.methods else ['GET', 'POST', 'PUT', 'DELETE']
+    merge_ops = {method.lower(): {} for method in methods}
+    for method, details in iteritems(operations or {}):
+        if method not in merge_ops:
+            raise APISpecError("Method {0} is not handled by route {0}".format(method, path))
+        merge_ops[method].update(details)
+    handler = route.handler
+    router = webapp2.get_app().router
+    if isinstance(handler, basestring):
+        if handler not in router.handlers:
+            router.handlers[handler] = handler = webapp2.import_string(handler)
+        else:
+            handler = router.handlers[handler]
+    for method, details in iteritems(merge_ops):
+        handler_method = getattr(handler, route.handler_method or method.lower().replace('-', '_'), None)
+        docops = utils.load_operations_from_docstring(getattr(handler_method, '__doc__', ''))
+        # Merge in any `method`: yaml subsection
+        if docops and docops.get(method, None):
+            details.update(docops.get(method))
+    path = Path(path=path, operations=merge_ops)
+    return path
+
+
+def setup(spec):
+    """Register plugin with the :class:`smore.apispec.APISpec`
+
+    :param smore.apispec.APISpec spec: The APISpec instance the plugin will register data onto
+    """
+    spec.register_path_helper(path_from_route)

--- a/smore/ext/webapp2.py
+++ b/smore/ext/webapp2.py
@@ -9,14 +9,15 @@ The :mod:`smore.ext.webapp2 <webapp2>` module generates swagger path objects fro
 from __future__ import absolute_import
 
 import webapp2
-from marshmallow.compat import iteritems
+from marshmallow.compat import iteritems, basestring
 from smore.apispec import Path
 from smore.apispec.exceptions import APISpecError
 from smore.apispec import utils
 
 
 def path_from_route(spec, route, operations=None, **kwargs):
-    """Creates a :class:`smore.apispec.Path` object based off of a :class:`webapp2.Route` and their subclasses
+    """Creates a :class:`smore.apispec.Path` object based off of a :class:`webapp2.Route`
+    and their subclasses
 
     :param smore.apispec.APISpec spec:
     :param webapp2.Route route:
@@ -41,7 +42,8 @@ def path_from_route(spec, route, operations=None, **kwargs):
         else:
             handler = router.handlers[handler]
     for method, details in iteritems(merge_ops):
-        handler_method = getattr(handler, route.handler_method or method.lower().replace('-', '_'), None)
+        try_method = route.handler_method or method.lower().replace('-', '_')
+        handler_method = getattr(handler, try_method, None)
         docops = utils.load_operations_from_docstring(getattr(handler_method, '__doc__', ''))
         # Merge in any `method`: yaml subsection
         if docops and docops.get(method, None):

--- a/smore/ext/webapp2.py
+++ b/smore/ext/webapp2.py
@@ -35,12 +35,11 @@ def path_from_route(spec, route, operations=None, **kwargs):
             raise APISpecError("Method {0} is not handled by route {0}".format(method, path))
         merge_ops[method].update(details)
     handler = route.handler
-    router = webapp2.get_app().router
     if isinstance(handler, basestring):
-        if handler not in router.handlers:
-            router.handlers[handler] = handler = webapp2.import_string(handler)
+        if handler not in _route_cache.handlers:
+            _route_cache[handler] = handler = webapp2.import_string(handler)
         else:
-            handler = router.handlers[handler]
+            handler = _route_cache[handler]
     for method, details in iteritems(merge_ops):
         try_method = route.handler_method or method.lower().replace('-', '_')
         handler_method = getattr(handler, try_method, None)
@@ -58,3 +57,7 @@ def setup(spec):
     :param smore.apispec.APISpec spec: The APISpec instance the plugin will register data onto
     """
     spec.register_path_helper(path_from_route)
+
+_route_cache = {}
+
+__all__ = ['path_from_route', 'setup']

--- a/tests/apispec/test_core.py
+++ b/tests/apispec/test_core.py
@@ -118,7 +118,7 @@ class TestExtensions:
     def test_setup_plugin(self, mock_setup, spec):
         spec.setup_plugin(self.DUMMY_PLUGIN)
         assert self.DUMMY_PLUGIN in spec.plugins
-        mock_setup.assert_called_once
+        mock_setup.assert_called_once()
         spec.setup_plugin(self.DUMMY_PLUGIN)
         assert mock_setup.call_count == 1
 

--- a/tests/apispec/test_core.py
+++ b/tests/apispec/test_core.py
@@ -114,11 +114,11 @@ class TestExtensions:
 
     DUMMY_PLUGIN = 'tests.apispec.plugins.dummy_plugin'
 
-    @mock.patch(DUMMY_PLUGIN + '.setup')
+    @mock.patch(DUMMY_PLUGIN + '.setup', autospec=True)
     def test_setup_plugin(self, mock_setup, spec):
         spec.setup_plugin(self.DUMMY_PLUGIN)
         assert self.DUMMY_PLUGIN in spec.plugins
-        mock_setup.assert_called_once()
+        mock_setup.assert_called_once_with(spec)
         spec.setup_plugin(self.DUMMY_PLUGIN)
         assert mock_setup.call_count == 1
 

--- a/tests/apispec/test_ext_webapp2.py
+++ b/tests/apispec/test_ext_webapp2.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+import pytest
+import sys
+
+PY2 = int(sys.version[0]) == 2
+
+pytestmark = pytest.mark.skipif(not PY2, reason='webapp2 is only compatible with Python 2')
+
+from smore.apispec import APISpec
+
+if PY2:
+    # everything should be skipped via `pytestmark` here so it is OK
+    import webapp2
+    from webapp2_extras import routes
+
+
+    class MainPage(webapp2.RequestHandler):
+        def get(self, *args, **kwargs):
+            self.response.write('Hello from GET!')
+
+        def post(self, *args, **kwargs):
+            self.response.write('Hello from POST!')
+
+        def put(self, *args, **kwargs):
+            self.response.write('Hello from PUT!')
+
+        def delete(self, *args, **kwargs):
+            self.response.write('Hello from DELETE!')
+
+        def patch(self, *args, **kwargs):
+            self.response.write('Hello from PATCH!')
+
+        def get_with_docstring(self, *args, **kwargs):
+            """A greeting endpoint.
+
+            ---
+            get:
+                description: get a greeting
+                responses:
+                    200:
+                        description: Greets you
+
+            post:
+                description: post a greeting
+                responses:
+                    200:
+                        description:some data
+
+            foo:
+                description: not a valid operation
+                responses:
+                    200:
+                        description:
+                            more junk
+            """
+            self.response.write('Hello from GET docstring!')
+
+
+@pytest.fixture()
+def spec():
+    return APISpec(
+        title='Swagger Petstore',
+        version='1.0.0',
+        description='This is a sample Petstore server.  You can find out more '
+        'about Swagger at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> '
+        'or on irc.freenode.net, #swagger.  For this sample, you can use the api '
+        'key \"special-key\" to test the authorization filters',
+        plugins=[
+            'smore.ext.webapp2'
+        ]
+    )
+
+
+@pytest.fixture()
+def app():
+    _app = webapp2.WSGIApplication([
+        routes.PathPrefixRoute('/prefix', [
+            # all routes go here
+            webapp2.Route(r'/path/<course_id>', MainPage, methods=['GET']),
+            webapp2.Route(r'/users/<user_id:\d+>/setting/<setting_id:\w\d+>', MainPage),
+        ]),
+        webapp2.Route(r'/1', MainPage),
+        webapp2.Route(r'/2', MainPage, methods=['POST']),
+        webapp2.Route(r'/3', MainPage, methods=['DELETE', 'GET'])
+    ], debug=True)
+    # set up app and request for testing
+    request = webapp2.Request.blank('/')
+    _app.set_globals(app=_app, request=request)
+    return _app
+
+
+class TestPathHelpers:
+
+    def test_path_from_view(self, app, spec):
+        route = webapp2.Route(r'/hello', MainPage, methods=['GET'])
+        spec.add_path(route=route)
+        assert '/hello' in spec._paths
+        assert 'get' in spec._paths['/hello']
+        assert spec._paths['/hello']['get'] == {}
+
+    def test_path_with_multiple_methods(self, app, spec):
+        route = webapp2.Route(r'/hello', MainPage, methods=['GET', 'POST'])
+        spec.add_path(route=route, operations=dict(
+            get={'description': 'get a greeting', 'responses': {'200': '..params..'}},
+            post={'description': 'post a greeting', 'responses': {'200': '..params..'}}
+        ))
+
+        get_op = spec._paths['/hello']['get']
+        post_op = spec._paths['/hello']['post']
+        assert get_op['description'] == 'get a greeting'
+        assert post_op['description'] == 'post a greeting'
+
+    def test_integration_with_docstring_introspection(self, app, spec):
+        route = webapp2.Route(r'/hello', MainPage, methods=['GET', 'POST'], handler_method='get_with_docstring')
+        spec.add_path(route=route)
+        get_op = spec._paths['/hello']['get']
+        post_op = spec._paths['/hello']['post']
+        assert get_op['description'] == 'get a greeting'
+        assert post_op['description'] == 'post a greeting'
+        assert 'foo' not in spec._paths['/hello']
+
+    def test_path_is_translated_to_swagger_template(self, app, spec):
+        route = webapp2.Route(r'/hello/<name:\d+>', MainPage, methods=['GET', 'POST'])
+        spec.add_path(route=route)
+
+        assert '/hello/{name}' in spec._paths
+
+    def test_route_types_can_be_translated(self, app, spec):
+        routes = set(r for route in app.router.match_routes for r in route.get_routes())
+        for route in routes:
+            spec.add_path(route=route)
+        assert len(spec._paths) == len(routes)
+        assert '/prefix/path/{course_id}' in spec._paths
+        assert '/prefix/users/{user_id}/setting/{setting_id}' in spec._paths
+        assert '/1' in spec._paths
+        assert '/2' in spec._paths
+        assert '/3' in spec._paths


### PR DESCRIPTION
This is what I am working on right now. I removed the check for non empty `responses` from  `smore/apispec/core.py` so that it could be aggregated from `APISpec.add_path` as well as docstring content. I was going under the assumption that the final call to generate the swagger document would take care of checking for missing items that are marked required per the spec.
