### PR TITLE
Force required=True on all path parameters.

### DIFF
--- a/smore/apispec/core.py
+++ b/smore/apispec/core.py
@@ -17,6 +17,20 @@ VALID_METHODS = [
 SWAGGER_VERSION = '2.0'
 
 
+def clean_operations(operations):
+    """Ensure that all parameters with "in" equal to "path" are also required
+    as required by the Swagger specification.
+
+    See https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#parameterObject.
+
+    :param dict operations: Dict mapping status codes to operations
+    """
+    for operation in (operations or {}).values():
+        for parameter in operation.get('parameters', []):
+            if parameter['in'] == 'path':
+                parameter['required'] = True
+
+
 class Path(dict):
     """Represents a Swagger Path object.
 
@@ -31,6 +45,7 @@ class Path(dict):
     def __init__(self, path=None, operations=None, **kwargs):
         self.path = path
         operations = operations or {}
+        clean_operations(operations)
         invalid = set(iterkeys(operations)) - set(VALID_METHODS)
         if invalid:
             raise APISpecError(

--- a/smore/apispec/tests/test_core.py
+++ b/smore/apispec/tests/test_core.py
@@ -153,6 +153,21 @@ class TestPath:
         assert 'get' in p
         assert 'put' in p
 
+    def test_add_path_ensures_path_parameters_required(self, spec):
+        path = '/pet/{petId}'
+        spec.add_path(
+            path=path,
+            operations=dict(
+                put=dict(
+                    parameters=[{
+                        'name': 'petId',
+                        'in': 'path',
+                    }]
+                )
+            )
+        )
+        assert spec._paths[path]['put']['parameters'][0]['required'] is True
+
     def test_add_path_with_no_path_raises_error(self, spec):
         with pytest.raises(APISpecError) as excinfo:
             spec.add_path()

--- a/smore/apispec/tests/test_ext_flask.py
+++ b/smore/apispec/tests/test_ext_flask.py
@@ -35,10 +35,10 @@ class TestPathHelpers:
         def hello():
             return 'hi'
 
-        spec.add_path(view=hello, operations={'get': {'parameters': '..params..', 'responses': {'200': '..params..'}}})
+        spec.add_path(view=hello, operations={'get': {'parameters': [], 'responses': {'200': '..params..'}}})
         assert '/hello' in spec._paths
         assert 'get' in spec._paths['/hello']
-        assert spec._paths['/hello']['get'] == {'parameters': '..params..', 'responses': {'200': '..params..'}}
+        assert spec._paths['/hello']['get'] == {'parameters': [], 'responses': {'200': '..params..'}}
 
     def test_path_with_multiple_methods(self, app, spec):
 


### PR DESCRIPTION
If `required` isn't set to `True` for any path parameters, swagger-tools responds with the unhelpful "Data does not match any schemas from 'oneOf'" message. Note that the proposed `clean_operations` helper modifies its argument in-place. If that's a problem, we can throw in a `deepcopy` so that users don't have their operations silently mutated.
