### PR TITLE
Remove `Fixed` from field mapping.

### DIFF
--- a/smore/swagger/__init__.py
+++ b/smore/swagger/__init__.py
@@ -24,7 +24,6 @@ FIELD_MAPPING = {
     fields.Integer: ('integer', 'int32'),
     fields.Number: ('number', None),
     fields.Float: ('number', 'float'),
-    fields.Fixed: ('number', None),
     fields.Decimal: ('number', None),
     fields.String: ('string', None),
     fields.Boolean: ('boolean', None),

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -177,7 +177,6 @@ class TestMarshmallowFieldToSwagger:
         (fields.Integer, 'integer'),
         (fields.Number, 'number'),
         (fields.Float, 'number'),
-        (fields.Fixed, 'number'),
         (fields.String, 'string'),
         (fields.Str, 'string'),
         (fields.Boolean, 'boolean'),


### PR DESCRIPTION
As of marshallow 2.0, the `Fixed` field is gone. Since `Fixed` is
included in `FIELD_MAPPING`, upgrading to marshmallow 2.0 breaks smore
on import. This patch simply removes `Fixed` from `FIELD_MAPPING`,
although we could instead check whether the field exists and only add it
to the mapping if so.
