### PR TITLE
Normalize paths relative to basePath in all cases

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -154,12 +154,19 @@ class APISpec(object):
         :param dict|None operations: describes the http methods and options for `path`
         :param dict kwargs: parameters used by any path helpers see :meth:`register_path_helper`
         """
+        def normalize_path(path):
+            if path and 'basePath' in self.options:
+                pattern = '^{0}'.format(re.escape(self.options['basePath']))
+                path = re.sub(pattern, '', path)
+
+            return path
+
         p = path
         if isinstance(path, Path):
             p = path.path
-        if p and 'basePath' in self.options:
-            pattern = '^{0}'.format(re.escape(self.options['basePath']))
-            p = re.sub(pattern, '', p)
+
+        p = normalize_path(p)
+
         if isinstance(path, Path):
             path.path = p
         else:
@@ -173,6 +180,7 @@ class APISpec(object):
             except TypeError:
                 continue
             if isinstance(ret, Path):
+                ret.path = normalize_path(ret.path)
                 path.update(ret)
 
         if not path.path:

--- a/tests/test_ext_flask.py
+++ b/tests/test_ext_flask.py
@@ -108,7 +108,8 @@ class TestPathHelpers:
 
     def test_path_includes_app_root(self, app, spec):
 
-        app.config['APPLICATION_ROOT'] = '/app/root'
+        spec.options['basePath'] = '/v1'
+        app.config['APPLICATION_ROOT'] = '/v1/app/root'
 
         @app.route('/partial/path/pet')
         def get_pet():
@@ -119,7 +120,8 @@ class TestPathHelpers:
 
     def test_path_with_args_includes_app_root(self, app, spec):
 
-        app.config['APPLICATION_ROOT'] = '/app/root'
+        spec.options['basePath'] = '/v1'
+        app.config['APPLICATION_ROOT'] = '/v1/app/root'
 
         @app.route('/partial/path/pet/{pet_id}')
         def get_pet(pet_id):
@@ -130,7 +132,8 @@ class TestPathHelpers:
 
     def test_path_includes_app_root_with_right_slash(self, app, spec):
 
-        app.config['APPLICATION_ROOT'] = '/app/root/'
+        spec.options['basePath'] = '/v1'
+        app.config['APPLICATION_ROOT'] = '/v1/app/root/'
 
         @app.route('/partial/path/pet')
         def get_pet():


### PR DESCRIPTION
Paths that include the basePath as set in options on the APISpec
instance were normalized to not have the basePath as part of each path.
However, this didn't work with the Flask plugin as normalization occured
before the plugin generated it's URLs.

This fixes the issue by also normalizing paths after plugin processing in
`add_path`.

Fixes #78.
