### PR TITLE
Use correct reference markup.

### DIFF
--- a/smore/apispec/tests/test_ext_marshmallow.py
+++ b/smore/apispec/tests/test_ext_marshmallow.py
@@ -94,4 +94,4 @@ class TestOperationHelper:
         assert 'get' in p
         op = p['get']
         assert 'responses' in op
-        assert op['responses'][200]['schema']['$ref'] == 'Pet'
+        assert op['responses'][200]['schema']['$ref'] == '#/definitions/Pet'

--- a/smore/ext/marshmallow.py
+++ b/smore/ext/marshmallow.py
@@ -47,7 +47,7 @@ def resolve_schema_dict(spec, schema):
     plug = spec.plugins[NAME]
     schema_cls = resolve_schema_cls(schema)
     if schema_cls in plug.get('refs', {}):
-        return {'$ref': plug['refs'][schema_cls]}
+        return {'$ref': '#/definitions/{0}'.format(plug['refs'][schema_cls])}
     return swagger.schema2jsonschema(schema_cls, spec=spec)
 
 def resolve_schema_cls(schema):

--- a/smore/swagger/tests/test_swagger.py
+++ b/smore/swagger/tests/test_swagger.py
@@ -320,7 +320,7 @@ class TestNesting:
     def test_field2property_nested_spec(self):
         spec.definition('Category', schema=CategorySchema)
         category = fields.Nested(CategorySchema)
-        assert swagger.field2property(category, spec=spec) == {'$ref': 'Category'}
+        assert swagger.field2property(category, spec=spec) == {'$ref': '#/definitions/Category'}
 
     def test_field2property_nested_ref(self):
         category = fields.Nested(CategorySchema)


### PR DESCRIPTION
Should've noticed this earlier, but the reference markup in the marshmallow path helper wasn't right in the first place--we were generating markup like `{"$ref": "Schema"}` instead of `{"$ref": "#/definitions/Schema"}`. Fixed here.
