### PR TITLE
Pass current state of the definition to definition_helpers in APISpec.definition

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -269,8 +269,8 @@ class APISpec(object):
         - Return a `dict` representation of the definition's Schema object.
 
         The helper may define any named arguments after the `name` argument.
-        In `kwargs`, you will find among other things:
-        - Definition: the current state of the definition of the schema.
+        ``kwargs`` will include (among other things):
+        - definition (dict): current state of the definition
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#definitionsObject
 

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -219,7 +219,7 @@ class APISpec(object):
         # Execute all helpers from plugins
         for func in self._definition_helpers:
             try:
-                ret.update(func(self, name, **kwargs))
+                ret.update(func(self, name, definition=ret, **kwargs))
             except TypeError:
                 continue
         if properties:
@@ -269,6 +269,8 @@ class APISpec(object):
         - Return a `dict` representation of the definition's Schema object.
 
         The helper may define any named arguments after the `name` argument.
+        In `kwargs`, you will find among other things:
+        - Definition: the current state of the definition of the schema.
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#definitionsObject
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -83,6 +83,20 @@ class TestDefinitions:
         defs_json = spec.to_dict()['definitions']
         assert defs_json['Pet']['discriminator'] == 'name'
 
+    def test_pass_definition_to_plugins(self, spec):
+        def def_helper(spec, name, **kwargs):
+            if kwargs.get('definition') is not None:
+                return {'available': True}
+
+            return {'available': False}
+
+        spec.register_definition_helper(def_helper)
+        spec.definition('Pet', properties=self.properties)
+
+        defs_json = spec.to_dict()['definitions']
+
+        assert defs_json['Pet']['available']
+
 
 class TestPath:
     paths = {


### PR DESCRIPTION
Now pass the current state of the definition (i.e. `ret`) as a `kwarg` to all definition helpers.

It will allow helpers to do modifications of nested value in the definition (like modifying a schema's property for example) without overriding the whole top-level dict (`properties`, in our example).