### PR TITLE
Marshmallow Extension Validation Fields

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -110,6 +110,47 @@ def field2range(field):
                 attributes['maximum'] = validator.max
     return attributes
 
+def field2length(field):
+    """Return the dictionary of swagger field attributes for a set of
+    :class:`Length <marshmallow.validators.Length>` validators.
+
+    :param Field field: A marshmallow field.
+    :rtype: dict
+    """
+    validators = [
+        validator for validator in field.validators
+        if (
+            hasattr(validator, 'min') and
+            hasattr(validator, 'max') and
+            hasattr(validator, 'equal')
+        )
+    ]
+
+    attributes = {}
+    for validator in validators:
+        if not validator.min is None:
+            if hasattr(attributes, 'minLength'):
+                attributes['minLength'] = max(
+                    attributes['minLength'],
+                    validator.min
+                )
+            else:
+                attributes['minLength'] = validator.min
+        if not validator.max is None:
+            if hasattr(attributes, 'maxLength'):
+                attributes['maxLength'] = min(
+                    attributes['maxLength'],
+                    validator.max
+                )
+            else:
+                attributes['maxLength'] = validator.max
+
+    for validator in validators:
+        if not validator.equal is None:
+            attributes['minLength'] = validator.equal
+            attributes['maxLength'] = validator.equal
+    return attributes
+
 
 # Properties that may be defined in a field's metadata that will be added to the output
 # of field2property
@@ -181,6 +222,7 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
         ret['enum'] = list(choices)
 
     ret.update(field2range(field))
+    ret.update(field2length(field))
 
     if isinstance(field, marshmallow.fields.Nested):
         del ret['type']

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -569,6 +569,18 @@ class ValidationSchema(Schema):
         validate.Range(max=10),
         validate.Range(max=7)
     ])
+    list_length = fields.List(fields.Str, validate=validate.Length(min=1, max=10))
+    string_length = fields.Str(validate=validate.Length(min=1, max=10))
+    multiple_lengths = fields.Str(validate=[
+        validate.Length(min=1),
+        validate.Length(min=3),
+        validate.Length(max=10),
+        validate.Length(max=7)
+    ])
+    equal_length = fields.Str(validate=[
+        validate.Length(equal=5),
+        validate.Length(min=1, max=10)
+    ])
 
 class TestFieldValidation:
 
@@ -598,3 +610,38 @@ class TestFieldValidation:
         assert 'maximum' in result
         assert result['maximum'] == 7
 
+    def test_list_length(self, spec):
+        spec.definition('Validation', schema=ValidationSchema)
+        result = spec._definitions['Validation']['properties']['list_length']
+
+        assert 'minLength' in result
+        assert result['minLength'] == 1
+        assert 'maxLength' in result
+        assert result['maxLength'] == 10
+
+    def test_string_length(self, spec):
+        spec.definition('Validation', schema=ValidationSchema)
+        result = spec._definitions['Validation']['properties']['string_length']
+
+        assert 'minLength' in result
+        assert result['minLength'] == 1
+        assert 'maxLength' in result
+        assert result['maxLength'] == 10
+
+    def test_multiple_lengths(self, spec):
+        spec.definition('Validation', schema=ValidationSchema)
+        result = spec._definitions['Validation']['properties']['multiple_lengths']
+
+        assert 'minLength' in result
+        assert result['minLength'] == 3
+        assert 'maxLength' in result
+        assert result['maxLength'] == 7
+
+    def test_equal_length(self, spec):
+        spec.definition('Validation', schema=ValidationSchema)
+        result = spec._definitions['Validation']['properties']['equal_length']
+
+        assert 'minLength' in result
+        assert result['minLength'] == 5
+        assert 'maxLength' in result
+        assert result['maxLength'] == 5


### PR DESCRIPTION
#66 Translate the following marshmallow validators to OpenAPI validation fields:
- [x] ~~Length (list)~~ (redundant)
  - ~~minItems~~
  - ~~maxItems~~
- [x] Length
  - minLength
  - maxLength
- [x] ~~OneOf~~ (already implemented)
  - ~~enum~~
- [x] Range
  - minimum
  - maximum

Punted
-  ~~Email~~
  - ~~pattern~~
- Equal
  - enum (single)
- Regexp
  - pattern
- ~~URL~~
  - ~~pattern~~
