### PR TITLE
Maintain order in which paths are added to spec

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Core apispec classes and functions."""
 import re
+from collections import OrderedDict
 
 from apispec.compat import iterkeys
 from .exceptions import APISpecError, PluginError
@@ -102,7 +103,7 @@ class APISpec(object):
         self._definitions = {}
         self._parameters = {}
         self._tags = []
-        self._paths = {}
+        self._paths = OrderedDict()
         # Plugin and helpers
         self.plugins = {}
         self._definition_helpers = []


### PR DESCRIPTION
Providing API documentation in a particular order, in general, makes the API design more obvious and API usage more easier for the users. 

For example, in petstore documentation, what if the API `/pet/{petId}/uploadImage` was mentioned before the API for adding a new pet to the store. In a quick glance, the end user would not be so happy to see the jumbled APIs.

![swagger-petstore](https://cloud.githubusercontent.com/assets/113700/17502426/6213a4e0-5e05-11e6-83d4-488393e60a16.png)

Currently, the generated spec (via `APISpec.to_dict`) does not maintain the order in which paths were added (via `APISpec.add_path`) to `APISpec`.
