### PR TITLE
Check base path

### DIFF
--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import re
+
 from marshmallow.compat import iterkeys
 from .exceptions import APISpecError, PluginError
 
@@ -99,6 +101,9 @@ class APISpec(object):
 
         https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#paths-object-
         """
+        if path and 'basePath' in self.options:
+            pattern = '^{0}'.format(re.escape(self.options['basePath']))
+            path = re.sub(pattern, '', path)
         path = Path(path=path, operations=operations)
         # Execute plugins' helpers
         for func in self._path_helpers:

--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -58,14 +58,19 @@ class APISpec(object):
     :param str title: API title
     :param str version: API version
     :param tuple plugins: Paths to plugin modules
+    :param dict info: Optional dict to add to `info`
+        See https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#infoObject
+    :param **dict options: Optional top-level keys
+        See https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#swagger-object
     """
 
-    def __init__(self, title, version, plugins=(), default_content_types=None, *args, **kwargs):
+    def __init__(self, title, version, plugins=(), info=None, **options):
         self.info = {
             'title': title,
             'version': version,
         }
-        self.info.update(kwargs)
+        self.info.update(info or {})
+        self.options = options
         # Metadata
         self._definitions = {}
         self._paths = {}
@@ -80,12 +85,14 @@ class APISpec(object):
             self.setup_plugin(plugin_path)
 
     def to_dict(self):
-        return {
+        ret = {
             'swagger': SWAGGER_VERSION,
             'info': self.info,
             'definitions': self._definitions,
             'paths': self._paths,
         }
+        ret.update(self.options)
+        return ret
 
     def add_path(self, path=None, operations=None, **kwargs):
         """Add a new path object to the spec.

--- a/smore/apispec/tests/test_core.py
+++ b/smore/apispec/tests/test_core.py
@@ -158,6 +158,12 @@ class TestPath:
             spec.add_path()
         assert 'Path template is not specified' in str(excinfo)
 
+    def test_add_path_strips_base_path(self, spec):
+        spec.options['basePath'] = '/v1'
+        spec.add_path('/v1/pets')
+        assert '/pets' in spec._paths
+        assert '/v1/pets' not in spec._paths
+
 
 class TestExtensions:
 

--- a/smore/apispec/tests/test_core.py
+++ b/smore/apispec/tests/test_core.py
@@ -17,7 +17,8 @@ def spec():
     return APISpec(
         title='Swagger Petstore',
         version='1.0.0',
-        description=description,
+        info={'description': description},
+        security=[{'apiKey': []}],
     )
 
 
@@ -26,11 +27,12 @@ class TestMetadata:
     def test_swagger_version(self, spec):
         assert spec.to_dict()['swagger'] == '2.0'
 
-    def test_swagger_info(self, spec):
-        info = spec.to_dict()['info']
-        assert info['title'] == 'Swagger Petstore'
-        assert info['version'] == '1.0.0'
-        assert info['description'] == description
+    def test_swagger_metadata(self, spec):
+        metadata = spec.to_dict()
+        assert metadata['security'] == [{'apiKey': []}]
+        assert metadata['info']['title'] == 'Swagger Petstore'
+        assert metadata['info']['version'] == '1.0.0'
+        assert metadata['info']['description'] == description
 
 
 class TestDefinitions:


### PR DESCRIPTION
Strip `basePath` from `path` if `basePath` set.

Otherwise, setting `basePath` can break URLs in swagger-ui.

@sloria: I think this is a reasonable feature to add to smore, but you could also argue that it's the user's responsibility to strip the base path from all paths if they're going to set `basePath`. I don't have a strong intuition about this--mostly wanted to log for discussion.

Depends on #13.
