### PR TITLE
Tornado getargspec with decorated handler method arguments.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,3 +26,4 @@ Contributors (chronological)
 - Jérôme Lafréchoux `@lafrech <https://github.com/lafrech>`_
 - Anders Steinlein `@asteinlein <https://github.com/asteinlein>`_
 - Yuri Heupa `@YuriHeupa <https://github.com/YuriHeupa>`_
+- Matija Besednik `@matijabesednik <https://github.com/matijabesednik>`_

--- a/apispec/ext/tornado.py
+++ b/apispec/ext/tornado.py
@@ -31,6 +31,7 @@ object to `add_path`.
 """
 from __future__ import absolute_import
 import inspect
+import sys
 from tornado.web import URLSpec
 
 from apispec import Path
@@ -80,7 +81,10 @@ def tornadopath2swagger(urlspec, method):
     :param method: Handler http method
     :type method: function
     """
-    args = inspect.getargspec(method).args[1:]
+    if sys.version_info >= (3, 3):
+        args = [i for i in inspect.signature(method).parameters.keys()][1:]
+    else:
+        args = inspect.getargspec(method).args[1:]
     params = tuple('{{{}}}'.format(arg) for arg in args)
     path = (urlspec._path % params)
     if path.count('/') > 1:

--- a/apispec/ext/tornado.py
+++ b/apispec/ext/tornado.py
@@ -82,7 +82,7 @@ def tornadopath2swagger(urlspec, method):
     :type method: function
     """
     if sys.version_info >= (3, 3):
-        args = [i for i in inspect.signature(method).parameters.keys()][1:]
+        args = list(inspect.signature(method).parameters.keys())[1:]
     else:
         args = inspect.getargspec(method).args[1:]
     params = tuple('{{{}}}'.format(arg) for arg in args)


### PR DESCRIPTION
Current implementation uses deprecated inspect.getargspec() method to get argument names. Fixes #102 

It causes issues having decorated handler methods and you get decorator arguments instead of method arguments which breaks swagger path generation.
