### PR TITLE
Filter view methods with rule methods

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,3 +40,4 @@ Contributors (chronological)
 - Evgeny Seliverstov `@theirix <https://github.com/theirix>`_
 - Michael Bangert `@Bangertm <https://github.com/Bangertm>`_
 - Bastien Sevajol `@buxx <https://github.com/buxx>`_
+- Durmus Karatay `@ukaratay <https://github.com/ukaratay>`_

--- a/apispec/ext/flask.py
+++ b/apispec/ext/flask.py
@@ -113,10 +113,11 @@ def path_from_view(spec, view, **kwargs):
     if hasattr(view, 'view_class') and issubclass(view.view_class, MethodView):
         operations = {}
         for method in view.methods:
-            method_name = method.lower()
-            method = getattr(view.view_class, method_name)
-            docstring_yaml = utils.load_yaml_from_docstring(method.__doc__)
-            operations[method_name] = docstring_yaml or dict()
+            if method in rule.methods:
+                method_name = method.lower()
+                method = getattr(view.view_class, method_name)
+                docstring_yaml = utils.load_yaml_from_docstring(method.__doc__)
+                operations[method_name] = docstring_yaml or dict()
         path.operations.update(operations)
     return path
 

--- a/tests/test_ext_flask.py
+++ b/tests/test_ext_flask.py
@@ -86,6 +86,35 @@ class TestPathHelpers:
         assert get_op['description'] == 'get a greeting'
         assert post_op['description'] == 'post a greeting'
 
+    def test_methods_from_rule(self, app, spec):
+        class HelloApi(MethodView):
+            """Greeting API.
+            ---
+            x-extension: global metadata
+            """
+            def get(self):
+                """A greeting endpoint.
+                ---
+                description: get a greeting
+                responses:
+                    200:
+                        description: said hi
+                """
+                return 'hi'
+
+            def post(self):
+                return 'hi'
+
+            def delete(self):
+                return 'hi'
+
+        method_view = HelloApi.as_view('hi')
+        app.add_url_rule("/hi", view_func=method_view, methods=('GET', 'POST'))
+        spec.add_path(view=method_view)
+        assert 'get' in spec._paths['/hi']
+        assert 'post' in spec._paths['/hi']
+        assert 'delete' not in spec._paths['/hi']
+
     def test_integration_with_docstring_introspection(self, app, spec):
 
         @app.route('/hello')


### PR DESCRIPTION
This commit makes sure that same documentation is not generated twice when a view used in different rules with different methods.