### PR TITLE
[Fix #69] Support the flask APPLICATION_ROOT config

### DIFF
--- a/apispec/ext/flask.py
+++ b/apispec/ext/flask.py
@@ -27,6 +27,11 @@ function to `add_path`. Inspects URL rules and view docstrings.
 from __future__ import absolute_import
 import re
 
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
 from flask import current_app
 
 from apispec.compat import iteritems
@@ -61,6 +66,8 @@ def path_from_view(spec, view, **kwargs):
     """Path helper that allows passing a Flask view function."""
     rule = _rule_for_view(view)
     path = flaskpath2swagger(rule.rule)
+    app_root = current_app.config['APPLICATION_ROOT'] or '/'
+    path = urljoin(app_root.rstrip('/') + '/', path.lstrip('/'))
     operations = utils.load_operations_from_docstring(view.__doc__)
     path = Path(path=path, operations=operations)
     return path

--- a/tests/test_ext_flask.py
+++ b/tests/test_ext_flask.py
@@ -105,3 +105,36 @@ class TestPathHelpers:
 
         spec.add_path(view=get_pet)
         assert '/pet/{pet_id}' in spec._paths
+
+    def test_path_includes_app_root(self, app, spec):
+
+        app.config['APPLICATION_ROOT'] = '/app/root'
+
+        @app.route('/partial/path/pet')
+        def get_pet():
+            return 'pet'
+
+        spec.add_path(view=get_pet)
+        assert '/app/root/partial/path/pet' in spec._paths
+
+    def test_path_with_args_includes_app_root(self, app, spec):
+
+        app.config['APPLICATION_ROOT'] = '/app/root'
+
+        @app.route('/partial/path/pet/{pet_id}')
+        def get_pet(pet_id):
+            return 'representation of pet {pet_id}'.format(pet_id=pet_id)
+
+        spec.add_path(view=get_pet)
+        assert '/app/root/partial/path/pet/{pet_id}' in spec._paths
+
+    def test_path_includes_app_root_with_right_slash(self, app, spec):
+
+        app.config['APPLICATION_ROOT'] = '/app/root/'
+
+        @app.route('/partial/path/pet')
+        def get_pet():
+            return 'pet'
+
+        spec.add_path(view=get_pet)
+        assert '/app/root/partial/path/pet' in spec._paths


### PR DESCRIPTION
Prefix the formatted swagger path with the `APPLICATION_ROOT` from the flask app's configuration settings.

I mentioned in [a comment on the issue](https://github.com/marshmallow-code/apispec/issues/69#issuecomment-215444641) that I preferred to lean on the `url_adapter` interface, but it does not expose a string transformation of the endpoint that does not require providing the values for the parameters.

> Note: I opted for the try/except import to support python 2 & 3, because [`future`](https://pypi.python.org/pypi/future) is not currently a dependency of the project.
> https://docs.python.org/3/howto/pyporting.html
