### PR TITLE
Enum from equal validator

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,3 +38,4 @@ Contributors (chronological)
 - Marat Sharafutdinov `@decaz <https://github.com/decaz>`_
 - Daniel Radetsky `@dradetsky <https://github.com/dradetsky>`_
 - Evgeny Seliverstov `@theirix <https://github.com/theirix>`_
+- Michael Bangert `@Bangertm <https://github.com/Bangertm>`_

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -112,15 +112,20 @@ def field2choices(field):
     :param Field field: A marshmallow field.
     :rtype: set
     """
-    validators = [
+    comparable = {
+        validator.comparable for validator in field.validators
+        if hasattr(validator, 'comparable')
+    }
+    if comparable:
+        return comparable
+
+    choices = [
         OrderedSet(validator.choices) for validator in field.validators
         if hasattr(validator, 'choices')
     ]
-    return (
-        functools.reduce(operator.and_, validators)
-        if validators
-        else None
-    )
+    if choices:
+        return functools.reduce(operator.and_, choices)
+
 
 def field2range(field):
     """Return the dictionary of swagger field attributes for a set of

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -154,6 +154,11 @@ class TestMarshmallowFieldToSwagger:
         res = swagger.field2property(field)
         assert set(res['enum']) == {'freddie', 'brian', 'john'}
 
+    def test_field_with_equal(self):
+        field = fields.Str(validate=validate.Equal('only choice'))
+        res = swagger.field2property(field)
+        assert res['enum'] == ['only choice']
+
     def test_only_allows_valid_properties_in_metadata(self):
         field = fields.Str(
             default='foo',


### PR DESCRIPTION
Swagger generated from fields with a Marshmallow fields.Equal validator now contain an enum with a single entry.