### PR TITLE
Update the condition to show warning about Meta.fields

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -454,10 +454,14 @@ def fields2jsonschema(fields, schema=None, spec=None, use_refs=True, dump=True, 
     """
     Meta = getattr(schema, 'Meta', None)
     if getattr(Meta, 'fields', None) or getattr(Meta, 'additional', None):
-        warnings.warn(
-            "Only explicitly-declared fields will be included in the Schema Object. "
-            "Fields defined in Meta.fields or Meta.additional are ignored."
-        )
+        declared_fields = set(schema._declared_fields.keys())
+        if (set(getattr(Meta, 'fields', set())) > declared_fields
+            or
+            set(getattr(Meta, 'additional', set())) > declared_fields):
+            warnings.warn(
+                "Only explicitly-declared fields will be included in the Schema Object. "
+                "Fields defined in Meta.fields or Meta.additional are ignored."
+            )
 
     jsonschema = {
         'type': 'object',


### PR DESCRIPTION
Closes #95: fields2jsonschema warning about Shema Object

If we have `ModelShema` with:

```python
class Meta:
        # pylint: disable=missing-docstring
        model = User
        fields = (
            User.id.key,
            User.username.key,
            User.first_name.key,
            User.middle_name.key,
            User.last_name.key,
            'woopy',
        )
        dump_only = (
            User.id.key,
        )
```

The field `'woopy'` doesn't exist in model.

Then in swagger.json we'll have:
```json
...
"properties": {
                        "first_name": {
                            "maxLength": 30,
                            "type": "string"
                        },
                        "id": {
                            "format": "int32",
                            "readOnly": true,
                            "type": "integer"
                        },
                        "last_name": {
                            "maxLength": 30,
                            "type": "string"
                        },
                        "middle_name": {
                            "maxLength": 30,
                            "type": "string"
                        },
                        "username": {
                            "maxLength": 80,
                            "type": "string"
                        },
                        "woopy": {
                            "type": "string"
                        }
                    },
...
```

The `'woopy'` is there as you can see.

Also if we have Shema:

```python
class User(Schema):
    class Meta:
        fields = (
            'name',
            'last_name',
        )
```

```python
>>> from app.simple import User
>>> from apispec.ext.marshmallow.swagger import schema2jsonschema
>>> from pprint import pprint
>>> pprint(schema2jsonschema(User))
... site-packages/apispec/ext/marshmallow/swagger.py:450: UserWarning: Only explicitly-declared fields will be included in the Schema Object. Fields defined in Meta.fields or Meta.additional are ignored.
  "Only explicitly-declared fields will be included in the Schema Object. "
{'properties': {}, 'type': 'object'}
```

As you can see the warning is there and the fields are not.

I think we don't need that warning if Meta has `model` and we do need it when it's not.