### PR TITLE
fix for tornado if methods (get, post etc) have *args and **kwargs passing to it.

### DIFF
--- a/apispec/ext/tornado.py
+++ b/apispec/ext/tornado.py
@@ -87,6 +87,11 @@ def tornadopath2swagger(urlspec, method):
         if getattr(method, '__tornado_coroutine__', False):
             method = method.__wrapped__
         args = inspect.getargspec(method).args[1:]
+    valid_args = []
+        for arg in args:
+            if arg != 'args' and arg != 'kwargs':
+                valid_args.append(arg)
+        args = set(valid_args)
     params = tuple('{{{}}}'.format(arg) for arg in args)
     try:
         path_tpl = urlspec.matcher._path


### PR DESCRIPTION
If your tornado RequestHandler has `def post(self, *args, **kwargs):` and `urlspecs = [
    url(r"/api/v1/auth", login_handler, name='authorization')
]` method tornadopath2swagger fails on `path = (path_tpl % params)` and path_from_urlspec return None, so APISpec class raise expention on method add_path `ret = func(
                        self, path=path, operations=operations, **kwargs
                    )`. 
ret will be none and you can't do spec.add_path(urlspec=urlspec) 