### PR TITLE
Note required model fields in separate list.

### DIFF
--- a/smore/swagger/__init__.py
+++ b/smore/swagger/__init__.py
@@ -64,7 +64,6 @@ def field2property(field, use_refs=True):
         ret['format'] = fmt
     if field.default:
         ret['default'] = field.default
-    ret['required'] = field.required
     ret.update(field.metadata)
     if isinstance(field, fields.Nested):
         if use_refs and field.metadata.get('ref'):
@@ -123,12 +122,11 @@ def schema2jsonschema(schema_cls):
     if getattr(schema_cls.Meta, 'fields', None) or getattr(schema_cls.Meta, 'additional', None):
         warnings.warn('Only explicitly-declared fields will be included in the Schema Object. '
                 'Fields defined in Meta.fields or Meta.addtional are excluded.')
-    ret = {
-        'properties': {
-            field_name: field2property(field_obj)
-            for field_name, field_obj in iteritems(schema_cls._declared_fields)
-        }
-    }
+    ret = {'properties': {}}
+    for field_name, field_obj in iteritems(schema_cls._declared_fields):
+        ret['properties'][field_name] = field2property(field_obj)
+        if field_obj.required:
+            ret.setdefault('required', []).append(field_name)
     if hasattr(schema_cls, 'Meta'):
         if hasattr(schema_cls.Meta, 'title'):
             ret['title'] = schema_cls.Meta.title

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -206,13 +206,6 @@ class TestMarshmallowFieldToSwagger:
         res = swagger.field2property(field)
         assert res['default'] == 'foo'
 
-    def test_field_required(self):
-        field = fields.Str(required=True)
-        res = swagger.field2property(field)
-        assert res['required'] is True
-        field2 = fields.Str()
-        assert swagger.field2property(field2)['required'] is False
-
     def test_field_with_additional_metadata(self):
         field = fields.Str(minLength=6, maxLength=100)
         res = swagger.field2property(field)
@@ -238,6 +231,20 @@ class TestMarshmallowSchemaToModelDefinition:
         assert props['email']['type'] == 'string'
         assert props['email']['format'] == 'email'
         assert props['email']['description'] == 'email address of the user'
+
+    def test_required_fields(self):
+        class BandSchema(Schema):
+            drummer = fields.Str(required=True)
+            bassist = fields.Str()
+        res = swagger.schema2jsonschema(BandSchema)
+        assert res['required'] == ['drummer']
+
+    def test_no_required_fields(self):
+        class BandSchema(Schema):
+            drummer = fields.Str()
+            bassist = fields.Str()
+        res = swagger.schema2jsonschema(BandSchema)
+        assert 'required' not in res
 
     def test_title_and_description_may_be_added(self):
         class UserSchema(Schema):


### PR DESCRIPTION
The official docs are vague on this point, but it looks like required
model fields are meant to be included in a `required` list on the model
definition, rather than in a `required` field on each property.
Including a `required` field on model properties also raises errors from
swagger-tools and swagger-ui.
