### PR TITLE
Skip non-dict elements on resolve to avoid AttributeError

### DIFF
--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -126,6 +126,8 @@ def schema_path_helper(spec, view=None, **kwargs):
         return
     operations = operations.copy()
     for operation in operations.values():
+        if not isinstance(operation, dict):
+            continue
         if 'parameters' in operation:
             operation['parameters'] = resolve_parameters(spec, operation['parameters'])
         for response in operation.get('responses', {}).values():

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -234,7 +234,7 @@ class TestOperationHelper:
             'items': {'$ref': '#/definitions/Pet'}
         }
 
-    def test_non_http_method_in_docstring(self, spec):
+    def test_other_than_http_method_in_docstring(self, spec):
         def pet_view():
             """Not much to see here.
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -234,6 +234,32 @@ class TestOperationHelper:
             'items': {'$ref': '#/definitions/Pet'}
         }
 
+    def test_non_http_method_in_docstring(self, spec):
+        def pet_view():
+            """Not much to see here.
+
+            ---
+            x-extension: value
+            get:
+                responses:
+                    200:
+                        schema:
+                            type: array
+                            items: tests.schemas.PetSchema
+            foo:
+                description: not a valid operation
+                responses:
+                    200:
+                        description: more junk
+            """
+            return '...'
+
+        spec.add_path(path='/pet', view=pet_view)
+        p = spec._paths['/pet']
+        assert 'get' in p
+        assert 'x-extension' in p
+        assert 'foo' not in p
+
     def test_schema_global_state_untouched_2json(self):
         assert RunSchema._declared_fields['sample']._Nested__schema is None
         data = swagger.schema2jsonschema(RunSchema)


### PR DESCRIPTION
Fix against "x-extension: value" cause following error:

```
>           for response in operation.get('responses', {}).values():
E           AttributeError: 'str' object has no attribute 'get'

apispec/ext/marshmallow/__init__.py:131: AttributeError
```