### PR TITLE
change README example code to generate valid Swagger

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,6 @@ Example Application
     spec = APISpec(
         title='Swagger Petstore',
         version='1.0.0',
-        description='A sample Petstore API.',
         plugins=[
             'apispec.ext.flask',
             'apispec.ext.marshmallow',
@@ -86,11 +85,10 @@ Generated Swagger Spec
     #     "version": "1.0.0"
     #   },
     #   "swagger": "2.0",
-    #   "description": "A sample Petstore API."
     #   "paths": {
     #     "/random": {
     #       "get": {
-    #         "description": "A cute furry animal endpoint."
+    #         "description": "A cute furry animal endpoint.",
     #         "responses": {
     #           "200": {
     #             "schema": {


### PR DESCRIPTION
The key "description" should not appear at the root of valid Swagger 2.0 JSON. Also, a comma was missing from the commented output, so it wasn't even valid Python.

See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields

The Swagger validation service is available at 
`http://online.swagger.io/validator/debug?url=<your swagger.json URL goes here>`
