### PR TITLE
Permit auto generation of definition schema names

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -91,11 +91,11 @@ class APISpec(object):
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#infoObject
     :param \*\*dict options: Optional top-level keys
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object
-    :param callable schema_name_resolver_callable: callable who generate the
+    :param callable schema_name_resolver: callable who generate the
         schema definition name. The schema will be given to this callable and
         definition name must be returned by callable, ex:
 
-            def schema_name_resolver_callable(schema):
+            def schema_name_resolver(schema):
                 return schema.__name__
     """
 
@@ -105,7 +105,7 @@ class APISpec(object):
         version,
         plugins=(),
         info=None,
-        schema_name_resolver_callable=None,
+        schema_name_resolver=None,
         **options
     ):
         self.info = {
@@ -114,7 +114,7 @@ class APISpec(object):
         }
         self.info.update(info or {})
         self.options = options
-        self.schema_name_resolver_callable = schema_name_resolver_callable
+        self.schema_name_resolver = schema_name_resolver
         # Metadata
         self._definitions = {}
         self._parameters = {}

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -91,7 +91,12 @@ class APISpec(object):
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#infoObject
     :param \*\*dict options: Optional top-level keys
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object
-    :param callable schema_name_resolver_callable: callable who generate the schema definition name
+    :param callable schema_name_resolver_callable: callable who generate the
+        schema definition name. The schema will be given to this callable and
+        definition name must be returned by callable, ex:
+
+            def schema_name_resolver_callable(schema):
+                return schema.__name__
     """
 
     def __init__(

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -91,15 +91,25 @@ class APISpec(object):
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#infoObject
     :param \*\*dict options: Optional top-level keys
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object
+    :param callable schema_name_resolver_callable: callable who generate the schema definition name
     """
 
-    def __init__(self, title, version, plugins=(), info=None, **options):
+    def __init__(
+        self,
+        title,
+        version,
+        plugins=(),
+        info=None,
+        schema_name_resolver_callable=None,
+        **options
+    ):
         self.info = {
             'title': title,
             'version': version,
         }
         self.info.update(info or {})
         self.options = options
+        self.schema_name_resolver_callable = schema_name_resolver_callable
         # Metadata
         self._definitions = {}
         self._parameters = {}

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -167,7 +167,8 @@ def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
     if schema_cls not in plug.get('refs', {}):
         if spec and spec.schema_name_resolver:
             definition_name = spec.schema_name_resolver(schema_cls)
-            spec.definition(definition_name, schema=schema)
+            if definition_name:
+                spec.definition(definition_name, schema=schema)
 
     if schema_cls in plug.get('refs', {}):
         ref_schema = {'$ref': '#/definitions/{0}'.format(plug['refs'][schema_cls])}

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -162,6 +162,17 @@ def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
         schema_cls = schema
     else:
         schema_cls = resolve_schema_cls(schema)
+
+    # Auto reference schema if available
+    if schema_cls not in plug.get('refs', {}):
+        if spec.schema_name_resolver_callable:
+            definition_name = spec.schema_name_resolver_callable(
+                schema_cls)
+            spec.definition(
+                definition_name,
+                schema=schema
+            )
+
     if schema_cls in plug.get('refs', {}):
         ref_schema = {'$ref': '#/definitions/{0}'.format(plug['refs'][schema_cls])}
         if getattr(schema, 'many', False):

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -166,12 +166,8 @@ def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
     # Auto reference schema if available
     if schema_cls not in plug.get('refs', {}):
         if spec and spec.schema_name_resolver_callable:
-            definition_name = spec.schema_name_resolver_callable(
-                schema_cls)
-            spec.definition(
-                definition_name,
-                schema=schema
-            )
+            definition_name = spec.schema_name_resolver_callable(schema_cls)
+            spec.definition(definition_name, schema=schema)
 
     if schema_cls in plug.get('refs', {}):
         ref_schema = {'$ref': '#/definitions/{0}'.format(plug['refs'][schema_cls])}

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -165,7 +165,7 @@ def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
 
     # Auto reference schema if available
     if schema_cls not in plug.get('refs', {}):
-        if spec.schema_name_resolver_callable:
+        if spec and spec.schema_name_resolver_callable:
             definition_name = spec.schema_name_resolver_callable(
                 schema_cls)
             spec.definition(

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -165,8 +165,8 @@ def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
 
     # Auto reference schema if available
     if schema_cls not in plug.get('refs', {}):
-        if spec and spec.schema_name_resolver_callable:
-            definition_name = spec.schema_name_resolver_callable(schema_cls)
+        if spec and spec.schema_name_resolver:
+            definition_name = spec.schema_name_resolver(schema_cls)
             spec.definition(definition_name, schema=schema)
 
     if schema_cls in plug.get('refs', {}):

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -69,18 +69,24 @@ def inspect_schema_for_auto_referencing(spec, original_schema_instance):
         plug['refs'] = {}
 
     for field_name, field in original_schema_instance.fields.items():
+        nested_schema_class = None
+
         if isinstance(field, marshmallow.fields.Nested):
             nested_schema_class = get_schema_class(field.schema)
 
-            if nested_schema_class not in plug['refs']:
-                definition_name = spec.schema_name_resolver(
-                    nested_schema_class,
+        elif isinstance(field, marshmallow.fields.List) \
+                and isinstance(field.container, marshmallow.fields.Nested):
+            nested_schema_class = get_schema_class(field.container.schema)
+
+        if nested_schema_class and nested_schema_class not in plug['refs']:
+            definition_name = spec.schema_name_resolver(
+                nested_schema_class,
+            )
+            if definition_name:
+                spec.definition(
+                    definition_name,
+                    schema=nested_schema_class,
                 )
-                if definition_name:
-                    spec.definition(
-                        definition_name,
-                        schema=nested_schema_class,
-                    )
 
 
 def schema_definition_helper(spec, name, schema, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def read(fname):
 
 setup(
     name='apispec',
-    version=__version__,
+    version='0.25.4-algoo',
     description='A pluggable API specification generator. Currently supports the '
                 'OpenAPI specification (f.k.a. Swagger 2.0).',
     long_description=read('README.rst'),

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def read(fname):
 
 setup(
     name='apispec',
-    version='0.25.4-algoo',
+    version=__version__,
     description='A pluggable API specification generator. Currently supports the '
                 'OpenAPI specification (f.k.a. Swagger 2.0).',
     long_description=read('README.rst'),

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -20,6 +20,10 @@ class AnalysisSchema(Schema):
     sample = fields.Nested(SampleSchema)
 
 
+class AnalysisWithListSchema(Schema):
+    samples = fields.List(fields.Nested(SampleSchema))
+
+
 class PatternedObjectSchema(Schema):
     count = fields.Int(dump_only=True, **{'x-count': 1})
     count2 = fields.Int(dump_only=True, x_count2=2)

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -45,7 +45,7 @@ class TestDefinitionHelper:
             plugins=(
                 'apispec.ext.marshmallow',
             ),
-            schema_name_resolver_callable=resolver,
+            schema_name_resolver=resolver,
         )
         assert {} == spec._definitions
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -37,7 +37,8 @@ class TestDefinitionHelper:
 
     @pytest.mark.parametrize('schema', [AnalysisSchema, AnalysisSchema()])
     def test_resolve_schema_dict_auto_reference(self, schema):
-        resolver = lambda s: s.__name__
+        def resolver(schema):
+            return schema.__name__
         spec = APISpec(
             title='Test auto-reference',
             version='2.0',
@@ -76,7 +77,10 @@ class TestDefinitionHelper:
 
     @pytest.mark.parametrize('schema', [AnalysisSchema, AnalysisSchema()])
     def test_resolve_schema_dict_auto_reference_return_none(self, schema):
-        resolver = lambda s: None  # this resolver return None
+        # this resolver return None
+        def resolver(schema):
+            return None
+
         spec = APISpec(
             title='Test auto-reference',
             version='2.0',

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -63,17 +63,11 @@ class TestDefinitionHelper:
             }
         })
 
-        # Other shemas not yet referenced
-        assert 1 == len(spec._definitions)
+        assert 3 == len(spec._definitions)
 
-        spec_dict = spec.to_dict()
-        assert spec_dict.get('definitions')
-        assert 'analysis' in spec_dict['definitions']
-        # Inspect/Read objects will trigger auto reference
-        json.dumps(spec_dict)
-        # Other shema is now referenced
-        assert 2 == len(spec._definitions)
-        assert 'SampleSchema' in spec_dict['definitions']
+        assert 'analysis' in spec._definitions
+        assert 'SampleSchema' in spec._definitions
+        assert 'RunSchema' in spec._definitions
 
     @pytest.mark.parametrize('schema', [AnalysisSchema, AnalysisSchema()])
     def test_resolve_schema_dict_auto_reference_return_none(self, schema):


### PR DESCRIPTION
The case we faced is the following one:

- we have a self referencing schema, lets call it NodeSchema.
- this schema is included in another schema - NodeList

When we try to define NodeList in APIspec, the NodeSchema is not yet reference, so its structure is inlined. As it is self referencing, the inline results in an infinite recursion, so it crashes

The global solution is to add definitions of our Schema in the right order. As we use APIspec in [hapic]( https://github.com/algoo/hapic/) (a generic auto-documented REST API framework), we can't assume that schema will be defined in the right order for APIspec.

There are two ways to get schemas defined in the right order:
1. first solution is to preprocess all the schema we have to document in order to add thems to apispec in the right order. It's not very elegant (but it works)
2. second solution is to define the rule to define name of a schema in the auto-generated documentation. This is quite easy to integrate in APIspec - this is the current PR.

How it works:
- if you do nothing special, APIspec keep on working as it already do.
- if you define a callable `schema_name_resolver_callable` at construction time of `APISpec`, then it will be used for auto-referencing required schemas.

We'd be happy this PR to be accepted fast, let us know if you are ok and/or if we should change some stuff for the PR to be accepted (naming, etc).

Damien
