### PR TITLE
Maintain order of fields in ordered schemas

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, unicode_literals
 import operator
 import warnings
 import functools
+from collections import OrderedDict
 
 import marshmallow
 from marshmallow.utils import is_collection
@@ -37,6 +38,10 @@ FIELD_MAPPING = {
     marshmallow.fields.Raw: ('string', None),
     marshmallow.fields.List: ('array', None),
 }
+
+
+class OrderedLazyDict(LazyDict, OrderedDict):
+    pass
 
 
 def _observed_name(field, name):
@@ -448,7 +453,7 @@ def fields2jsonschema(fields, schema=None, spec=None, use_refs=True, dump=True, 
 
     jsonschema = {
         'type': 'object',
-        'properties': LazyDict({}),
+        'properties': OrderedLazyDict() if getattr(Meta, 'ordered', None) else LazyDict(),
     }
 
     exclude = set(getattr(Meta, 'exclude', []))

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -25,3 +25,14 @@ class SelfReferencingSchema(Schema):
     single_with_ref = fields.Nested('self', ref='#/definitions/Self')
     many = fields.Nested('self', many=True)
     many_with_ref = fields.Nested('self', many=True, ref='#/definitions/Selves')
+
+
+class OrderedSchema(Schema):
+    field1 = fields.Int()
+    field2 = fields.Int()
+    field3 = fields.Int()
+    field4 = fields.Int()
+    field5 = fields.Int()
+
+    class Meta:
+        ordered = True

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -171,4 +171,4 @@ class TestOrderedSchema:
     def test_ordered_schema(self, spec):
         spec.definition('Ordered', schema=OrderedSchema)
         result = spec._definitions['Ordered']['properties']
-        assert list(result.keys()) == ['field1', 'field2','field3','field4','field5']
+        assert list(result.keys()) == ['field1', 'field2', 'field3', 'field4', 'field5']

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -3,7 +3,7 @@ import pytest
 
 from apispec import APISpec
 from apispec.ext.marshmallow import swagger
-from .schemas import PetSchema, AnalysisSchema, SampleSchema, RunSchema, SelfReferencingSchema
+from .schemas import PetSchema, AnalysisSchema, SampleSchema, RunSchema, SelfReferencingSchema, OrderedSchema
 
 
 @pytest.fixture()
@@ -164,3 +164,11 @@ class TestSelfReference:
 
         result = spec._definitions['SelfReference']['properties']['many_with_ref']
         assert result == {'type': 'array', 'items': {'$ref': '#/definitions/Selves'}}
+
+
+class TestOrderedSchema:
+
+    def test_ordered_schema(self, spec):
+        spec.definition('Ordered', schema=OrderedSchema)
+        result = spec._definitions['Ordered']['properties']
+        assert list(result.keys()) == ['field1', 'field2','field3','field4','field5']


### PR DESCRIPTION
Respect `ordered` Meta setting in schemas so that generated swagger JSON has appropriate order of fields
