### PR TITLE
Support vendor extensions

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -54,7 +54,9 @@ class Path(dict):
         self.path = path
         operations = operations or {}
         clean_operations(operations)
-        invalid = set(iterkeys(operations)) - set(VALID_METHODS)
+        invalid = {key for key in
+                   set(iterkeys(operations)) - set(VALID_METHODS)
+                   if not key.startswith('x-')}
         if invalid:
             raise APISpecError(
                 'One or more HTTP methods are invalid: {0}'.format(", ".join(invalid))

--- a/apispec/ext/tornado.py
+++ b/apispec/ext/tornado.py
@@ -28,7 +28,8 @@ def path_from_urlspec(spec, urlspec, operations, **kwargs):
             'Could not find endpoint for urlspec {0}'.format(urlspec))
     params_method = getattr(urlspec.handler_class, list(operations.keys())[0])
     path = tornadopath2swagger(urlspec, params_method)
-
+    extensions = _extensions_from_handler(urlspec.handler_class)
+    operations.update(extensions)
     return Path(path=path, operations=operations)
 
 def _operations_from_methods(handler_class):
@@ -58,3 +59,12 @@ def tornadopath2swagger(urlspec, method):
     if path.count('/') > 1:
         path = path.rstrip('/?*')
     return path
+
+def _extensions_from_handler(handler_class):
+    """Returns extensions dict from handler docstring
+
+    :param handler_class:
+    :type handler_class: RequestHandler descendant
+    """
+    extensions = utils.load_yaml_from_docstring(handler_class.__doc__) or {}
+    return extensions

--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -79,7 +79,7 @@ def load_operations_from_docstring(docstring):
     doc_data = load_yaml_from_docstring(docstring)
     if doc_data:
         return {key: val for key, val in iteritems(doc_data)
-                        if key in PATH_KEYS}
+                        if key in PATH_KEYS or key.startswith('x-')}
     else:
         return None
 

--- a/tests/test_ext_flask.py
+++ b/tests/test_ext_flask.py
@@ -64,6 +64,7 @@ class TestPathHelpers:
             """A greeting endpoint.
 
             ---
+            x-extension: value
             get:
                 description: get a greeting
                 responses:
@@ -90,9 +91,11 @@ class TestPathHelpers:
         spec.add_path(view=hello)
         get_op = spec._paths['/hello']['get']
         post_op = spec._paths['/hello']['post']
+        extension = spec._paths['/hello']['x-extension']
         assert get_op['description'] == 'get a greeting'
         assert post_op['description'] == 'post a greeting'
         assert 'foo' not in spec._paths['/hello']
+        assert extension == 'value'
 
     def test_path_is_translated_to_swagger_template(self, app, spec):
 

--- a/tests/test_ext_tornado.py
+++ b/tests/test_ext_tornado.py
@@ -65,6 +65,10 @@ class TestPathHelpers:
     def test_integration_with_docstring_introspection(self, spec):
 
         class HelloHandler(RequestHandler):
+            """
+            ---
+            x-extension: value
+            """
             def get(self):
                 """Get a greeting endpoint.
                 ---
@@ -90,8 +94,10 @@ class TestPathHelpers:
         spec.add_path(urlspec=urlspec)
         get_op = spec._paths['/hello']['get']
         post_op = spec._paths['/hello']['post']
+        extension = spec._paths['/hello']['x-extension']
         assert get_op['description'] == 'get a greeting'
         assert post_op['description'] == 'post a greeting'
+        assert extension == 'value'
 
     def test_path_removing_trailing_or_optional_slash(self, spec):
 


### PR DESCRIPTION
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#vendorExtensions
Useful e.g. for specifying `x-swagger-router-controller` when mocking requests.
