### PR TITLE
Pass array collection format.

### DIFF
--- a/smore/swagger/__init__.py
+++ b/smore/swagger/__init__.py
@@ -193,6 +193,8 @@ def arg2parameter(arg, name=None, default_in='body'):
             schema_props[name] = arg_as_property
         ret['schema']['properties'] = schema_props
     else:
+        if arg.multiple:
+            ret['collectionFormat'] = 'multi'
         ret.update(arg_as_property)
     return ret
 
@@ -216,8 +218,8 @@ def arg2property(arg):
         json_type, fmt = _get_json_type(arg.type)
     ret = {
         'type': json_type,
+        'description': arg.metadata.get('description', ''),
     }
-    ret['description'] = arg.metadata.get('description', '')
     if fmt:
         ret['format'] = fmt
     if arg.default:

--- a/smore/swagger/tests/test_swagger.py
+++ b/smore/swagger/tests/test_swagger.py
@@ -58,6 +58,17 @@ class TestArgToSwagger:
         result2 = arg2parameter(arg2)
         assert result2['required'] is False
 
+    def test_collection_translation_multiple(self):
+        arg = Arg(int, multiple=True, location='querystring')
+        result = arg2parameter(arg)
+        assert result['type'] == 'array'
+        assert result['collectionFormat'] == 'multi'
+
+    def test_collection_translation_single(self):
+        arg = Arg(int, location='querystring')
+        result = arg2parameter(arg)
+        assert 'collectionFormat' not in result
+
     def test_arg_with_description(self):
         arg = Arg(int, location='form', description='a webargs arg')
         result = arg2parameter(arg)


### PR DESCRIPTION
Swagger allows different formats for arrays that are not passed in the
body, including comma-separated, tab-separated, and repeated parameters.
Since webargs supports repeated parameters (`foo=bar&foo=baz`), we
should set `collectionFormat` to `multi` by default. This also gets
swagger-ui to format request parameters correctly for array-typed
values.
