### PR TITLE
Allow Patterned Objects

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -194,6 +194,9 @@ _VALID_PROPERTIES = {
     'example',
 }
 
+_VALID_PREFIX = 'x-'
+
+
 def field2property(field, spec=None, use_refs=True, dump=True, name=None):
     """Return the JSON Schema property definition given a marshmallow
     :class:`Field <marshmallow.fields.Field>`.
@@ -263,7 +266,7 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
         ret['items'] = field2property(field.container, spec=spec, use_refs=use_refs, dump=dump)
 
     for key, value in iteritems(field.metadata):
-        if key in _VALID_PROPERTIES:
+        if key in _VALID_PROPERTIES or key.startswith(_VALID_PREFIX):
             ret[key] = value
     # Avoid validation error with "Additional properties not allowed"
     # Property "ref" is not valid in this context

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -1,5 +1,6 @@
 from marshmallow import Schema, fields
 
+
 class PetSchema(Schema):
     id = fields.Int(dump_only=True)
     name = fields.Str()
@@ -17,6 +18,10 @@ class RunSchema(Schema):
 
 class AnalysisSchema(Schema):
     sample = fields.Nested(SampleSchema)
+
+
+class PatternedObjectSchema(Schema):
+    count = fields.Int(dump_only=True, **{'x-meta': 1})
 
 
 class SelfReferencingSchema(Schema):

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -3,7 +3,8 @@ import pytest
 
 from apispec import APISpec
 from apispec.ext.marshmallow import swagger
-from .schemas import PetSchema, AnalysisSchema, SampleSchema, RunSchema, SelfReferencingSchema, OrderedSchema
+from .schemas import PetSchema, AnalysisSchema, SampleSchema, RunSchema, SelfReferencingSchema,\
+    OrderedSchema, PatternedObjectSchema
 
 
 @pytest.fixture()
@@ -172,3 +173,10 @@ class TestOrderedSchema:
         spec.definition('Ordered', schema=OrderedSchema)
         result = spec._definitions['Ordered']['properties']
         assert list(result.keys()) == ['field1', 'field2', 'field3', 'field4', 'field5']
+
+
+class TestFieldWithCustomProps:
+    def test_field_with_custom_props(self, spec):
+        spec.definition('PatternedObject', schema=PatternedObjectSchema)
+        result = spec._definitions['PatternedObject']['properties']['count']
+        assert 'x-meta' in result


### PR DESCRIPTION
Allow to add attributes to fields which are not in `_VALID_PROPERTIES` if their key starts with `x-` (as written everywhere in https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md)
