### PR TITLE
Integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ python:
 install:
   - pip install -r dev-requirements.txt
   - pip install -U .
+  - npm install -g swagger-tools
 
 before_script:
   - flake8 .

--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -12,6 +12,8 @@ VALID_METHODS = [
     'head',
 ]
 
+SWAGGER_VERSION = '2.0'
+
 
 class Path(dict):
     """Represents a Swagger Path object.
@@ -52,9 +54,18 @@ class Path(dict):
 
 class APISpec(object):
     """Stores metadata that describes a RESTful API using the Swagger 2.0 specification.
+
+    :param str title: API title
+    :param str version: API version
+    :param tuple plugins: Paths to plugin modules
     """
 
-    def __init__(self, plugins=(), default_content_types=None, *args, **kwargs):
+    def __init__(self, title, version, plugins=(), default_content_types=None, *args, **kwargs):
+        self.info = {
+            'title': title,
+            'version': version,
+        }
+        self.info.update(kwargs)
         # Metadata
         self._definitions = {}
         self._paths = {}
@@ -70,6 +81,8 @@ class APISpec(object):
 
     def to_dict(self):
         return {
+            'swagger': SWAGGER_VERSION,
+            'info': self.info,
             'definitions': self._definitions,
             'paths': self._paths,
         }

--- a/tests/apispec/test_core.py
+++ b/tests/apispec/test_core.py
@@ -6,16 +6,31 @@ from smore.apispec import APISpec, Path
 from smore.apispec.exceptions import PluginError, APISpecError
 
 
+description = 'This is a sample Petstore server.  You can find out more '
+'about Swagger at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> '
+'or on irc.freenode.net, #swagger.  For this sample, you can use the api '
+'key \"special-key\" to test the authorization filters'
+
+
 @pytest.fixture()
 def spec():
     return APISpec(
         title='Swagger Petstore',
         version='1.0.0',
-        description='This is a sample Petstore server.  You can find out more '
-        'about Swagger at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> '
-        'or on irc.freenode.net, #swagger.  For this sample, you can use the api '
-        'key \"special-key\" to test the authorization filters'
+        description=description,
     )
+
+
+class TestMetadata:
+
+    def test_swagger_version(self, spec):
+        assert spec.to_dict()['swagger'] == '2.0'
+
+    def test_swagger_info(self, spec):
+        info = spec.to_dict()['info']
+        assert info['title'] == 'Swagger Petstore'
+        assert info['version'] == '1.0.0'
+        assert info['description'] == description
 
 
 class TestDefinitions:
@@ -40,6 +55,7 @@ class TestDefinitions:
         )
         defs_json = spec.to_dict()['definitions']
         assert defs_json['Pet']['enum'] == enum
+
 
 class TestPath:
     paths = {
@@ -140,6 +156,7 @@ class TestPath:
             spec.add_path()
         assert 'Path template is not specified' in str(excinfo)
 
+
 class TestExtensions:
 
     DUMMY_PLUGIN = 'tests.apispec.plugins.dummy_plugin'
@@ -195,6 +212,7 @@ class TestDefinitionHelpers:
         expected = {'properties': {'age': {'type': 'number', 'format': 'int32'}}}
         assert spec._definitions['Pet'] == expected
 
+
 class TestPathHelpers:
 
     def test_path_helper_is_used(self, spec):
@@ -217,13 +235,14 @@ class TestPathHelpers:
         )
         expected = {
             '/pet/{petId}': {
-                'get': {'produces': ('application/xml', ),
-                        'responses': {
-                            "200": {
-                                "schema": {'$ref': '#/definitions/Pet'},
-                                'description': 'successful operation'
-                            }
+                'get': {
+                    'produces': ('application/xml', ),
+                    'responses': {
+                        '200': {
+                            'schema': {'$ref': '#/definitions/Pet'},
+                            'description': 'successful operation',
                         }
+                    }
                 }
             }
         }
@@ -250,4 +269,3 @@ class TestResponseHelpers:
         resp_obj = spec._paths['/pet/{petId}']['get']['responses'][200]
         assert resp_obj['schema'] == {'$ref': 'Pet'}
         assert resp_obj['description'] == 'success!'
-


### PR DESCRIPTION
Add integration tests with swagger-tools. Also add swagger version and `info` hash to `APISpec`, since both are required for a valid API specification.
