### PR TITLE
Fix output codes.

### DIFF
--- a/smore/apispec/tests/test_ext_marshmallow.py
+++ b/smore/apispec/tests/test_ext_marshmallow.py
@@ -64,16 +64,25 @@ class TestOperationHelper:
                     200:
                         schema: smore.apispec.tests.schemas.PetSchema
                         description: successful operation
+            post:
+                responses:
+                    201:
+                        schema: smore.apispec.tests.schemas.PetSchema
+                        description: successful operation
             """
             return '...'
 
         spec.add_path(path='/pet', view=pet_view)
         p = spec._paths['/pet']
         assert 'get' in p
-        op = p['get']
-        assert 'responses' in op
-        assert op['responses'][200]['schema'] == swagger.schema2jsonschema(PetSchema)
-        assert op['responses'][200]['description'] == 'successful operation'
+        get = p['get']
+        assert 'responses' in get
+        assert get['responses'][200]['schema'] == swagger.schema2jsonschema(PetSchema)
+        assert get['responses'][200]['description'] == 'successful operation'
+        post = p['post']
+        assert 'responses' in post
+        assert post['responses'][201]['schema'] == swagger.schema2jsonschema(PetSchema)
+        assert post['responses'][201]['description'] == 'successful operation'
 
     def test_schema_in_docstring_uses_ref_if_available(self, spec):
         spec.definition('Pet', schema=PetSchema)

--- a/smore/ext/marshmallow.py
+++ b/smore/ext/marshmallow.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 
 import marshmallow
-from marshmallow.compat import iteritems
 
 from smore import swagger
 from smore.apispec.core import Path
@@ -32,13 +31,10 @@ def schema_path_helper(spec, view, **kwargs):
     if not operations:
         return
     operations = operations.copy()
-    for method, operation_dict in iteritems(operations):
-        for status_code, response_dict in iteritems(operation_dict.get('responses', {})):
-            if 'schema' in response_dict:
-                schema_dict = resolve_schema_dict(spec, response_dict['schema'])
-                if not operations[method]['responses'].get(200):
-                    operations[method]['responses'][200] = {}
-                operations[method]['responses'][200]['schema'] = schema_dict
+    for operation in operations.values():
+        for response in operation.get('responses', {}).values():
+            if 'schema' in response:
+                response['schema'] = resolve_schema_dict(spec, response['schema'])
     return Path(operations=operations)
 
 def resolve_schema_dict(spec, schema):


### PR DESCRIPTION
Currently, the Marshmallow path helper only modifies response objects
with status codes of 200, regardless of the status code of the original
response object. This patch respects the original response codes and
doesn't set the 200 response object unless specified by the user.
