### PR TITLE
Added use_instances parameter to Marshmallow plugin

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,3 +37,4 @@ Contributors (chronological)
 - Douglas Anderson `@djanderson <https://github.com/djanderson>`_
 - Marat Sharafutdinov `@decaz <https://github.com/decaz>`_
 - Daniel Radetsky `@dradetsky <https://github.com/dradetsky>`_
+- Evgeny Seliverstov `@theirix <https://github.com/theirix>`_

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -147,13 +147,16 @@ def resolve_parameters(spec, parameters):
     return resolved
 
 
-def resolve_schema_dict(spec, schema, dump=True):
+def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
     if isinstance(schema, dict):
         if (schema.get('type') == 'array' and 'items' in schema):
             schema['items'] = resolve_schema_dict(spec, schema['items'])
         return schema
     plug = spec.plugins[NAME] if spec else {}
-    schema_cls = resolve_schema_cls(schema)
+    if isinstance(schema, marshmallow.Schema) and use_instances:
+        schema_cls = schema
+    else:
+        schema_cls = resolve_schema_cls(schema)
     if schema_cls in plug.get('refs', {}):
         ref_schema = {'$ref': '#/definitions/{0}'.format(plug['refs'][schema_cls])}
         if getattr(schema, 'many', False):

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -360,7 +360,8 @@ def schema2parameters(schema, **kwargs):
 
 
 def fields2parameters(fields, schema=None, spec=None, use_refs=True,
-                      default_in='body', name='body', required=False):
+                      default_in='body', name='body', required=False,
+                      use_instances=False):
     """Return an array of OpenAPI parameters given a mapping between field names and
     :class:`Field <marshmallow.Field>` objects. If `default_in` is "body", then return an array
     of a single parameter; else return an array of a parameter for each included field in
@@ -372,7 +373,7 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True,
         if schema is not None:
             # Prevent circular import
             from apispec.ext.marshmallow import resolve_schema_dict
-            prop = resolve_schema_dict(spec, schema, dump=False)
+            prop = resolve_schema_dict(spec, schema, dump=False, use_instances=use_instances)
         else:
             prop = fields2jsonschema(fields, spec=spec, use_refs=use_refs, dump=False)
 


### PR DESCRIPTION
It allows to support partial Marshmallow schemas because partial fields can be specified only for Marshmallow instance.

It is not user-facing change but useful for writing plugins.