### PR TITLE
Adjust field name in spec according to `load_from` and `dump_to`.

### DIFF
--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -283,6 +283,24 @@ class TestMarshmallowSchemaToModelDefinition:
         assert props['email']['format'] == 'email'
         assert props['email']['description'] == 'email address of the user'
 
+    def test_schema2jsonschema_override_name(self):
+        class ExampleSchema(Schema):
+            _id = fields.Int(load_from='id', dump_to='id')
+            _as = fields.Int(load_from='as', dump_to='other')
+            _global = fields.Int(load_from='global', dump_to='global')
+
+            class Meta:
+                exclude = ('_global', )
+
+        res = swagger.schema2jsonschema(ExampleSchema)
+        props = res['properties']
+        # `_id` renamed to `id`
+        assert '_id' not in props and props['id']['type'] == 'integer'
+        # `load_from` and `dump_to` do not match for `_as`
+        assert 'as' not in props
+        # `_global` excluded correctly
+        assert '_global' not in props and 'global' not in props
+
     def test_required_fields(self):
         class BandSchema(Schema):
             drummer = fields.Str(required=True)


### PR DESCRIPTION
In marshmallow you can work around clashes with reserved names (e.g.
`global`) by using the `load_from` and `dump_to` attributes in a field
to effectively override the actual field name.

Doing so implicitly changes the schema however, and this commit attempts
to correct for that by replacing the field name with the values of
`load_from` and `dump_to` if they are the same.

An open question is what to do if `dump_to` and `load_from` differ. In
this case in practice the input schema differs from the output schema,
but there is no simple way of generating two schemas for the same
definition, and it's probably too much of an edge case to bother with.
