### PR TITLE
Improved further #37: Schema instances introspection for `many=True`

### DIFF
--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -52,7 +52,13 @@ def resolve_schema_dict(spec, schema, dump=True):
     plug = spec.plugins[NAME] if spec else {}
     schema_cls = resolve_schema_cls(schema)
     if schema_cls in plug.get('refs', {}):
-        return {'$ref': '#/definitions/{0}'.format(plug['refs'][schema_cls])}
+        ref_schema = {'$ref': '#/definitions/{0}'.format(plug['refs'][schema_cls])}
+        if getattr(schema, 'many', False):
+            return {
+                'type': 'array',
+                'items': ref_schema,
+            }
+        return ref_schema
     if not isinstance(schema, marshmallow.Schema):
         schema = schema_cls
     return swagger.schema2jsonschema(schema, spec=spec, dump=dump)

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -53,7 +53,9 @@ def resolve_schema_dict(spec, schema, dump=True):
     schema_cls = resolve_schema_cls(schema)
     if schema_cls in plug.get('refs', {}):
         return {'$ref': '#/definitions/{0}'.format(plug['refs'][schema_cls])}
-    return swagger.schema2jsonschema(schema_cls, spec=spec, dump=dump)
+    if not isinstance(schema, marshmallow.Schema):
+        schema = schema_cls
+    return swagger.schema2jsonschema(schema, spec=spec, dump=dump)
 
 def resolve_schema_cls(schema):
     if isinstance(schema, type) and issubclass(schema, marshmallow.Schema):

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -316,7 +316,8 @@ def fields2jsonschema(fields, schema=None, spec=None, use_refs=True, dump=True):
         )
 
     jsonschema = {
-        'properties': LazyDict({})
+        'type': 'object',
+        'properties': LazyDict({}),
     }
 
     exclude = set(getattr(Meta, 'exclude', []))


### PR DESCRIPTION
The reproduction example code:

``` python
from marshmallow import Schema, fields
from apispec.ext.marshmallow.swagger import schema2jsonschema

class A(Schema):
    q = fields.Integer()

print(schema2jsonschema(A(many=True)))
```

Current `dev` branch produces:

``` python
$ python bug_53.py
{'properties': {'q': {'format': 'int32', 'type': 'integer'}}}
```

After applying this PR:

``` python
$ python bug_53.py
{'type': 'array', 'items': {'properties': {'q': {'type': 'integer', 'format': 'int32'}}}}
```

BONUS: resolved `fields` global import and local arguments collision by importing `marshmallow` module instead of `fields` from `marshmallow`.

P.S. This issue is related to the recently PRed Bulk-type arguments support in webargs: https://github.com/sloria/webargs/issues/91
