### PR TITLE
Exclude fields that are both dump_only and load_only

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -347,7 +347,7 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True, dump=True,
             for field_name, field_obj in iteritems(fields)
             if (
                 (field_name not in exclude_fields)
-                and not (field_obj.dump_only and not dump)
+                and not (field_obj.dump_only and (not dump or field_obj.load_only))
             )
     ]
 


### PR DESCRIPTION
In Marshmallow, a field can be both `dump_only` and `load_only`, which means don't serialize and don't deserialize (see [nice explanation here](https://github.com/marshmallow-code/marshmallow/issues/453#issuecomment-221673132)).

Shouldn't such a field be removed from the spec just like an "exclude" field ?

Here's a quick attempt.

Note that 

- It has not unit tests (just tested in my use case).

- It only deals with `dump_only` / `load_only` properties defined in the field, not in `Meta`.

The fix to the latter might also address https://github.com/marshmallow-code/apispec/issues/84.

I'd rather have feedback about this before going any further.

Also, I'm not sure I understand the rationale behind the `dump` parameter correctly. I wouldn't like to screw it up, so any enlightenment welcome.

Thanks.