### PR TITLE
Nested Meta BugFix

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -118,6 +118,7 @@ def field2property(field, spec=None, use_refs=True, dump=True):
                 ret['type'] = 'array'
                 ret['items'] = ref_schema
             else:
+                del ret['type']
                 ret.update(ref_schema)
         elif spec:
             ret = resolve_schema_dict(spec, field.schema)

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -118,7 +118,7 @@ def field2property(field, spec=None, use_refs=True, dump=True):
                 ret['type'] = 'array'
                 ret['items'] = ref_schema
             else:
-                ret = ref_schema
+                ret.update(ref_schema)
         elif spec:
             ret = resolve_schema_dict(spec, field.schema)
         else:

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -561,6 +561,13 @@ class TestNesting:
         cat_with_ref = fields.Nested(CategorySchema, ref='Category')
         assert swagger.field2property(cat_with_ref) == {'$ref': 'Category'}
 
+    def test_field2property_nested_ref_with_meta(self):
+        category = fields.Nested(CategorySchema)
+        assert swagger.field2property(category) == swagger.schema2jsonschema(CategorySchema)
+
+        cat_with_ref = fields.Nested(CategorySchema, ref='Category', description="A category")
+        assert swagger.field2property(cat_with_ref) == {'$ref': 'Category', 'description': "A category"}
+
     def test_field2property_nested_many(self):
         categories = fields.Nested(CategorySchema, many=True)
         res = swagger.field2property(categories)


### PR DESCRIPTION
Fixed meta on nested fields being erased when many=False.
