### PR TITLE
Bugfix: Nested Metadatas

### DIFF
--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -15,6 +15,7 @@ from . import swagger
 
 NAME = 'apispec.ext.marshmallow'
 
+
 def schema_definition_helper(spec, name, schema, **kwargs):
     """Definition helper that allows using a marshmallow
     :class:`Schema <marshmallow.Schema>` to provide OpenAPI
@@ -28,6 +29,7 @@ def schema_definition_helper(spec, name, schema, **kwargs):
         plug['refs'] = {}
     plug['refs'][schema] = name
     return swagger.schema2jsonschema(schema, spec=spec)
+
 
 def schema_path_helper(spec, view, **kwargs):
     """Path helper that allows passing a Schema as a response. Responses can be
@@ -46,6 +48,7 @@ def schema_path_helper(spec, view, **kwargs):
                 response['schema'] = resolve_schema_dict(spec, response['schema'])
     return Path(operations=operations)
 
+
 def resolve_schema_dict(spec, schema, dump=True):
     if isinstance(schema, dict):
         return schema
@@ -63,12 +66,14 @@ def resolve_schema_dict(spec, schema, dump=True):
         schema = schema_cls
     return swagger.schema2jsonschema(schema, spec=spec, dump=dump)
 
+
 def resolve_schema_cls(schema):
     if isinstance(schema, type) and issubclass(schema, marshmallow.Schema):
         return schema
     if isinstance(schema, marshmallow.Schema):
         return type(schema)
     return marshmallow.class_registry.get_class(schema)
+
 
 def setup(spec):
     """Setup for the marshmallow plugin."""

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 invoke
+pyyaml
 
 # Syntax checking
 flake8==2.5.4

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -541,6 +541,11 @@ class PetSchema(Schema):
 
 
 class TestNesting:
+    def test_field2property_nested_spec_metadatas(self):
+        spec.definition('Category', schema=CategorySchema)
+        category = fields.Nested(CategorySchema, description="A category")
+        assert swagger.field2property(category, spec=spec) == {'$ref': '#/definitions/Category', 'description': 'A category'}
+
 
     def test_field2property_nested_spec(self):
         spec.definition('Category', schema=CategorySchema)


### PR DESCRIPTION
This PR definitely fix Metadatas for Nested Fields.

On the current version, metadatas of a nested field with no refs would be overridden.
With this update, those are never removed.

(+ added backspaces in `marshmallow/__init__.py` for PEP8 compliance)
