### PR TITLE
Pass use_instances parameter for Marshmallow many=True

### DIFF
--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -150,7 +150,7 @@ def resolve_parameters(spec, parameters):
 def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
     if isinstance(schema, dict):
         if (schema.get('type') == 'array' and 'items' in schema):
-            schema['items'] = resolve_schema_dict(spec, schema['items'])
+            schema['items'] = resolve_schema_dict(spec, schema['items'], use_instances=use_instances)
         return schema
     plug = spec.plugins[NAME] if spec else {}
     if isinstance(schema, marshmallow.Schema) and use_instances:


### PR DESCRIPTION
A small fix for a PR #144 for Marshmallow schemas with many=True.