### PR TITLE
Translate allow_none property into x-nullable

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -241,6 +241,9 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
     if field.dump_only:
         ret['readOnly'] = True
 
+    if field.allow_none:
+        ret['x-nullable'] = True
+
     ret.update(field2range(field))
     ret.update(field2length(field))
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -128,6 +128,10 @@ class TestMarshmallowFieldToSwagger:
         assert res['maxLength'] == 100
         assert res['minLength'] == 6
 
+    def test_field_with_allow_none(self):
+        field = fields.Str(allow_none=True)
+        res = swagger.field2property(field)
+        assert res['x-nullable'] is True
 
 class TestMarshmallowSchemaToModelDefinition:
 


### PR DESCRIPTION
This makes `allow_none` property in a field translate to `x-nullable` in the spec.

As I wrote in https://github.com/marshmallow-code/apispec/issues/66#issuecomment-280878572:

It would map to `nullable`, except [`nullable` does not exist... yet](https://github.com/OAI/OpenAPI-Specification/issues/229). There seems to be a wide consensus upon the use of `x-nullable` until `nullable is added` (OpenAPI 3). It has been [integrated in ReDoc](https://github.com/Rebilly/ReDoc/pull/95), for instance.