### PR TITLE
Bug fix for observed field names.

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -310,11 +310,12 @@ def fields2jsonschema(fields, schema_cls=None, spec=None, use_refs=True, dump=Tr
     for field_name, field_obj in iteritems(fields):
         if field_name in exclude or (field_obj.dump_only and not dump):
             continue
+        observed_field_name = _observed_name(field_obj, field_name)
         prop_func = lambda field_obj=field_obj:\
             field2property(field_obj, spec=spec, use_refs=use_refs, dump=dump)  # flake8: noqa
-        ret['properties'][_observed_name(field_obj, field_name)] = prop_func
+        ret['properties'][observed_field_name] = prop_func
         if field_obj.required:
-            ret.setdefault('required', []).append(field_name)
+            ret.setdefault('required', []).append(observed_field_name)
     if Meta is not None:
         if hasattr(Meta, 'title'):
             ret['title'] = Meta.title

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -353,6 +353,14 @@ class TestMarshmallowSchemaToModelDefinition:
         assert expected_msg in str(warning.message)
         assert issubclass(warning.category, UserWarning)
 
+    def test_observed_field_name_for_required_field(self):
+        class UserSchema(Schema):
+            user_id = fields.Int(load_from="id", dump_to="id", required=True)
+
+        res = swagger.fields2jsonschema(UserSchema)
+        assert res["required"] == ["id"]
+
+
 class TestMarshmallowSchemaToParameters:
 
     def test_field_multiple(self):

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -354,10 +354,11 @@ class TestMarshmallowSchemaToModelDefinition:
         assert issubclass(warning.category, UserWarning)
 
     def test_observed_field_name_for_required_field(self):
-        class UserSchema(Schema):
-            user_id = fields.Int(load_from="id", dump_to="id", required=True)
+        fields_dict = {
+            "user_id": fields.Int(load_from="id", dump_to="id", required=True)
+        }
 
-        res = swagger.fields2jsonschema(UserSchema)
+        res = swagger.fields2jsonschema(fields_dict)
         assert res["required"] == ["id"]
 
 


### PR DESCRIPTION
When the field is required, the observed field name should be used instead of the real field name.

@sloria - I couldn't figure out how to edit the other pull request, so I created a new request with the added regression test you asked for in #47.
