### PR TITLE
Pass operations to downstream extension

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -182,6 +182,7 @@ class APISpec(object):
             if isinstance(ret, Path):
                 ret.path = normalize_path(ret.path)
                 path.update(ret)
+                operations = ret.operations
 
         if not path.path:
             raise APISpecError('Path template is not specified')

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -57,7 +57,7 @@ def schema_definition_helper(spec, name, schema, **kwargs):
     return swagger.schema2jsonschema(schema_instance, spec=spec, name=name)
 
 
-def schema_path_helper(spec, view, **kwargs):
+def schema_path_helper(spec, view=None, **kwargs):
     """Path helper that allows passing a Schema as a response. Responses can be
     defined in a view's docstring.
     ::
@@ -119,8 +119,8 @@ def schema_path_helper(spec, view, **kwargs):
 
     """
     operations = (
-        load_operations_from_docstring(view.__doc__) or
-        kwargs.get('operations')
+        kwargs.get('operations') or
+        (view and load_operations_from_docstring(view.__doc__))
     )
     if not operations:
         return

--- a/tests/test_ext_tornado_marshmallow.py
+++ b/tests/test_ext_tornado_marshmallow.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from apispec import APISpec
+from apispec.ext.marshmallow import swagger
+from tornado.web import RequestHandler
+from .schemas import PetSchema
+
+@pytest.fixture()
+def spec():
+    return APISpec(
+        title='Swagger Petstore',
+        version='1.0.0',
+        description='This is a sample Petstore server.  You can find out more '
+        'about Swagger at <a href=\"http://swagger.wordnik.com\">'
+        'http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.'
+        'For this sample, you can use the api key \"special-key\" to test the'
+        'authorization filters',
+        plugins=[
+            'apispec.ext.tornado',
+            'apispec.ext.marshmallow'
+        ]
+    )
+
+
+class TestPathHelpers:
+
+    def test_integration_with_docstring_introspection(self, spec):
+
+        class HelloHandler(RequestHandler):
+            def get(self):
+                """Get a greeting endpoint.
+                ---
+                description: get a greeting
+                responses:
+                    200:
+                        description: a pet to be returned
+                        schema: tests.schemas.PetSchema
+                """
+                self.write("hello")
+
+        urlspec = (r'/hello', HelloHandler)
+        spec.add_path(urlspec=urlspec)
+        get_op = spec._paths['/hello']['get']
+        assert get_op['description'] == 'get a greeting'
+        response = get_op['responses'][200]
+        assert response['description'] == 'a pet to be returned'
+        assert response['schema'] == swagger.schema2jsonschema(PetSchema)


### PR DESCRIPTION
As I commented in https://github.com/marshmallow-code/apispec/pull/134 ,
even if preceding extension construct 'operations', it won't be used in ext.marshmallow to resolve Schema class.
I've added a test to illustrate the problem (https://github.com/yoichi/apispec/commit/833724a4d029d15b7db207817b895f28279a07a2), then fix it (https://github.com/yoichi/apispec/commit/fdd97dd9b97677dca86e3db5de307fec02348e7b).

Regards,