### PR TITLE
Marshmallow Schema Array

### DIFF
--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -52,6 +52,63 @@ def schema_definition_helper(spec, name, schema, **kwargs):
 def schema_path_helper(spec, view, **kwargs):
     """Path helper that allows passing a Schema as a response. Responses can be
     defined in a view's docstring.
+    ::
+
+        from pprint import pprint
+
+        from my_app import Users, UserSchema
+
+        class UserHandler:
+            def get(self, user_id):
+                '''Get a user endpoint.
+                ---
+                description: Get a user
+                responses:
+                    200:
+                        description: A user
+                        schema: UserSchema
+                '''
+                user = Users.get(id=user_id)
+                schema = UserSchema()
+                return schema.dumps(user)
+
+        urlspec = (r'/users/{user_id}', UserHandler)
+        spec.add_path(urlspec=urlspec)
+        pprint(spec.to_dict()['paths'])
+        # {'/users/{user_id}': {'get': {'description': 'Get a user',
+        #                               'responses': {200: {'description': 'A user',
+        #                                                   'schema': {'$ref': '#/definitions/User'}}}}}}
+
+    ::
+
+        from pprint import pprint
+
+        from my_app import Users, UserSchema
+
+        class UsersHandler:
+            def get(self):
+                '''Get users endpoint.
+                ---
+                description: Get a list of users
+                responses:
+                    200:
+                        description: A list of user
+                        schema:
+                            type: array
+                            items: UserSchema
+                '''
+                users = Users.all()
+                schema = UserSchema(many=True)
+                return schema.dumps(users)
+
+        urlspec = (r'/users', UsersHandler)
+        spec.add_path(urlspec=urlspec)
+        pprint(spec.to_dict()['paths'])
+        # {'/users': {'get': {'description': 'Get a list of users',
+        #                     'responses': {200: {'description': 'A list of users',
+        #                                         'schema': {'type': 'array',
+        #                                                    'items': {'$ref': '#/definitions/User'}}}}}}}
+
     """
     operations = (
         load_operations_from_docstring(view.__doc__) or

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -69,6 +69,8 @@ def schema_path_helper(spec, view, **kwargs):
 
 def resolve_schema_dict(spec, schema, dump=True):
     if isinstance(schema, dict):
+        if (schema.get('type') == 'array' and 'items' in schema):
+            schema['items'] = resolve_schema_dict(spec, schema['items'])
         return schema
     plug = spec.plugins[NAME] if spec else {}
     schema_cls = resolve_schema_cls(schema)

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -105,6 +105,32 @@ class TestOperationHelper:
         assert 'responses' in op
         assert op['responses'][200]['schema']['$ref'] == '#/definitions/Pet'
 
+    def test_schema_array_in_docstring_uses_ref_if_available(self, spec):
+        spec.definition('Pet', schema=PetSchema)
+
+        def pet_view():
+            """Not much to see here.
+
+            ---
+            get:
+                responses:
+                    200:
+                        schema:
+                            type: array
+                            items: tests.schemas.PetSchema
+            """
+            return '...'
+
+        spec.add_path(path='/pet', view=pet_view)
+        p = spec._paths['/pet']
+        assert 'get' in p
+        op = p['get']
+        assert 'responses' in op
+        assert op['responses'][200]['schema'] == {
+            'type': 'array',
+            'items': {'$ref': '#/definitions/Pet'}
+        }
+
 class TestCircularReference:
 
     def test_circular_referencing_schemas(self, spec):


### PR DESCRIPTION
The marshmallow extension should support schema array definitions since it allows schema instances to override `many` during construction.
- [x] Tests #71 
- [x] Fixes #71
- [x] Update docs
