### PR TITLE
Fix swagger location mapping for default_in param in fields2parameters

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -369,7 +369,8 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True,
 
     https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
     """
-    if default_in == 'body':
+    swagger_default_in = __location_map__.get(default_in, default_in)
+    if swagger_default_in == 'body':
         if schema is not None:
             # Prevent circular import
             from apispec.ext.marshmallow import resolve_schema_dict
@@ -378,7 +379,7 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True,
             prop = fields2jsonschema(fields, spec=spec, use_refs=use_refs, dump=False)
 
         return [{
-            'in': default_in,
+            'in': swagger_default_in,
             'required': required,
             'name': name,
             'schema': prop,

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -129,6 +129,15 @@ class TestMarshmallowFieldToSwagger:
         res = swagger.fields2parameters(field_dict, default_in='headers')
         assert res[0]['in'] == 'header'
 
+    def test_fields_default_location_mapping_if_schema_many(self):
+
+        class ExampleSchema(Schema):
+            id = fields.Int()
+
+        schema = ExampleSchema(many=True)
+        res = swagger.fields2parameters(schema.fields, schema=schema, default_in='json')
+        assert res[0]['in'] == 'body'
+
     def test_fields_with_dump_only(self):
         class UserSchema(Schema):
             name = fields.Str(dump_only=True)


### PR DESCRIPTION
We should specify 'json' location when using `schema.many=True`: https://github.com/sloria/webargs/blob/d6dada2323ffda6ffcdf171a474522f835737656/webargs/core.py#L261.
So apispec's swagger extension should correctly handle such case.