### PR TITLE
field2property won't pop "location" from field metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,9 @@ Features:
 
 Bug fixes:
 
-* Fix bug in introspecting self-referencing marshmallow fields, i.e. ``fields.Nested('self')`` (:issue:`55`). Thanks :user:`whoiswes` for reporting.
 * Fix error message when plugin does not have a ``setup()`` function.
+* [apispec.ext.marshmallow] Fix bug in introspecting self-referencing marshmallow fields, i.e. ``fields.Nested('self')`` (:issue:`55`). Thanks :user:`whoiswes` for reporting.
+* [apispec.ext.marshmallow] ``field2property`` no longer pops off ``location`` from a field's metadata (:issue:`67`).
 
 0.10.1 (2016-04-09)
 +++++++++++++++++++

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -80,6 +80,14 @@ class TestMarshmallowFieldToSwagger:
         res = swagger.fields2parameters(field_dict, default_in='headers')
         assert res[0]['in'] == 'query'
 
+    def test_fields2parameters_does_not_modify_metadata(self):
+        field_dict = {'field': fields.Str(location='querystring')}
+        res = swagger.fields2parameters(field_dict, default_in='headers')
+        assert res[0]['in'] == 'query'
+
+        res = swagger.fields2parameters(field_dict, default_in='headers')
+        assert res[0]['in'] == 'query'
+
     def test_fields_with_dump_only(self):
         field_dict = {'field': fields.Str(dump_only=True)}
         res = swagger.fields2parameters(field_dict, default_in='query', dump=False)
@@ -89,6 +97,22 @@ class TestMarshmallowFieldToSwagger:
         field = fields.Str(validate=validate.OneOf(['freddie', 'brian', 'john']))
         res = swagger.field2property(field)
         assert set(res['enum']) == {'freddie', 'brian', 'john'}
+
+    def test_only_allows_valid_properties_in_metadata(self):
+        field = fields.Str(
+            default='foo',
+            description='foo',
+            enum=['red', 'blue'],
+            allOf=['bar'],
+            not_valid='lol'
+        )
+        res = swagger.field2property(field)
+        assert 'default' in res
+        assert res['default'] == field.default
+        assert 'description' in res
+        assert 'enum' in res
+        assert 'allOf' in res
+        assert 'not_valid' not in res
 
     def test_field_with_choices_multiple(self):
         field = fields.Str(validate=[


### PR DESCRIPTION
Before this change, `field2property` modified field's metadata by popping of `location`, which is unexpected behavior.

As an example, the following code would fail

``` python
field_dict = {'field': fields.Str(location='querystring')}
swagger.fields2parameters(field_dict, default_in='headers')assert res[0]['in'] == 'query'
# The first call popped off 'location' from metadata, so the 2nd call won't have the correct location
res = swagger.fields2parameters(field_dict, default_in='headers')
assert res[0]['in'] == 'query'
```

This behavior could have adverse consequences, especially when working with webargs.

This PR changes `field2property` so that it doesn't pop off `location`, and only valid OpenAPI properties can be added to its output.
