### PR TITLE
Pop extraneous `ref` key on `schema`.

### DIFF
--- a/smore/swagger/tests/test_swagger.py
+++ b/smore/swagger/tests/test_swagger.py
@@ -309,7 +309,7 @@ class CategorySchema(Schema):
 
 
 class PetSchema(Schema):
-    category = fields.Nested(CategorySchema)
+    category = fields.Nested(CategorySchema, many=True, ref='#/definitions/Category')
 
 
 class TestNesting:
@@ -333,9 +333,9 @@ class TestNesting:
         assert res['items'] == {'$ref': 'Category'}
 
     def test_schema2jsonschema_with_nested_fields(self):
-        res = swagger.schema2jsonschema(PetSchema)
+        res = swagger.schema2jsonschema(PetSchema, use_refs=False)
         props = res['properties']
-        assert props['category'] == swagger.schema2jsonschema(CategorySchema)
+        assert props['category']['items'] == swagger.schema2jsonschema(CategorySchema)
 
 
 spec = APISpec(
@@ -353,9 +353,9 @@ spec.add_path(
         'get': {
             'responses': {
                 200: {
-                    'description': 'A pet category',
-                    'schema': {'$ref': '#/definitions/Category'},
-                }
+                    'schema': swagger.schema2jsonschema(PetSchema),
+                    'description': 'A pet',
+                },
             },
             'parameters': [
                 {'name': 'category_id', 'in': 'path', 'type': 'string'},


### PR DESCRIPTION
The "ref" key is not allowed on the schema object. This patch pops the
"ref" key if present and adds a regression test using `swagger-tools`.
