### PR TITLE
Respect `exclude` meta option.

### DIFF
--- a/smore/swagger/__init__.py
+++ b/smore/swagger/__init__.py
@@ -123,9 +123,12 @@ def schema2jsonschema(schema_cls):
     """
     if getattr(schema_cls.Meta, 'fields', None) or getattr(schema_cls.Meta, 'additional', None):
         warnings.warn('Only explicitly-declared fields will be included in the Schema Object. '
-                'Fields defined in Meta.fields or Meta.addtional are excluded.')
+                'Fields defined in Meta.fields or Meta.additional are excluded.')
     ret = {'properties': {}}
+    exclude = set(getattr(schema_cls.Meta, 'exclude', []))
     for field_name, field_obj in iteritems(schema_cls._declared_fields):
+        if field_name in exclude:
+            continue
         ret['properties'][field_name] = field2property(field_obj)
         if field_obj.required:
             ret.setdefault('required', []).append(field_name)

--- a/smore/swagger/tests/test_swagger.py
+++ b/smore/swagger/tests/test_swagger.py
@@ -263,6 +263,17 @@ class TestMarshmallowSchemaToModelDefinition:
         assert res['description'] == 'A registered user'
         assert res['title'] == 'User'
 
+    def test_excluded_fields(self):
+        class WhiteStripesSchema(Schema):
+            class Meta:
+                exclude = ('bassist', )
+            guitarist = fields.Str()
+            drummer = fields.Str()
+            bassist = fields.Str()
+
+        res = swagger.schema2jsonschema(WhiteStripesSchema)
+        assert set(res['properties'].keys()) == set(['guitarist', 'drummer'])
+
     def test_only_explicitly_declared_fields_are_translated(self, recwarn):
         class UserSchema(Schema):
             _id = fields.Int()


### PR DESCRIPTION
It makes sense to ignore the `fields` and `additional` meta options,
since we don't have enough information to build accurate Swagger markup,
but we can still respect the `exclude` option.
