### PR TITLE
Fix parameter without 'in' on clean_operations

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -33,7 +33,8 @@ def clean_operations(operations):
         if 'parameters' in operation:
             parameters = operation.get('parameters')
             for parameter in parameters:
-                if isinstance(parameter, dict) and parameter['in'] == 'path':
+                if (isinstance(parameter, dict) and
+                        'in' in parameter and parameter['in'] == 'path'):
                     parameter['required'] = True
             operation['parameters'] = [get_ref(p) for p in parameters]
 


### PR DESCRIPTION
The following is a valid YAML and breaks in the current code, since the param will be a `dict` but won't have `in`:

``` yaml
parameters:
  - in: path
    name: some_param
    required: true
    type: string
  - $ref: "#/parameters/ParamRef"
```
