### PR TITLE
Add items description to array properties.

### DIFF
--- a/smore/swagger/__init__.py
+++ b/smore/swagger/__init__.py
@@ -76,6 +76,8 @@ def field2property(field, use_refs=True):
             ret['items'] = schema
         else:
             ret = schema
+    elif isinstance(field, fields.List):
+        ret['items'] = field2property(field.container)
     return ret
 
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -181,6 +181,7 @@ class TestMarshmallowFieldToSwagger:
         field = fields.List(fields.String)
         res = swagger.field2property(field)
         assert res['type'] == 'array'
+        assert res['items'] == swagger.field2property(fields.String())
 
     @mark.parametrize(('FieldClass', 'expected_format'), [
         (fields.Integer, 'int32'),


### PR DESCRIPTION
"items" object is required for properties of type "array". See
https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#itemsObject.
