### PR TITLE
Generate parameters specification by marshmallow schema

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,3 +32,4 @@ Contributors (chronological)
 - Lucas Coutinho `@lucasrc <https://github.com/lucasrc>`_
 - `@lamiskin <https://github.com/lamiskin>`_
 - Florian Scheffler `@nebularazer <https://github.com/nebularazer>`_
+- Yoichi Nakayama `@yoichi <https://github.com/yoichi>`_

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -127,21 +127,21 @@ def schema_path_helper(spec, view, **kwargs):
     operations = operations.copy()
     for operation in operations.values():
         if 'parameters' in operation:
-            operation['parameters'] = resolve_parameters(operation['parameters'])
+            operation['parameters'] = resolve_parameters(spec, operation['parameters'])
         for response in operation.get('responses', {}).values():
             if 'schema' in response:
                 response['schema'] = resolve_schema_dict(spec, response['schema'])
     return Path(operations=operations)
 
 
-def resolve_parameters(parameters):
+def resolve_parameters(spec, parameters):
     resolved = []
     for parameter in parameters:
         if not isinstance(parameter.get('schema', {}), dict):
             schema_cls = resolve_schema_cls(parameter['schema'])
             if issubclass(schema_cls, marshmallow.Schema) and 'in' in parameter:
                 resolved += swagger.schema2parameters(
-                    schema_cls, default_in=parameter['in'])
+                    schema_cls, default_in=parameter['in'], spec=spec)
                 continue
         resolved.append(parameter)
     return resolved

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -68,6 +68,9 @@ Our application will have a marshmallow `Schema <marshmallow.Schema>` for gists.
 
     from marshmallow import Schema, fields
 
+    class GistParameter(Schema):
+        gist_id = fields.Int()
+
     class GistSchema(Schema):
         id = fields.Int()
         content = fields.Str()
@@ -116,6 +119,9 @@ We'll add some YAML in the docstring to add response information.
         """Gist detail view.
         ---
         get:
+            parameters:
+                - in: path
+                  schema: GistParameter
             responses:
                 200:
                     schema: GistSchema
@@ -148,7 +154,12 @@ Our OpenAPI spec now looks like this:
     #         'title': 'Gisty',
     #         'version': '1.0.0'},
     # 'parameters': {},
-    # 'paths': {'/gists/{gist_id}': {'get': {'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}}}},
+    # 'paths': {'/gists/{gist_id}': {'get': {'parameters': [{'format': 'int32',
+    #                                                        'in': 'path',
+    #                                                        'name': 'gist_id',
+    #                                                        'required': True,
+    #                                                        'type': 'integer'}],
+    #                                        'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}}}},
     # 'swagger': '2.0',
     # 'tags': []}
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -87,6 +87,37 @@ class TestOperationHelper:
         assert post['responses'][201]['schema'] == swagger.schema2jsonschema(PetSchema)
         assert post['responses'][201]['description'] == 'successful operation'
 
+    def test_schema_in_docstring_expand_parameters(self, spec):
+
+        def pet_view():
+            """Not much to see here.
+
+            ---
+            get:
+                parameters:
+                    - in: query
+                      schema: tests.schemas.PetSchema
+            post:
+                parameters:
+                    - in: body
+                      schema: tests.schemas.PetSchema
+                responses:
+                    200:
+                        schema: tests.schemas.PetSchema
+                        description: successful operation
+            """
+            return '...'
+
+        spec.add_path(path='/pet', view=pet_view)
+        p = spec._paths['/pet']
+        assert 'get' in p
+        get = p['get']
+        assert 'parameters' in get
+        assert get['parameters'] == swagger.schema2parameters(PetSchema, default_in='query')
+        post = p['post']
+        assert 'parameters' in post
+        assert post['parameters'] == swagger.schema2parameters(PetSchema, default_in='body')
+
     def test_schema_in_docstring_uses_ref_if_available(self, spec):
         spec.definition('Pet', schema=PetSchema)
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -101,10 +101,6 @@ class TestOperationHelper:
                 parameters:
                     - in: body
                       schema: tests.schemas.PetSchema
-                responses:
-                    200:
-                        schema: tests.schemas.PetSchema
-                        description: successful operation
             """
             return '...'
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -135,6 +135,36 @@ class TestOperationHelper:
         assert 'responses' in op
         assert op['responses'][200]['schema']['$ref'] == '#/definitions/Pet'
 
+    def test_schema_in_docstring_uses_ref_in_parameters_if_available(self, spec):
+        spec.definition('Pet', schema=PetSchema)
+
+        def pet_view():
+            """Not much to see here.
+
+            ---
+            get:
+                parameters:
+                    - in: query
+                      schema: tests.schemas.PetSchema
+            post:
+                parameters:
+                    - in: body
+                      schema: tests.schemas.PetSchema
+            """
+            return '...'
+
+        spec.add_path(path='/pet', view=pet_view)
+        p = spec._paths['/pet']
+        assert 'get' in p
+        get = p['get']
+        assert 'parameters' in get
+        for parameter in get['parameters']:
+            assert 'schema' not in parameter
+        post = p['post']
+        assert 'parameters' in post
+        assert len(post['parameters']) == 1
+        assert post['parameters'][0]['schema']['$ref'] == '#/definitions/Pet'
+
     def test_schema_array_in_docstring_uses_ref_if_available(self, spec):
         spec.definition('Pet', schema=PetSchema)
 


### PR DESCRIPTION
Implement the proposal in
https://github.com/marshmallow-code/apispec/issues/127

* generate single entry by "in: body"
* generate array of primitive types otherwise
