### PR TITLE
Convert marshmallow Schemas to Swagger parameters.

### DIFF
--- a/smore/ext/marshmallow.py
+++ b/smore/ext/marshmallow.py
@@ -40,7 +40,7 @@ def schema_path_helper(spec, view, **kwargs):
 def resolve_schema_dict(spec, schema):
     if isinstance(schema, dict):
         return schema
-    plug = spec.plugins[NAME]
+    plug = spec.plugins[NAME] if spec else {}
     schema_cls = resolve_schema_cls(schema)
     if schema_cls in plug.get('refs', {}):
         return {'$ref': '#/definitions/{0}'.format(plug['refs'][schema_cls])}

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -310,6 +310,7 @@ class TestMarshmallowSchemaToParameters:
     def test_field_multiple(self):
         field = fields.List(fields.Str, location='querystring')
         res = swagger.field2parameter('field', field)
+        assert res['in'] == 'query'
         assert res['type'] == 'array'
         assert res['items']['type'] == 'string'
         assert res['collectionFormat'] == 'multi'
@@ -319,9 +320,53 @@ class TestMarshmallowSchemaToParameters:
         res = swagger.field2parameter('field', field)
         assert res['required'] is True
 
+    def test_schema_body(self):
+        class UserSchema(Schema):
+            name = fields.Str()
+            email = fields.Email()
+        res = swagger.schema2parameters(UserSchema, default_in='body')
+        assert len(res) == 1
+        param = res[0]
+        assert param['in'] == 'body'
+        assert param['schema'] == swagger.schema2jsonschema(UserSchema)
+
+    def test_schema_query(self):
+        class UserSchema(Schema):
+            name = fields.Str()
+            email = fields.Email()
+        res = swagger.schema2parameters(UserSchema, default_in='query')
+        assert len(res) == 2
+        res.sort(key=lambda param: param['name'])
+        assert res[0]['name'] == 'email'
+        assert res[0]['in'] == 'query'
+        assert res[1]['name'] == 'name'
+        assert res[1]['in'] == 'query'
+
+    def test_fields_body(self):
+        field_dict = {
+            'name': fields.Str(),
+            'email': fields.Email(),
+        }
+        res = swagger.fields2parameters(field_dict)
+        assert len(res) == 1
+        assert set(res[0]['schema']['properties'].keys()) == {'name', 'email'}
+
+    def test_fields_query(self):
+        field_dict = {
+            'name': fields.Str(),
+            'email': fields.Email(),
+        }
+        res = swagger.fields2parameters(field_dict, default_in='query')
+        assert len(res) == 2
+        res.sort(key=lambda param: param['name'])
+        assert res[0]['name'] == 'email'
+        assert res[0]['in'] == 'query'
+        assert res[1]['name'] == 'name'
+        assert res[1]['in'] == 'query'
+
 class CategorySchema(Schema):
     id = fields.Int()
-    name = fields.Str()
+    name = fields.Str(required=True)
 
 class PageSchema(Schema):
     offset = fields.Int()
@@ -392,7 +437,7 @@ spec.add_path(
         'post': {
             'parameters': (
                 [{'name': 'category_id', 'in': 'path', 'required': True, 'type': 'string'}] +
-                swagger.schema2parameters(PetSchema, spec=spec, default_in='body')
+                swagger.schema2parameters(CategorySchema, spec=spec, default_in='body')
             ),
             'responses': {
                 201: {


### PR DESCRIPTION
Proposal:

Given plans to add request parsing based on marshmallow `Schema` classes, we need a mechanism to convert `Schema`s to Swagger parameter objects. This patch adds the `schema2parameters` helper, which returns a list of a single parameter object if the location is the JSON body of the request (since Swagger only permits a single parameter with "in" equal to "body"), and a list of one parameter per `Field` otherwise.

We may also want to support the use case of converting a mapping of parameter names to a list of parameters (e.g. `{'name': fields.Str()}`). This would be straightforward if we decide to add it.

If this interface makes sense, I'll flesh out tests and documentation. See the integration test in `tests/swagger/test_swagger.py` for usage examples.

:guitar: 
