### PR TITLE
Add dump flag.

### DIFF
--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -225,9 +225,14 @@ class TestMarshmallowFieldToSwagger:
         assert res['description'] == 'a username'
 
     def test_field_with_default(self):
-        field = fields.Str(default='foo')
+        field = fields.Str(default='foo', missing='bar')
         res = swagger.field2property(field)
         assert res['default'] == 'foo'
+
+    def test_field_with_default_load(self):
+        field = fields.Str(default='foo', missing='bar')
+        res = swagger.field2property(field, dump=False)
+        assert res['default'] == 'bar'
 
     def test_field_with_choices(self):
         field = fields.Str(validate=validate.OneOf(['freddie', 'brian', 'john']))


### PR DESCRIPTION
When `dump` is `True` (the default value), introspect serialization
behavior; else introspect deserialization behavior. This is useful for
introspecting webargs fields and schemas, for which the default value
should be populated by `field.missing` rather than the usual
`field.default`.

[Resolves #32]
