### PR TITLE
Allow default value for fields to be callable.

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -232,7 +232,10 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
 
     default = field.default if dump else field.missing
     if default is not marshmallow.missing:
-        ret['default'] = default
+        if callable(default):
+            ret['default'] = default()
+        else:
+            ret['default'] = default
 
     choices = field2choices(field)
     if choices:

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -42,3 +42,7 @@ class OrderedSchema(Schema):
 
     class Meta:
         ordered = True
+
+
+class DefaultCallableSchema(Schema):
+    numbers = fields.List(fields.Int, default=list)

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -5,7 +5,7 @@ import json
 from apispec import APISpec
 from apispec.ext.marshmallow import swagger
 from .schemas import PetSchema, AnalysisSchema, SampleSchema, RunSchema, SelfReferencingSchema,\
-    OrderedSchema, PatternedObjectSchema
+    OrderedSchema, PatternedObjectSchema, DefaultCallableSchema
 
 
 @pytest.fixture()
@@ -200,3 +200,10 @@ class TestFieldWithCustomProps:
         result = spec._definitions['PatternedObject']['properties']['count2']
         assert 'x-count2' in result
         assert result['x-count2'] == 2
+
+
+class TestDefaultCanBeCallable:
+    def test_default_can_be_callable(self, spec):
+        spec.definition('DefaultCallableSchema', schema=DefaultCallableSchema)
+        result = spec._definitions['DefaultCallableSchema']['properties']['numbers']
+        assert result['default'] == []


### PR DESCRIPTION
Hi there! As docstring 
https://github.com/marshmallow-code/marshmallow/blob/dev/marshmallow/fields.py#L63 says the default value may be callable. I think it's a common use case, f.e. passing list or dict constructor to field.
```
from marshmallow import Schema, fields
class MySchema(Schema):
    numbers = fields.List(fields.Int, default=list)
```
