### PR TITLE
Detect refs in `Nested` fields if not specified.

### DIFF
--- a/smore/swagger/tests/test_swagger.py
+++ b/smore/swagger/tests/test_swagger.py
@@ -317,7 +317,12 @@ class PetSchema(Schema):
 
 class TestNesting:
 
-    def test_field2property_nested(self):
+    def test_field2property_nested_spec(self):
+        spec.definition('Category', schema=CategorySchema)
+        category = fields.Nested(CategorySchema)
+        assert swagger.field2property(category, spec=spec) == {'$ref': 'Category'}
+
+    def test_field2property_nested_ref(self):
         category = fields.Nested(CategorySchema)
         assert swagger.field2property(category) == swagger.schema2jsonschema(CategorySchema)
 


### PR DESCRIPTION
If the schema of a `Nested` field has been registered with the current
`APISpec`, use the `ref` of that schema unless otherwise specified.

Just another small change that avoids the usually unnecessary boilerplate of including a `ref` key when defining `Nested` fields.
