### PR TITLE
Remove dump parameter from fields2parameters and field2parameter

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -317,7 +317,7 @@ def schema2parameters(schema, **kwargs):
     return fields2parameters(fields, schema, **kwargs)
 
 
-def fields2parameters(fields, schema=None, spec=None, use_refs=True, dump=True,
+def fields2parameters(fields, schema=None, spec=None, use_refs=True,
                       default_in='body', name='body', required=False):
     """Return an array of OpenAPI parameters given a mapping between field names and
     :class:`Field <marshmallow.Field>` objects. If `default_in` is "body", then return an array
@@ -330,9 +330,9 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True, dump=True,
         if schema is not None:
             # Prevent circular import
             from apispec.ext.marshmallow import resolve_schema_dict
-            prop = resolve_schema_dict(spec, schema, dump=dump)
+            prop = resolve_schema_dict(spec, schema, dump=False)
         else:
-            prop = fields2jsonschema(fields, spec=spec, use_refs=use_refs, dump=dump)
+            prop = fields2jsonschema(fields, spec=spec, use_refs=use_refs, dump=False)
 
         return [{
             'in': default_in,
@@ -346,7 +346,6 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True, dump=True,
 
     exclude_fields = getattr(getattr(schema, 'Meta', None), 'exclude', [])
     dump_only_fields = getattr(getattr(schema, 'Meta', None), 'dump_only', [])
-    load_only_fields = getattr(getattr(schema, 'Meta', None), 'load_only', [])
 
     return [
         field2parameter(
@@ -354,26 +353,25 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True, dump=True,
             name=_observed_name(field_obj, field_name),
             spec=spec,
             use_refs=use_refs,
-            dump=dump,
             default_in=default_in
         )
             for field_name, field_obj in iteritems(fields)
             if not (
                 field_name in exclude_fields or
-                (not dump and (field_obj.dump_only or field_name in dump_only_fields)) or 
-                (dump and (field_obj.load_only or field_name in load_only_fields))
+                field_obj.dump_only or
+                field_name in dump_only_fields
             )
     ]
 
 
-def field2parameter(field, name='body', spec=None, use_refs=True, dump=True, default_in='body'):
+def field2parameter(field, name='body', spec=None, use_refs=True, default_in='body'):
     """Return an OpenAPI parameter as a `dict`, given a marshmallow
     :class:`Field <marshmallow.Field>`.
 
     https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
     """
     location = field.metadata.get('location', None)
-    prop = field2property(field, spec=spec, use_refs=use_refs, dump=dump)
+    prop = field2property(field, spec=spec, use_refs=use_refs, dump=False)
     return property2parameter(
         prop,
         name=name,

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -77,7 +77,7 @@ class TestMarshmallowFieldToSwagger:
 
     def test_fields_with_default_load(self):
         field_dict = {'field': fields.Str(default='foo', missing='bar')}
-        res = swagger.fields2parameters(field_dict, default_in='query', dump=False)
+        res = swagger.fields2parameters(field_dict, default_in='query')
         assert res[0]['default'] == 'bar'
 
     def test_fields_with_location(self):
@@ -96,11 +96,9 @@ class TestMarshmallowFieldToSwagger:
     def test_fields_with_dump_only(self):
         class UserSchema(Schema):
             name = fields.Str(dump_only=True)
-        res = swagger.fields2parameters(
-            UserSchema._declared_fields, default_in='query', dump=False)
+        res = swagger.fields2parameters(UserSchema._declared_fields, default_in='query')
         assert len(res) == 0
-        res = swagger.fields2parameters(
-            UserSchema().fields, default_in='query', dump=False)
+        res = swagger.fields2parameters(UserSchema().fields, default_in='query')
         assert len(res) == 0
 
         class UserSchema(Schema):
@@ -109,32 +107,10 @@ class TestMarshmallowFieldToSwagger:
             class Meta:
                 dump_only = ('name',)
         res = swagger.fields2parameters(
-            UserSchema._declared_fields, schema=UserSchema, default_in='query', dump=False)
+            UserSchema._declared_fields, schema=UserSchema, default_in='query')
         assert len(res) == 0
         res = swagger.fields2parameters(
-            UserSchema().fields, schema=UserSchema, default_in='query', dump=False)
-        assert len(res) == 0
-
-    def test_fields_with_load_only(self):
-        class UserSchema(Schema):
-            name = fields.Str(load_only=True)
-        res = swagger.fields2parameters(
-            UserSchema._declared_fields, default_in='query', dump=True)
-        assert len(res) == 0
-        res = swagger.fields2parameters(
-            UserSchema().fields, default_in='query', dump=True)
-        assert len(res) == 0
-
-        class UserSchema(Schema):
-            name = fields.Str()
-
-            class Meta:
-                load_only = ('name',)
-        res = swagger.fields2parameters(
-            UserSchema._declared_fields, schema=UserSchema, default_in='query', dump=True)
-        assert len(res) == 0
-        res = swagger.fields2parameters(
-            UserSchema().fields, schema=UserSchema, default_in='query', dump=True)
+            UserSchema().fields, schema=UserSchema, default_in='query')
         assert len(res) == 0
 
     def test_field_with_choices(self):
@@ -357,15 +333,7 @@ class TestMarshmallowSchemaToParameters:
             name = fields.Str()
             email = fields.Email(dump_only=True)
 
-        res_dump = swagger.schema2parameters(UserSchema, default_in='body', dump=True)
-        assert len(res_dump) == 1
-        param = res_dump[0]
-        assert param['in'] == 'body'
-        assert param['schema'] == swagger.schema2jsonschema(UserSchema, dump=True)
-        assert set(param['schema']['properties'].keys()) == {'name', 'email'}
-        assert param['schema']['properties']['email']['readOnly'] is True
-
-        res_nodump = swagger.schema2parameters(UserSchema, default_in='body', dump=False)
+        res_nodump = swagger.schema2parameters(UserSchema, default_in='body')
         assert len(res_nodump) == 1
         param = res_nodump[0]
         assert param['in'] == 'body'


### PR DESCRIPTION
Fixes #114.

This can be a breaking change for people calling `fields2parameters` or `field2parameter` with `dump` parameter in their code. People calling `schema2parameters` with `dump=False` are not affected as it will be silently ignored.