### PR TITLE
Recover context in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,13 +68,11 @@ Example Application
         pet = get_random_pet()
         return jsonify(PetSchema().dump(pet).data)
 
-    ctx = app.test_request_context()
-    ctx.push()
-
     # Register entities and paths
     spec.definition('Category', schema=CategorySchema)
     spec.definition('Pet', schema=PetSchema)
-    spec.add_path(view=random_pet)
+    with app.test_request_context():
+        spec.add_path(view=random_pet)
 
 
 Generated OpenAPI Spec

--- a/apispec/ext/bottle.py
+++ b/apispec/ext/bottle.py
@@ -17,7 +17,6 @@ to `add_path`.
         '''
         return 'detail for gist {}'.format(gist_id)
 
-    app.test_request_context().push()
     spec.add_path(view=gist_detail)
     print(spec.to_dict()['paths'])
     # {'/gists/{gist_id}': {'get': {'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}}}}

--- a/apispec/ext/flask.py
+++ b/apispec/ext/flask.py
@@ -21,8 +21,8 @@ Passing a view function::
         '''
         return 'detail for gist {}'.format(gist_id)
 
-    app.test_request_context().push()
-    spec.add_path(view=gist_detail)
+    with app.test_request_context():
+        spec.add_path(view=gist_detail)
     print(spec.to_dict()['paths'])
     # {'/gists/{gist_id}': {'get': {'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}},
     #                  'x-extension': 'metadata'}}
@@ -52,10 +52,10 @@ Passing a method view function::
         def post(self):
            pass
 
-    app.test_request_context().push()
     method_view = GistApi.as_view('gists')
     app.add_url_rule("/gists", view_func=method_view)
-    spec.add_path(view=method_view)
+    with app.test_request_context():
+        spec.add_path(view=method_view)
     print(spec.to_dict()['paths'])
     # {'/gists': {'get': {'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}},
     #             'post': {},

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,13 +59,11 @@ Example Application
         pet = get_random_pet()
         return jsonify(PetSchema().dump(pet).data)
 
-    ctx = app.test_request_context()
-    ctx.push()
-
     # Register entities and paths
     spec.definition('Category', schema=CategorySchema)
     spec.definition('Pet', schema=PetSchema)
-    spec.add_path(view=random_pet)
+    with app.test_request_context():
+        spec.add_path(view=random_pet)
 
 
 Generated OpenAPI Spec

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -135,10 +135,8 @@ The Flask plugin allows us to pass this view to `spec.add_path <apispec.APISpec.
 
     # Since add_path inspects the view and its route,
     # we need to be in a Flask request context
-    ctx = app.test_request_context()
-    ctx.push()
-
-    spec.add_path(view=gist_detail)
+    with app.test_request_context():
+        spec.add_path(view=gist_detail)
 
 
 Our OpenAPI spec now looks like this:
@@ -184,10 +182,10 @@ If your API uses `method-based dispatching <http://flask.pocoo.org/docs/0.12/vie
         def post(self):
             pass
 
-    app.test_request_context().push()
     method_view = GistApi.as_view('gist')
     app.add_url_rule("/gist", view_func=method_view)
-    spec.add_path(view=method_view)
+    with app.test_request_context():
+        spec.add_path(view=method_view)
     print(spec.to_dict()['paths'])
     # {'/gist': {'get': {'description': 'get a gist',
     #                    'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}},


### PR DESCRIPTION
In flask example code, test_request_context is pushed but not poped. It may affect the subsequent operation.
I think it is better to use "with" statement which recover the context automatically.
http://flask.pocoo.org/docs/0.12/reqcontext/

Thanks,