### PR TITLE
Pass `dump` in `fields2parameters`.

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -150,7 +150,7 @@ def fields2parameters(fields, schema_cls=None, spec=None, use_refs=True, dump=Tr
         }]
     return [
         field2parameter(field_obj, name=field_name, spec=spec,
-            use_refs=use_refs, default_in=default_in)
+            use_refs=use_refs, dump=dump, default_in=default_in)
         for field_name, field_obj in iteritems(fields)
         if field_name not in getattr(Meta, 'exclude', [])
     ]

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -234,6 +234,11 @@ class TestMarshmallowFieldToSwagger:
         res = swagger.field2property(field, dump=False)
         assert res['default'] == 'bar'
 
+    def test_fields_with_default_load(self):
+        field_dict = {'field': fields.Str(default='foo', missing='bar')}
+        res = swagger.fields2parameters(field_dict, default_in='query', dump=False)
+        assert res[0]['default'] == 'bar'
+
     def test_field_with_choices(self):
         field = fields.Str(validate=validate.OneOf(['freddie', 'brian', 'john']))
         res = swagger.field2property(field)


### PR DESCRIPTION
Ack! Forgot to pass `dump` through in `fields2parameters` in #33.
