### PR TITLE
sort list of reqd fields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -28,3 +28,4 @@ Contributors (chronological)
 - Yuri Heupa `@YuriHeupa <https://github.com/YuriHeupa>`_
 - Matija Besednik `@matijabesednik <https://github.com/matijabesednik>`_
 - Boris Serebrov `@serebrov <https://github.com/serebrov>`_
+- Daniel Radetsky `@dradetsky <https://github.com/dradetsky>`_

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -502,6 +502,8 @@ def fields2jsonschema(fields, schema=None, spec=None, use_refs=True, dump=True, 
             if not partial or (is_collection(partial) and field_name not in partial):
                 jsonschema.setdefault('required', []).append(observed_field_name)
 
+    jsonschema.setdefault('required', []).sort()
+
     if Meta is not None:
         if hasattr(Meta, 'title'):
             jsonschema['title'] = Meta.title

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -502,7 +502,8 @@ def fields2jsonschema(fields, schema=None, spec=None, use_refs=True, dump=True, 
             if not partial or (is_collection(partial) and field_name not in partial):
                 jsonschema.setdefault('required', []).append(observed_field_name)
 
-    jsonschema.setdefault('required', []).sort()
+    if 'required' in jsonschema:
+        jsonschema['required'].sort()
 
     if Meta is not None:
         if hasattr(Meta, 'title'):


### PR DESCRIPTION
apropos of #113, i was recently trying to make some changes to something-or-other, and then diffing the generated swagger output to confirm that i hadn't actually screwed anything up. I noticed that the order of the requirements lists in generated definitions changed arbitrarily between runs, making it impossible to do this check. This change just sorts the required list.

There are 5 failing tests, but they're failing on dev too, and all have to do with tornado, which I can't see this having anything to do with.