### PR TITLE
Definition Doc

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -182,6 +182,11 @@ class APISpec(object):
     def definition(self, name, properties=None, enum=None, **kwargs):
         """Add a new definition to the spec.
 
+        If you are using the Marshmallow extension, you can pass fields' metadatas in the fields' kwargs.
+        For example, if you want to add an enum to your field Status:
+
+        status = fields.String(required=True, enum=['open', 'closed']
+
         https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#definitionsObject
         """
         ret = {}

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -182,7 +182,9 @@ class APISpec(object):
     def definition(self, name, properties=None, enum=None, **kwargs):
         """Add a new definition to the spec.
 
-        If you are using the Marshmallow extension, you can pass fields' metadatas in the fields' kwargs.
+        If you are using the Marshmallow extension, you can pass fields'metadatas in the
+        fields' kwargs.
+
         For example, if you want to add an enum to your field Status:
 
         status = fields.String(required=True, enum=['open', 'closed']


### PR DESCRIPTION
A very tiny pull request, where I just added info about how to pass fields' metadatas in the definition specs by passing them in the kwargs of the field.

(I found out it was already implemented by looking in the code; didn't find any reference to this feature in the doc actually)
