### PR TITLE
Expose `swagger-tools` validation in utils.

### DIFF
--- a/smore/exceptions.py
+++ b/smore/exceptions.py
@@ -3,3 +3,6 @@
 class SmoreError(Exception):
     """Base class for all smore-related errors."""
     pass
+
+class SwaggerError(SmoreError):
+    pass

--- a/smore/swagger/tests/test_swagger.py
+++ b/smore/swagger/tests/test_swagger.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import json
-import tempfile
-import subprocess
-
 import pytest
 from pytest import mark
 from webargs import Arg
@@ -11,6 +7,8 @@ from marshmallow import fields, Schema
 from marshmallow.compat import binary_type
 
 from smore import swagger
+from smore import exceptions
+from smore.apispec import utils
 from smore.apispec import APISpec
 from smore.swagger import arg2parameter, arg2property
 
@@ -366,13 +364,7 @@ spec.add_path(
 )
 
 def test_swagger_tools_validate():
-    with tempfile.NamedTemporaryFile(mode='w') as fp:
-        json.dump(spec.to_dict(), fp)
-        fp.seek(0)
-        try:
-            subprocess.check_output(
-                ['swagger-tools', 'validate', fp.name],
-                stderr=subprocess.STDOUT,
-            )
-        except subprocess.CalledProcessError as error:
-            pytest.fail(error.output.decode('utf-8'))
+    try:
+        utils.validate_swagger(spec)
+    except exceptions.SwaggerError as error:
+        pytest.fail(str(error))


### PR DESCRIPTION
Validating Swagger output may be useful to smore users as well as for
internal tests.
