### PR TITLE
Add support for Flask MethodView to apispec.ext.flask

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,3 +32,4 @@ Contributors (chronological)
 - Lucas Coutinho `@lucasrc <https://github.com/lucasrc>`_
 - `@lamiskin <https://github.com/lamiskin>`_
 - Florian Scheffler `@nebularazer <https://github.com/nebularazer>`_
+- Douglas Anderson `@djanderson <https://github.com/djanderson>`_

--- a/apispec/ext/flask.py
+++ b/apispec/ext/flask.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-"""Flask plugin. Includes a path helper that allows you to pass a view
+"""Flask plugin. Includes path helpers that allow you to pass a view
 function to `add_path`. Inspects URL rules and view docstrings.
-::
+
+Passing a view function::
 
     from flask import Flask
 
@@ -23,6 +24,31 @@ function to `add_path`. Inspects URL rules and view docstrings.
     spec.add_path(view=gist_detail)
     print(spec.to_dict()['paths'])
     # {'/gists/{gist_id}': {'get': {'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}}}}
+
+Passing a method view function::
+
+    from flask import Flask
+    from flask.views import MethodView
+
+    app = Flask(__name__)
+
+    class GistApi(MethodView):
+        def get(self):
+           '''Gist view
+           ---
+           responses:
+               200:
+                   schema:
+                       $ref: '#/definitions/Gist'
+           '''
+
+    app.test_request_context().push()
+    method_view = GistApi.as_view('gists')
+    app.add_url_rule("/gists", view_func=method_view)
+    spec.add_path(method_view=method_view)
+    print(spec.to_dict()['paths'])
+    # {'/gists', {'get': {'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}}}}
+
 """
 from __future__ import absolute_import
 import re
@@ -72,6 +98,22 @@ def path_from_view(spec, view, **kwargs):
     path = Path(path=path, operations=operations)
     return path
 
+def path_from_method_view(spec, method_view, **kwargs):
+    """Path helper that allows passing a Flask MethodView view function."""
+    rule = _rule_for_view(method_view)
+    path = flaskpath2swagger(rule.rule)
+    app_root = current_app.config['APPLICATION_ROOT'] or '/'
+    path = urljoin(app_root.rstrip('/') + '/', path.lstrip('/'))
+    operations = {}
+    for method in method_view.methods:
+        method_name = method.lower()
+        view = getattr(method_view.view_class, method_name)
+        docstring_yaml = utils.load_yaml_from_docstring(view.__doc__)
+        operations[method_name] = docstring_yaml or dict()
+
+    return Path(path=path, operations=operations or None)
+
 def setup(spec):
     """Setup for the plugin."""
     spec.register_path_helper(path_from_view)
+    spec.register_path_helper(path_from_method_view)

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -152,6 +152,37 @@ Our OpenAPI spec now looks like this:
     # 'swagger': '2.0',
     # 'tags': []}
 
+If your API uses `method-based dispatching <http://flask.pocoo.org/docs/0.12/views/#method-based-dispatching>`_, the process is similar. Note that the method no longer needs to be included in the docstring, and that we add the path as a `method_view`.
+
+.. code-block:: python
+
+    from flask.views import MethodView
+
+    class GistApi(MethodView):
+        def get(self):
+            '''Gist view
+            ---
+            description: get a gist
+            responses:
+               200:
+                   schema:
+                       $ref: '#/definitions/Gist'
+            '''
+            pass
+
+        def post(self):
+            pass
+
+    app.test_request_context().push()
+    method_view = GistApi.as_view('gist')
+    app.add_url_rule("/gist", view_func=method_view)
+    spec.add_path(method_view=method_view)
+    print(spec.to_dict()['paths'])
+    # {'/gist': {'get': {'description': 'get a gist',
+    #                    'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}},
+    #            'post': {}}}
+    #
+
 Next Steps
 ----------
 

--- a/tests/test_ext_flask.py
+++ b/tests/test_ext_flask.py
@@ -2,6 +2,7 @@
 import pytest
 
 from flask import Flask
+from flask.views import MethodView
 from apispec import APISpec
 
 @pytest.fixture()
@@ -41,6 +42,31 @@ class TestPathHelpers:
         assert 'get' in spec._paths['/hello']
         expected = {'parameters': [], 'responses': {'200': '..params..'}}
         assert spec._paths['/hello']['get'] == expected
+
+    def test_path_from_method_view(self, app, spec):
+        class HelloApi(MethodView):
+            def get(self):
+                """A greeting endpoint.
+                ---
+                description: get a greeting
+                responses:
+                    200:
+                        description: said hi
+                """
+                return 'hi'
+
+            def post(self):
+                return 'hi'
+
+        method_view = HelloApi.as_view('hi')
+        app.add_url_rule("/hi", view_func=method_view, methods=('GET', 'POST'))
+        spec.add_path(method_view=method_view)
+        assert '/hi' in spec._paths
+        assert 'get' in spec._paths['/hi']
+        expected = {'description': 'get a greeting',
+                    'responses': {200: {'description': 'said hi'}}}
+        assert spec._paths['/hi']['get'] == expected
+        assert spec._paths['/hi']['post'] == {}
 
     def test_path_with_multiple_methods(self, app, spec):
 

--- a/tests/test_ext_flask.py
+++ b/tests/test_ext_flask.py
@@ -45,6 +45,10 @@ class TestPathHelpers:
 
     def test_path_from_method_view(self, app, spec):
         class HelloApi(MethodView):
+            """Greeting API.
+            ---
+            x-extension: global metadata
+            """
             def get(self):
                 """A greeting endpoint.
                 ---
@@ -61,12 +65,11 @@ class TestPathHelpers:
         method_view = HelloApi.as_view('hi')
         app.add_url_rule("/hi", view_func=method_view, methods=('GET', 'POST'))
         spec.add_path(method_view=method_view)
-        assert '/hi' in spec._paths
-        assert 'get' in spec._paths['/hi']
         expected = {'description': 'get a greeting',
                     'responses': {200: {'description': 'said hi'}}}
         assert spec._paths['/hi']['get'] == expected
         assert spec._paths['/hi']['post'] == {}
+        assert spec._paths['/hi']['x-extension'] == 'global metadata'
 
     def test_path_with_multiple_methods(self, app, spec):
 


### PR DESCRIPTION
Addresses issues #85 and #125.

There are only two slight differences when using a MethodView function:

1. the method ("get", "post", etc) is inferred and is not included in the docstring
2. the path is added with `spec.add_path(method_view=view)`

Here's the patch in action: 

```python
from flask import Flask
from flask.views import MethodView

app = Flask(__name__)

class GistApi(MethodView):
    def get(self):
       """Gist view
       ---
       responses:
           200:
               schema:
                   $ref: '#/definitions/Gist'
       """

app.test_request_context().push()
method_view = GistApi.as_view('gists')
app.add_url_rule("/gists", view_func=method_view)
spec.add_path(method_view=method_view)
print(spec.to_dict()['paths'])
# {'/gists', {'get': {'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}}}}

```

Please review!