### PR TITLE
Don't catch/pass YAMLError when parsing docstring fails.

### DIFF
--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -60,10 +60,7 @@ def load_yaml_from_docstring(docstring):
 
     yaml_string = "\n".join(split_lines[cut_from:])
     yaml_string = dedent(yaml_string)
-    try:
-        return yaml.load(yaml_string)
-    except yaml.YAMLError:
-        return None
+    return yaml.load(yaml_string)
 
 PATH_KEYS = set([
     'get',


### PR DESCRIPTION
The current behavior is to swallow any parse errors silently, which makes
trying to add more than a trivial apispec docstring confusing and frustrating.

See issue #135 for more discussion.