### PR TITLE
APISpec.add_path now accepts Path objects

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -136,11 +136,21 @@ class APISpec(object):
         """Add a new path object to the spec.
 
         https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#paths-object-
+
+        :param str|Path|None path: URL Path component or Path instance
+        :param dict|None operations: describes the http methods and options for `path`
+        :param dict kwargs: parameters used by any path helpers see :meth:`register_path_helper`
         """
-        if path and 'basePath' in self.options:
+        p = path
+        if isinstance(path, Path):
+            p = path.path
+        if p and 'basePath' in self.options:
             pattern = '^{0}'.format(re.escape(self.options['basePath']))
-            path = re.sub(pattern, '', path)
-        path = Path(path=path, operations=operations)
+            p = re.sub(pattern, '', p)
+        if isinstance(path, Path):
+            path.path = p
+        else:
+            path = Path(path=p, operations=operations)
         # Execute plugins' helpers
         for func in self._path_helpers:
             try:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -179,6 +179,24 @@ class TestPath:
         assert '/pets' in spec._paths
         assert '/v1/pets' not in spec._paths
 
+    def test_add_path_accepts_path(self, spec):
+        route = '/pet/{petId}'
+        route_spec = self.paths[route]
+        path = Path(path=route, operations={'get': route_spec['get']})
+        spec.add_path(path)
+
+        p = spec._paths[path.path]
+        assert path.path == p.path
+        assert 'get' in p
+
+    def test_add_path_strips_path_base_path(self, spec):
+        spec.options['basePath'] = '/v1'
+        path = Path(path='/v1/pets')
+        spec.add_path(path)
+        assert '/pets' in spec._paths
+        assert '/v1/pets' not in spec._paths
+
+
     def test_add_parameters(self, spec):
         route_spec = self.paths['/pet/{petId}']['get']
 


### PR DESCRIPTION
Had to do a little `basePath` dance, not as succinct as I'd like

Fixes #49
