### PR TITLE
correctly fill default parameter if default is boolean False

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,3 +31,4 @@ Contributors (chronological)
 - Daniel Radetsky `@dradetsky <https://github.com/dradetsky>`_
 - Lucas Coutinho `@lucasrc <https://github.com/lucasrc>`_
 - `@lamiskin <https://github.com/lamiskin>`_
+- Florian Scheffler `@nebularazer <https://github.com/nebularazer>`_

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 import copy
 
 import marshmallow
-from marshmallow.utils import is_collection
+from marshmallow.utils import is_collection, _Missing
 from marshmallow.compat import text_type, binary_type, iteritems
 from marshmallow.orderedset import OrderedSet
 
@@ -231,7 +231,7 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
         ret['format'] = fmt
 
     default = field.default if dump else field.missing
-    if default:
+    if not isinstance(default, _Missing):
         ret['default'] = default
 
     choices = field2choices(field)

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -70,10 +70,20 @@ class TestMarshmallowFieldToSwagger:
         res = swagger.field2property(field)
         assert res['default'] == 'foo'
 
+    def test_field_with_boolean_false_default(self):
+        field = fields.Boolean(default=False, missing=None)
+        res = swagger.field2property(field)
+        assert res['default'] is False
+
     def test_field_with_default_load(self):
         field = fields.Str(default='foo', missing='bar')
         res = swagger.field2property(field, dump=False)
         assert res['default'] == 'bar'
+
+    def test_field_with_boolean_false_default_load(self):
+        field = fields.Boolean(default=None, missing=False)
+        res = swagger.field2property(field, dump=False)
+        assert res['default'] is False
 
     def test_fields_with_default_load(self):
         field_dict = {'field': fields.Str(default='foo', missing='bar')}


### PR DESCRIPTION
When using `False` as a default or missing parameter the swagger spec does not include a default.
This PR fixes this.
```python
from apispec.ext.marshmallow import swagger
from marshmallow import fields

field = fields.Boolean(default=False, missing=False)
swagger.field2property(field)
# {'type': 'boolean'}  # actual response
# {'default': False, 'type': 'boolean'}  # expected
```