### PR TITLE
Introduce handling of plugins with different and conflicting signatures

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -122,9 +122,12 @@ class APISpec(object):
         path = Path(path=path, operations=operations)
         # Execute plugins' helpers
         for func in self._path_helpers:
-            ret = func(
-                self, path=path, operations=operations, **kwargs
-            )
+            try:
+                ret = func(
+                    self, path=path, operations=operations, **kwargs
+                )
+            except TypeError:
+                continue
             if isinstance(ret, Path):
                 path.update(ret)
 
@@ -153,7 +156,10 @@ class APISpec(object):
         ret = {}
         # Execute all helpers from plugins
         for func in self._definition_helpers:
-            ret.update(func(self, name, **kwargs))
+            try:
+                ret.update(func(self, name, **kwargs))
+            except TypeError:
+                continue
         if properties:
             ret['properties'] = properties
         if enum:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -209,6 +209,30 @@ class TestExtensions:
         spec.register_path_helper(my_path_helper)
         assert my_path_helper in spec._path_helpers
 
+    def test_multiple_path_helpers_w_different_signatures(self, spec):
+        def helper1(spec, spam, **kwargs):
+            return Path(path='/foo/bar')
+
+        def helper2(spec, eggs, **kwargs):
+            return Path(path='/foo/bar')
+
+        spec.register_path_helper(helper1)
+        spec.register_path_helper(helper2)
+
+        spec.add_path(eggs=object())
+
+    def test_multiple_definition_helpers_w_different_signatures(self, spec):
+        def helper1(spec, name, spam, **kwargs):
+            return mock.MagicMock()
+
+        def helper2(spec, name, eggs, **kwargs):
+            return mock.MagicMock()
+
+        spec.register_definition_helper(helper1)
+        spec.register_definition_helper(helper2)
+
+        spec.definition('SpammitySpam', eggs=mock.MagicMock())
+
 
 class TestDefinitionHelpers:
 


### PR DESCRIPTION
Subj. If there are multiple plugins with different signatures - Apispec fails. This patch fixes it.
