### PR TITLE
Load-only fields must be skipped if 'dump' is True

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -337,6 +337,8 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True, dump=True,
         "Schemas with many=True are only supported for 'json' location (aka 'in: body')"
 
     exclude_fields = getattr(getattr(schema, 'Meta', None), 'exclude', [])
+    dump_only_fields = getattr(getattr(schema, 'Meta', None), 'dump_only', [])
+    load_only_fields = getattr(getattr(schema, 'Meta', None), 'load_only', [])
 
     return [
         field2parameter(
@@ -348,9 +350,10 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True, dump=True,
             default_in=default_in
         )
             for field_name, field_obj in iteritems(fields)
-            if (
-                (field_name not in exclude_fields)
-                and not (field_obj.dump_only and not dump)
+            if not (
+                field_name in exclude_fields or
+                (not dump and (field_obj.dump_only or field_name in dump_only_fields)) or 
+                (dump and (field_obj.load_only or field_name in load_only_fields))
             )
     ]
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -89,8 +89,47 @@ class TestMarshmallowFieldToSwagger:
         assert res[0]['in'] == 'query'
 
     def test_fields_with_dump_only(self):
-        field_dict = {'field': fields.Str(dump_only=True)}
-        res = swagger.fields2parameters(field_dict, default_in='query', dump=False)
+        class UserSchema(Schema):
+            name = fields.Str(dump_only=True)
+        res = swagger.fields2parameters(
+            UserSchema._declared_fields, default_in='query', dump=False)
+        assert len(res) == 0
+        res = swagger.fields2parameters(
+            UserSchema().fields, default_in='query', dump=False)
+        assert len(res) == 0
+
+        class UserSchema(Schema):
+            name = fields.Str()
+
+            class Meta:
+                dump_only = ('name',)
+        res = swagger.fields2parameters(
+            UserSchema._declared_fields, schema=UserSchema, default_in='query', dump=False)
+        assert len(res) == 0
+        res = swagger.fields2parameters(
+            UserSchema().fields, schema=UserSchema, default_in='query', dump=False)
+        assert len(res) == 0
+
+    def test_fields_with_load_only(self):
+        class UserSchema(Schema):
+            name = fields.Str(load_only=True)
+        res = swagger.fields2parameters(
+            UserSchema._declared_fields, default_in='query', dump=True)
+        assert len(res) == 0
+        res = swagger.fields2parameters(
+            UserSchema().fields, default_in='query', dump=True)
+        assert len(res) == 0
+
+        class UserSchema(Schema):
+            name = fields.Str()
+
+            class Meta:
+                load_only = ('name',)
+        res = swagger.fields2parameters(
+            UserSchema._declared_fields, schema=UserSchema, default_in='query', dump=True)
+        assert len(res) == 0
+        res = swagger.fields2parameters(
+            UserSchema().fields, schema=UserSchema, default_in='query', dump=True)
         assert len(res) == 0
 
     def test_field_with_choices(self):


### PR DESCRIPTION
Symmetric to "Dump-only fields must be skipped if 'dump=False' is passed".
Also fixes cases where dump_only or load_only is specified in Meta.
_De facto_ removes fields both dump_only and load_only.

This replaces #101. I assumed load_only fields should be removed if dump is True. Now I'm wondering the point of parameters with dump=True. If parameters are inputs of the API, those should only be used for loading, so what is the use case for dump=True?

