### PR TITLE
Handle `items` in array parameters.

### DIFF
--- a/smore/swagger/__init__.py
+++ b/smore/swagger/__init__.py
@@ -222,9 +222,30 @@ def arg2property(arg):
     }
     if fmt:
         ret['format'] = fmt
+    if arg.multiple:
+        ret['items'] = type2items(arg.type)
     if arg.default:
         ret['default'] = arg.default
     ret.update(arg.metadata)
+    return ret
+
+
+def type2items(type):
+    """Return the JSON Schema property definition given a webargs :class:`Arg <webargs.core.Arg>`.
+
+    https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#itemsObject
+
+    Example: ::
+
+        type2items(int)
+        # {'type': 'integer', 'format': 'int32'}
+
+    :rtype: dict, an Items Object
+    """
+    json_type, fmt = _get_json_type(type)
+    ret = {'type': json_type}
+    if fmt:
+        ret['format'] = fmt
     return ret
 
 

--- a/smore/swagger/tests/test_swagger.py
+++ b/smore/swagger/tests/test_swagger.py
@@ -69,6 +69,11 @@ class TestArgToSwagger:
         result = arg2parameter(arg)
         assert 'collectionFormat' not in result
 
+    def test_items_multiple_querystring(self):
+        arg = Arg(int, multiple=True, location='querystring')
+        result = arg2parameter(arg)
+        assert result['items'] == {'type': 'integer', 'format': 'int32'}
+
     def test_arg_with_description(self):
         arg = Arg(int, location='form', description='a webargs arg')
         result = arg2parameter(arg)
@@ -358,8 +363,9 @@ spec.add_path(
                 }
             },
             'parameters': [
-                {'name': 'category_id', 'in': 'path', 'type': 'string'},
                 {'name': 'q', 'in': 'query', 'type': 'string'},
+                {'name': 'category_id', 'in': 'path', 'type': 'string'},
+                arg2parameter(Arg(str, multiple=True, location='querystring')),
             ],
         },
     },


### PR DESCRIPTION
Parameters where "in" is not "body" and "type" is "array" must define an
"items" object describing the types of the nested items. This patch adds
the items key and adds regression tests for both `arg2parameter` and
validation using `swagger-tools`.
