### PR TITLE
Fix global Schema state corruption

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -9,6 +9,7 @@ import operator
 import warnings
 import functools
 from collections import OrderedDict
+import copy
 
 import marshmallow
 from marshmallow.utils import is_collection
@@ -297,7 +298,7 @@ def schema2parameters(schema, **kwargs):
     if hasattr(schema, 'fields'):
         fields = schema.fields
     elif hasattr(schema, '_declared_fields'):
-        fields = schema._declared_fields
+        fields = copy.deepcopy(schema._declared_fields)
     else:
         raise ValueError(
             "{0!r} doesn't have either `fields` or `_declared_fields`".format(schema)
@@ -410,7 +411,7 @@ def schema2jsonschema(schema, spec=None, use_refs=True, dump=True, name=None):
     if hasattr(schema, 'fields'):
         fields = schema.fields
     elif hasattr(schema, '_declared_fields'):
-        fields = schema._declared_fields
+        fields = copy.deepcopy(schema._declared_fields)
     else:
         raise ValueError(
             "{0!r} doesn't have either `fields` or `_declared_fields`".format(schema)

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+import json
 
 from apispec import APISpec
 from apispec.ext.marshmallow import swagger
@@ -132,6 +133,18 @@ class TestOperationHelper:
             'type': 'array',
             'items': {'$ref': '#/definitions/Pet'}
         }
+
+    def test_schema_global_state_untouched_2json(self):
+        assert RunSchema._declared_fields['sample']._Nested__schema is None
+        data = swagger.schema2jsonschema(RunSchema)
+        json.dumps(data)
+        assert RunSchema._declared_fields['sample']._Nested__schema is None
+
+    def test_schema_global_state_untouched_2parameters(self):
+        assert RunSchema._declared_fields['sample']._Nested__schema is None
+        data = swagger.schema2parameters(RunSchema)
+        json.dumps(data)
+        assert RunSchema._declared_fields['sample']._Nested__schema is None
 
 class TestCircularReference:
 


### PR DESCRIPTION
The `Schema`s setup is done on the class level,
so `Schema` and it's fields are global objects, initialized during the
application startup.

The global field objects are available as `SchemaClass._declared_fields`
or as `schema_object._declared_fields` when we are working with the Schema
instance.

`Schema` itself does this:

```
    self.declared_fields = copy.deepcopy(self._declared_fields)`
```

before doing anything with the fields.

So `self._declared_fields` are global, and `self.declared_fields` are local
in the field object.
But apispec uses global copy during the serialization thus modifying this
global state and affecting further Schema usages.

This issue was tracked down with `Nested` field, which has `__schema` property.
This property is not set on object creation and modified later, during
the serialization (see https://github.com/marshmallow-code/marshmallow/blob/4457426e7447195e5b390605ec90349b81ded507/marshmallow/fields.py#L398).

So the following assertion was always true:

```
assert GalleryLocationSchema._declared_fields['city']._Nested__schema is None
```

But it failed after exporting APISpec to json:

```
apispec.init_app(current_app)
data = apispec.to_dict()
json.dumps(data)
assert GalleryLocationSchema._declared_fields['city']._Nested__schema is None  # Fails!
```

The assert started failing after json.dumps, which triggered the serialization
of the data in `LazyDict`s inside the apispec.ext.marshmallow.swagger which
in turn triggered the serialization process for the global
`Schema._declared_fields`.

The overall effect of the issue in our case was a complete breakage of the
application, our API started serving empty objects after someone accessed
the API docs in swagger.

The fix is to do the same thing `Schema.__init__` does and copy the fields
before doing anything to them.