### PR TITLE
Test schema2jsonschema with dump_only/load_only fields

### DIFF
--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -321,6 +321,21 @@ class TestMarshmallowSchemaToModelDefinition:
         assert excinfo.value.args[0] == ("{0!r} doesn't have either `fields` "
                                          "or `_declared_fields`".format(NotASchema))
 
+    def test_dump_only_load_only_fields(self):
+        class UserSchema(Schema):
+            _id = fields.Str(dump_only=True)
+            name = fields.Str()
+            password = fields.Str(load_only=True)
+
+        res = swagger.schema2jsonschema(UserSchema())
+        props = res['properties']
+        assert 'name' in props
+        # dump_only field appears with readOnly attribute
+        assert '_id' in props
+        assert 'readOnly' in props['_id']
+        # load_only field appears (writeOnly attribute does not exist)
+        assert 'password' in props
+
 
 class TestMarshmallowSchemaToParameters:
 


### PR DESCRIPTION
This test ensure that when creating a definition from a schema, both dump_only and load_only fields appear in the output.

- dump_only fields have a readOnly attribute
- load_only fields have no attribute because writeOnly does not exist

In fact, load_only is not really supported. The right way to define a schema with load_only fields would be to create another schema without the load_only fields. schema2jsonschema should not remove those fields. It is up to the user to either create a second schema or use some sort of custom attribute to express the load_only property.