### PR TITLE
Add "options" method to allowed methods

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -13,6 +13,7 @@ VALID_METHODS = [
     'patch',
     'delete',
     'head',
+    'options',
 ]
 
 OPENAPI_VERSION = SWAGGER_VERSION = '2.0'


### PR DESCRIPTION
Hello,

Why "OPTIONS" method is not listed in allowed methods ? I use apispec for application who need to describe it's OPTIONS roads.

Is it possible to add it officially ?

Regards,
Bux.