### PR TITLE
Convert schemas to Swagger on add path.

### DIFF
--- a/smore/apispec/tests/test_ext_marshmallow.py
+++ b/smore/apispec/tests/test_ext_marshmallow.py
@@ -31,6 +31,28 @@ class TestDefinitionHelper:
 
 class TestOperationHelper:
 
+    def test_schema(self, spec):
+
+        def pet_view():
+            return '...'
+
+        spec.add_path(
+            path='/pet',
+            view=pet_view,
+            operations={
+                'get': {
+                    'responses': {
+                        200: {'schema': PetSchema}
+                    }
+                }
+            }
+        )
+        p = spec._paths['/pet']
+        assert 'get' in p
+        op = p['get']
+        assert 'responses' in op
+        assert op['responses'][200]['schema'] == swagger.schema2jsonschema(PetSchema)
+
     def test_schema_in_docstring(self, spec):
 
         def pet_view():

--- a/smore/swagger/tests/test_swagger.py
+++ b/smore/swagger/tests/test_swagger.py
@@ -362,7 +362,7 @@ spec.add_path(
             },
             'parameters': [
                 {'name': 'q', 'in': 'query', 'type': 'string'},
-                {'name': 'category_id', 'in': 'path', 'type': 'string'},
+                {'name': 'category_id', 'in': 'path', 'required': True, 'type': 'string'},
                 arg2parameter(Arg(str, multiple=True, location='querystring')),
             ],
         },


### PR DESCRIPTION
Allow users to avoid the boilerplate of calling `schema2jsonschema` directly when using Marshmallow:

``` python
spec.add_path(
    path='/pet',
    view=pet_view,
    operations={
        'get': {
            'responses': {
                200: {'schema': PetSchema}
            }
        }
    }
)
```

This also uses references instead of converting to JSON schemas if the schema has already been registered.
