### PR TITLE
Added handling for description in model definitions

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -200,7 +200,7 @@ class APISpec(object):
 
         self._paths.setdefault(path.path, path).update(path)
 
-    def definition(self, name, properties=None, enum=None, **kwargs):
+    def definition(self, name, properties=None, enum=None, description=None, **kwargs):
         """Add a new definition to the spec.
 
         .. note::
@@ -225,6 +225,8 @@ class APISpec(object):
             ret['properties'] = properties
         if enum:
             ret['enum'] = enum
+        if description:
+            ret['description'] = description
         self._definitions[name] = ret
 
     # PLUGIN INTERFACE

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,6 +61,12 @@ class TestDefinitions:
         assert 'Pet' in defs_json
         assert defs_json['Pet']['properties'] == self.properties
 
+    def test_definition_description(self, spec):
+        model_description = 'An animal which lives with humans.'
+        spec.definition('Pet', properties=self.properties, description=model_description)
+        defs_json = spec.to_dict()['definitions']
+        assert defs_json['Pet']['description'] == model_description
+
     def test_definition_stores_enum(self, spec):
         enum = ['name', 'photoUrls']
         spec.definition(


### PR DESCRIPTION
Allow to set a description when declaring a definition of a Schema (as described [here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject)).

```
spec.definition(
    'Pet',
    schema=PetSchema,
    description="An animal which lives with humans."
)
```

```
"Pet": {
    "description": "An animal which lives with humans.",
    "properties": {...},
    ...
}
```
