### PR TITLE
Add global parameters to spec.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -179,6 +179,26 @@ class TestPath:
         assert '/pets' in spec._paths
         assert '/v1/pets' not in spec._paths
 
+    def test_add_parameters(self, spec):
+        route_spec = self.paths['/pet/{petId}']['get']
+
+        spec.add_parameter('test_parameter', 'path', **route_spec['parameters'][0])
+
+        spec.add_path(
+            path='/pet/{petId}',
+            operations=dict(
+                get=dict(
+                    parameters=['test_parameter'],
+                )
+            )
+        )
+
+        metadata = spec.to_dict()
+        p = spec._paths['/pet/{petId}']['get']
+
+        assert p['parameters'][0] == {'$ref': '#/parameters/test_parameter'}
+        assert route_spec['parameters'][0] == metadata['parameters']['test_parameter']
+
 
 class TestExtensions:
 


### PR DESCRIPTION
Swagger supports referencing common parameters by inserting a `$ref` to
`#/parameters/<name>`. This commit adds a `add_parameter` method to
APISpec, which appends parameters to the base swagger config.

When parsing the YAML doc, string objects in the parameters field get
converted into references. This makes the docstrings much shorter, e.g:

```
    get:
        description: Retrieve object
        parameters:
         - arg1
         - name: arg2
           in: path
           ...
```

Currently no check is made to verify `arg1` is a valid reference, but
this could easily be done by validating the resulting yaml from
`spec.to_dict()`.

I'm not hung up on implementation since I've only played around with the
code for a bit, but I do need the feature in order to be able to write
larger APIs without repeating myself constantly. Feel free to suggest
improvements.
