### PR TITLE
Add 'query' to __location_map__'

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -487,6 +487,7 @@ def fields2jsonschema(fields, schema=None, spec=None, use_refs=True, dump=True, 
     return jsonschema
 
 __location_map__ = {
+    'query': 'query',
     'querystring': 'query',
     'json': 'body',
     'headers': 'header',


### PR DESCRIPTION
Adding query to **location_map** allows users to use 'query' as location.

The goal here is not just to save 6 characters writing 'query' instead of 'querystring'. The idea is to be coherent with webargs, which allows 'query' as an equivalent for 'querystring', thus facilitate integration of apispec with webargs.
