### PR TITLE
Correct definition to match output in document.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -26,7 +26,7 @@ Add definitions to your spec using `definition <apispec.APISpec.definition>`.
 
     spec.definition('Gist', properties={
         'id': {'type': 'integer', 'format': 'int64'},
-        'content': 'type': 'string'},
+        'name': {'type': 'string'}
     })
 
 


### PR DESCRIPTION
Code was malformed, with un-even brackets and output was not matching.