### PR TITLE
Plugin to support Flask-RESTful

### DIFF
--- a/apispec/ext/flask_restful.py
+++ b/apispec/ext/flask_restful.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Flask-RESTful plugin. Includes a path helper that allows you to pass a resource
+object to `add_path`.
+::
+
+    from pprint import pprint
+
+    from flask_restful import Api, Resource
+    from flask import Flask
+
+    class HelloResource(Resource):
+        def get(self, hello_id):
+            '''A greeting endpoint.
+                   ---
+                   description: get a greeting
+                   responses:
+                       200:
+                           description: a pet to be returned
+                           schema:
+                               $ref: #/definitions/Pet
+            '''
+            pass
+
+    app = Flask(__name__)
+    api = Api(app)
+    api.add_resource(HelloResource, '/hello')
+
+    spec.add_path(resource=HelloResource, api=api)
+    pprint(spec.to_dict()['paths'])
+
+    # {'/hello': {'get': {'description': 'Get a greeting',
+    #                     'responses': {200: {'description': 'a pet to be returned',
+    #                                         'schema': {'$ref': '#/definitions/Pet'}}}}}}
+
+    Method `add_path` can be invoked with a resource path in a `path` parameter instead of `api` parameter:
+
+        spec.add_path(resource=HelloResource, path='/hello')
+
+    Flask blueprints are supported too by passing Flask app in `app` parameter:
+
+        spec.add_path(resource=HelloResource, api=api, app=app)
+"""
+
+import logging
+import re
+
+from apispec import Path, utils
+from apispec.exceptions import APISpecError
+
+
+def deduce_path(resource, **kwargs):
+    """Find resource path using provided API or path itself"""
+    api = kwargs.get('api', None)
+    if not api:
+        # flask-restful resource url passed
+        return kwargs.get('path').path
+
+    # flask-restful API passed
+    # Require MethodView
+    if not getattr(resource, 'endpoint', None):
+        raise APISpecError('Flask-RESTful resource needed')
+
+    if api.blueprint:
+        # it is required to have Flask app to be able enumerate routes
+        app = kwargs.get('app')
+        if app:
+            for rule in app.url_map.iter_rules():
+                if rule.endpoint.endswith('.' + resource.endpoint):
+                    break
+            else:
+                raise APISpecError('Cannot find blueprint resource {}'.format(resource.endpoint))
+        else:
+            # Application not initialized yet, fallback to path
+            return kwargs.get('path').path
+
+    else:
+        for rule in api.app.url_map.iter_rules():
+            if rule.endpoint == resource.endpoint:
+                rule.endpoint.endswith('.' + resource.endpoint)
+                break
+        else:
+            raise APISpecError('Cannot find resource {}'.format(resource.endpoint))
+
+    return rule.rule
+
+
+def parse_operations(resource):
+    """Parse operations for each method in a flask-restful resource"""
+    operations = {}
+    for method in resource.methods:
+        docstring = getattr(resource, method.lower()).__doc__
+        if docstring:
+            operation = utils.load_yaml_from_docstring(docstring)
+            if not operation:
+                logging.getLogger(__name__).warning(
+                    'Cannot load docstring for {}/{}'.format(resource, method))
+            operations[method.lower()] = operation or dict()
+    return operations
+
+
+def path_helper(_spec, **kwargs):
+    """Extracts swagger spec from `flask-restful` methods."""
+    try:
+        resource = kwargs.pop('resource')
+
+        path = deduce_path(resource, **kwargs)
+
+        # normalize path
+        path = re.sub(r'<(?:[^:<>]+:)?([^<>]+)>', r'{\1}', path)
+
+        operations = parse_operations(resource)
+
+        return Path(path=path, operations=operations)
+    except Exception as e:
+        logging.getLogger(__name__).exception("Exception parsing APISpec %s", e)
+        raise
+
+
+def setup(spec):
+    spec.register_path_helper(path_helper)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ flake8==3.0.4
 
 # soft dependencies
 Flask
+Flask-RESTful
 marshmallow
 tornado
 bottle

--- a/tests/test_ext_flask_restful.py
+++ b/tests/test_ext_flask_restful.py
@@ -1,0 +1,192 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from apispec import APISpec
+from flask import Flask, Blueprint
+from flask_restful import Api, Resource
+
+
+@pytest.fixture()
+def spec():
+    return APISpec(
+        title='Swagger Petstore',
+        version='1.0.0',
+        description='This is a sample Petstore server.  You can find out more '
+                    'about Swagger at <a href=\"http://swagger.wordnik.com\">'
+                    'http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.'
+                    'For this sample, you can use the api key \"special-key\" to test the'
+                    'authorization filters',
+        plugins=[
+            'apispec.ext.flask_restful'
+        ]
+    )
+
+@pytest.yield_fixture()
+def app():
+    _app = Flask(__name__)
+    ctx = _app.test_request_context()
+    ctx.push()
+    yield _app
+    ctx.pop()
+
+
+@pytest.yield_fixture()
+def api():
+    _app = Flask(__name__)
+    _api = Api(_app)
+    ctx = _app.test_request_context()
+    ctx.push()
+    yield _api
+    ctx.pop()
+
+
+class TestPathHelpers:
+    def test_path_from_view(self, api, spec):
+        class HelloResource(Resource):
+            def get(self, hello_id):
+                return 'hi'
+
+        api.add_resource(HelloResource, '/hello')
+
+        spec.add_path(resource=HelloResource, api=api,
+                      operations={'get': {'parameters': [], 'responses': {'200': '..params..'}}})
+        assert '/hello' in spec._paths
+        assert 'get' in spec._paths['/hello']
+        expected = {'parameters': [], 'responses': {'200': '..params..'}}
+        assert spec._paths['/hello']['get'] == expected
+
+    def test_path_from_view_added_via_path(self, api, spec):
+        class HelloResource(Resource):
+            def get(self, hello_id):
+                return 'hi'
+
+        api.add_resource(HelloResource, '/hello')
+
+        spec.add_path(resource=HelloResource, path='/hello',
+                      operations={'get': {'parameters': [], 'responses': {'200': '..params..'}}})
+        assert '/hello' in spec._paths
+        assert 'get' in spec._paths['/hello']
+        expected = {'parameters': [], 'responses': {'200': '..params..'}}
+        assert spec._paths['/hello']['get'] == expected
+
+    def test_path_with_multiple_methods(self, api, spec):
+        class HelloResource(Resource):
+            def get(self, hello_id):
+                return 'hi'
+
+            def post(self, hello_id):
+                pass
+
+        api.add_resource(HelloResource, '/hello')
+
+        spec.add_path(resource=HelloResource, api=api, operations=dict(
+            get={'description': 'get a greeting', 'responses': {'200': '..params..'}},
+            post={'description': 'post a greeting', 'responses': {'200': '..params..'}}
+        ))
+        get_op = spec._paths['/hello']['get']
+        post_op = spec._paths['/hello']['post']
+        assert get_op['description'] == 'get a greeting'
+        assert post_op['description'] == 'post a greeting'
+
+    def test_integration_with_docstring_introspection(self, api, spec):
+        class HelloResource(Resource):
+            def get(self, hello_id):
+                """A greeting endpoint.
+                       ---
+                       x-extension: value
+                       description: get a greeting
+                       responses:
+                           200:
+                               description: a pet to be returned
+                               schema:
+                                   $ref: #/definitions/Pet
+                 """
+
+            pass
+
+            def post(self, hello_id):
+                """A greeting endpoint.
+                   ---
+                   x-extension: value
+                   description: post a greeting
+                   responses:
+                       200:
+                           description:some data
+                   """
+            pass
+
+        api.add_resource(HelloResource, '/hello')
+
+        spec.add_path(resource=HelloResource, api=api)
+        get_op = spec._paths['/hello']['get']
+        post_op = spec._paths['/hello']['post']
+        extension = spec._paths['/hello']['get']['x-extension']
+        assert get_op['description'] == 'get a greeting'
+        assert post_op['description'] == 'post a greeting'
+        assert extension == 'value'
+
+    def test_integration_invalid_docstring(self, api, spec):
+        class HelloResource(Resource):
+            def get(self, hello_id):
+                """A greeting endpoint.
+                       ---
+                    description: it is an invalid string in YAML
+                       responses:
+                           200:
+                               description: a pet to be returned
+                               schema:
+                                   $ref: #/definitions/Pet
+                 """
+
+            pass
+
+        api.add_resource(HelloResource, '/hello')
+
+        spec.add_path(resource=HelloResource, api=api)
+        get_op = spec._paths['/hello']['get']
+        assert not get_op
+
+    def test_path_is_translated_to_swagger_template(self, api, spec):
+        class HelloResource(Resource):
+            def get(self, hello_id):
+                pass
+
+        api.add_resource(HelloResource, '/pet/<pet_id>')
+
+        spec.add_path(resource=HelloResource, api=api)
+        assert '/pet/{pet_id}' in spec._paths
+
+    def test_path_blueprint(self, app, spec):
+        class HelloResource(Resource):
+            def get(self, hello_id):
+                return 'hi'
+
+        bp = Blueprint(app, __name__)
+        api = Api(bp)
+        app.register_blueprint(bp, url_prefix='/v1')
+        api.add_resource(HelloResource, '/hello')
+
+        spec.add_path(resource=HelloResource, api=api, app=app,
+                      operations={'get': {'parameters': [], 'responses': {'200': '..params..'}}})
+        assert '/v1/hello' in spec._paths
+        assert 'get' in spec._paths['/v1/hello']
+        expected = {'parameters': [], 'responses': {'200': '..params..'}}
+        assert spec._paths['/v1/hello']['get'] == expected
+
+    def test_path_blueprint_no_app_fallback(self, app, spec):
+        class HelloResource(Resource):
+            def get(self, hello_id):
+                return 'hi'
+
+        bp = Blueprint(app, __name__)
+        api = Api(bp)
+        app.register_blueprint(bp, url_prefix='/v1')
+        api.add_resource(HelloResource, '/hello')
+
+        spec.add_path(resource=HelloResource, api=api, app=None,
+                      path='/v1/hello',
+                      operations={'get': {'parameters': [], 'responses': {'200': '..params..'}}})
+        assert '/v1/hello' in spec._paths
+        assert 'get' in spec._paths['/v1/hello']
+        expected = {'parameters': [], 'responses': {'200': '..params..'}}
+        assert spec._paths['/v1/hello']['get'] == expected


### PR DESCRIPTION
This PR provides a plugin to support Flask-RESTful documentation.
I am aware of existing plugin apispec_restful which unfortunately doesn't work with Blueprints and possibly with classic Flask apps. This plugin overcomes these limitations.

Plugin is tested by unittests and by usage in a real application.
I added a documentation with typical use-cases and several docstrings.

Commit message:
```
Added path-helper which accepts Flask-RESTful resources.
Resources can be linked to Path via Api instance or endpoint.
Plugin works with Flask Blueprints and Flask classic apps.
```