### PR TITLE
Allow additional properties (dump_only,...) on Nested schemas using allOf

### DIFF
--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -146,7 +146,9 @@ def resolve_schema_dict(spec, schema, dump=True):
                 'type': 'array',
                 'items': ref_schema,
             }
-        return ref_schema
+        return {
+            'allOf': [ref_schema]
+        }
     if not isinstance(schema, marshmallow.Schema):
         schema = schema_cls
     return swagger.schema2jsonschema(schema, spec=spec, dump=dump)

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -146,9 +146,7 @@ def resolve_schema_dict(spec, schema, dump=True):
                 'type': 'array',
                 'items': ref_schema,
             }
-        return {
-            'allOf': [ref_schema]
-        }
+        return ref_schema
     if not isinstance(schema, marshmallow.Schema):
         schema = schema_cls
     return swagger.schema2jsonschema(schema, spec=spec, dump=dump)

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -266,9 +266,16 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
                 ret['type'] = 'array'
                 ret['items'] = ref_schema
             else:
-                ret.update({'allOf': [ref_schema]})
+                if ret:
+                    ret.update({'allOf': [ref_schema]})
+                else:
+                    ret.update(ref_schema)
         elif spec:
-            ret.update(resolve_schema_dict(spec, field.schema, dump=dump))
+            schema_dict = resolve_schema_dict(spec, field.schema, dump=dump)
+            if ret and '$ref' in schema_dict:
+                ret.update({'allOf': [schema_dict]})
+            else:
+                ret.update(schema_dict)
         else:
             ret.update(schema2jsonschema(field.schema, dump=dump))
     elif isinstance(field, marshmallow.fields.List):

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -266,7 +266,7 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
                 ret['type'] = 'array'
                 ret['items'] = ref_schema
             else:
-                ret.update(ref_schema)
+                ret.update({'allOf': [ref_schema]})
         elif spec:
             ret.update(resolve_schema_dict(spec, field.schema, dump=dump))
         else:

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -544,6 +544,31 @@ class TestNesting:
         category_props = res['properties']['category']['properties']
         assert 'breed' not in category_props
 
+    def test_nested_field_with_property(self, spec):
+        category_1 = fields.Nested(CategorySchema)
+        category_2 = fields.Nested(CategorySchema, ref='#/definitions/Category')
+        category_3 = fields.Nested(CategorySchema, dump_only=True)
+        category_4 = fields.Nested(CategorySchema, dump_only=True, ref='#/definitions/Category')
+        category_5 = fields.Nested(CategorySchema, many=True)
+        category_6 = fields.Nested(CategorySchema, many=True, ref='#/definitions/Category')
+        category_7 = fields.Nested(CategorySchema, many=True, dump_only=True)
+        category_8 = fields.Nested(CategorySchema, many=True, dump_only=True, ref='#/definitions/Category')
+        spec.definition('Category', schema=CategorySchema)
+
+        assert swagger.field2property(category_1, spec=spec) == {'$ref': '#/definitions/Category'}
+        assert swagger.field2property(category_2, spec=spec) == {'$ref': '#/definitions/Category'}
+        assert swagger.field2property(category_3, spec=spec) == {
+            'allOf': [{'$ref': '#/definitions/Category'}], 'readOnly': True}
+        assert swagger.field2property(category_4, spec=spec) == {
+            'allOf': [{'$ref': '#/definitions/Category'}], 'readOnly': True}
+        assert swagger.field2property(category_5, spec=spec) == {
+            'items': {'$ref': '#/definitions/Category'}, 'type': 'array'}
+        assert swagger.field2property(category_6, spec=spec) == {
+            'items': {'$ref': '#/definitions/Category'}, 'type': 'array'}
+        assert swagger.field2property(category_7, spec=spec) == {
+            'items': {'$ref': '#/definitions/Category'}, 'readOnly': True, 'type': 'array'}
+        assert swagger.field2property(category_8, spec=spec) == {
+            'items': {'$ref': '#/definitions/Category'}, 'readOnly': True, 'type': 'array'}
 
 def test_swagger_tools_validate():
     spec = APISpec(


### PR DESCRIPTION
Fixes #108.

Uses `allOf` as proposed [here](https://github.com/darklynx/request-baskets/issues/5) to add properties to a ref field, so as to circumvent a [limitation in JsonSchema](https://github.com/swagger-api/swagger-js/issues/402).