### PR TITLE
adds optional config param for OpenAPI version 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 - pypy
 install:
 - pip install -U .
-- npm install -g swagger-tools
+- npm install -g check_api
 - pip install -r dev-requirements.txt
 script: invoke test
 jobs:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -32,7 +32,7 @@ Setting Up for Local Development
 
     # After activating your virtualenv
     $ pip install -r dev-requirements.txt
-    $ npm install -g swagger-tools
+    $ npm install -g check_api
 
 3. Install apispec in develop mode. ::
 

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -222,7 +222,7 @@ def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
         schema_cls = resolve_schema_cls(schema)
 
     if schema_cls in plug.get('refs', {}):
-        ref_path = swagger.get_ref_path(spec.openapi_version)
+        ref_path = swagger.get_ref_path(spec.openapi_version.version[0])
         ref_schema = {'$ref': '#/{0}/{1}'.format(ref_path,
                                                  plug['refs'][schema_cls])}
         if getattr(schema, 'many', False):

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -222,7 +222,9 @@ def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
         schema_cls = resolve_schema_cls(schema)
 
     if schema_cls in plug.get('refs', {}):
-        ref_schema = {'$ref': '#/definitions/{0}'.format(plug['refs'][schema_cls])}
+        ref_path = swagger.get_ref_path(spec.openapi_version)
+        ref_schema = {'$ref': '#/{0}/{1}'.format(ref_path,
+                                                 plug['refs'][schema_cls])}
         if getattr(schema, 'many', False):
             return {
                 'type': 'array',

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -308,7 +308,9 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
                     raise ValueError('Must pass `name` argument for self-referencing Nested fields.')
                 # We need to use the `name` argument when the field is self-referencing and
                 # unbound (doesn't have `parent` set) because we can't access field.schema
-                ref_name =  '#/definitions/{name}'.format(name=name)
+                ref_path = get_ref_path(spec.openapi_version)
+                ref_name =  '#/{ref_path}/{name}'.format(ref_path=ref_path,
+                                                         name=name)
             ref_schema = {'$ref': ref_name}
             if field.many:
                 ret['type'] = 'array'
@@ -577,6 +579,16 @@ def fields2jsonschema(fields, schema=None, spec=None, use_refs=True, dump=True, 
         }
 
     return jsonschema
+
+
+def get_ref_path(openapi_version):
+    """Return the path for references based on the openapi version
+
+    :param openapi_version|string: the open api version number
+    """
+    ref_paths = {'2.0': 'definitions',
+                 '3.0.0': 'components/schemas'}
+    return ref_paths[openapi_version]
 
 __location_map__ = {
     'query': 'query',

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -308,7 +308,7 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
                     raise ValueError('Must pass `name` argument for self-referencing Nested fields.')
                 # We need to use the `name` argument when the field is self-referencing and
                 # unbound (doesn't have `parent` set) because we can't access field.schema
-                ref_path = get_ref_path(spec.openapi_version)
+                ref_path = get_ref_path(spec.openapi_version.version[0])
                 ref_name =  '#/{ref_path}/{name}'.format(ref_path=ref_path,
                                                          name=name)
             ref_schema = {'$ref': ref_name}
@@ -581,14 +581,15 @@ def fields2jsonschema(fields, schema=None, spec=None, use_refs=True, dump=True, 
     return jsonschema
 
 
-def get_ref_path(openapi_version):
+def get_ref_path(openapi_major_version):
     """Return the path for references based on the openapi version
 
-    :param openapi_version|string: the open api version number
+    :param int openapi_major_version: The major version of the OpenAPI standard
+        to use. Supported values are 2 and 3.
     """
-    ref_paths = {'2.0': 'definitions',
-                 '3.0.0': 'components/schemas'}
-    return ref_paths[openapi_version]
+    ref_paths = {2: 'definitions',
+                 3: 'components/schemas'}
+    return ref_paths[openapi_major_version]
 
 __location_map__ = {
     'query': 'query',

--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -2,6 +2,7 @@
 """Various utilities for parsing OpenAPI operations from docstrings and validating against
 the OpenAPI spec.
 """
+import os
 import re
 import json
 import tempfile
@@ -85,18 +86,19 @@ def load_operations_from_docstring(docstring):
 
 def validate_swagger(spec):
     """Validate the output of an :class:`APISpec` object.
-    Note: Requires installing the node package `swagger-tools`.
+    Note: Requires installing the node package `check_api`.
 
     :raise: SwaggerError if validation fails.
     """
     with tempfile.NamedTemporaryFile(mode='w') as fp:
         json.dump(spec.to_dict(), fp)
         fp.seek(0)
+        shell = os.name == 'nt'  # Set shell to true if running on Windows
         try:
             subprocess.check_output(
-                ['swagger-tools', 'validate', fp.name],
+                ['check_api', fp.name],
                 stderr=subprocess.STDOUT,
-                shell=True,
+                shell=shell,
             )
         except subprocess.CalledProcessError as error:
             raise exceptions.SwaggerError(error.output.decode('utf-8'))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -295,6 +295,25 @@ class TestPath:
         assert p['parameters'][0] == {'$ref': '#/parameters/test_parameter'}
         assert route_spec['parameters'][0] == metadata['parameters']['test_parameter']
 
+    def test_add_parameters_3(self, spec_3):
+        route_spec = self.paths['/pet/{petId}']['get']
+
+        spec_3.add_parameter('test_parameter', 'path', **route_spec['parameters'][0])
+
+        spec_3.add_path(
+            path='/pet/{petId}',
+            operations=dict(
+                get=dict(
+                    parameters=['test_parameter'],
+                )
+            )
+        )
+
+        metadata = spec_3.to_dict()
+        p = spec_3._paths['/pet/{petId}']['get']
+
+        assert p['parameters'][0] == {'$ref': '#/components/parameters/test_parameter'}
+        assert route_spec['parameters'][0] == metadata['components']['parameters']['test_parameter']
 
 class TestPlugins:
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,11 +21,38 @@ def spec():
         security=[{'apiKey': []}],
     )
 
+@pytest.fixture()
+def spec_3():
+    return APISpec(
+        title='Swagger Petstore',
+        version='1.0.0',
+        info={'description': description},
+        security=[{'apiKey': []}],
+        openapi_version='3.0.0'
+    )
+
+
+class TestAPISpecInit:
+
+    def test_raises_wrong_apispec_version(self):
+        with pytest.raises(APISpecError) as excinfo:
+            APISpec(
+                'Swagger Petstore',
+                version='1.0.0',
+                info={'description': description},
+                security=[{'apiKey': []}],
+                openapi_version='no version'
+            )
+        assert 'Not a valid OpenAPI version number:' in str(excinfo)
+
 
 class TestMetadata:
 
     def test_swagger_version(self, spec):
         assert spec.to_dict()['swagger'] == '2.0'
+
+    def test_openapi_version_3(self, spec_3):
+        assert spec_3.to_dict()['openapi'] == '3.0.0'
 
     def test_swagger_metadata(self, spec):
         metadata = spec.to_dict()
@@ -60,6 +87,12 @@ class TestDefinitions:
         defs_json = spec.to_dict()['definitions']
         assert 'Pet' in defs_json
         assert defs_json['Pet']['properties'] == self.properties
+
+    def test_definition_3(self, spec_3):
+        spec_3.definition('Pet', properties=self.properties)
+        schemas = spec_3.to_dict()['components']['schemas']
+        assert 'Pet' in schemas
+        assert schemas['Pet']['properties'] == self.properties
 
     def test_definition_description(self, spec):
         model_description = 'An animal which lives with humans.'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -41,7 +41,7 @@ class TestAPISpecInit:
                 version='1.0.0',
                 info={'description': description},
                 security=[{'apiKey': []}],
-                openapi_version='no version'
+                openapi_version='4.0'  # 4.0 is not supported
             )
         assert 'Not a valid OpenAPI version number:' in str(excinfo)
 

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -560,12 +560,12 @@ class TestNesting:
 
     def test_field2property_nested_self(self, spec):
         self_nesting = fields.Nested('self')
-        res = swagger.field2property(self_nesting, name='Foo')
+        res = swagger.field2property(self_nesting, spec=spec, name='Foo')
         assert res == {'$ref': '#/definitions/Foo'}
 
     def test_field2property_nested_self_many(self, spec):
         self_nesting = fields.Nested('self', many=True)
-        res = swagger.field2property(self_nesting, name='Foo')
+        res = swagger.field2property(self_nesting, spec=spec, name='Foo')
         assert res == {'type': 'array', 'items': {'$ref': '#/definitions/Foo'}}
 
     def test_field2property_nested_self_ref_with_meta(self, spec):


### PR DESCRIPTION
This is an intial attempt to add basic support for OpenApi 3.
Based on the value of the openapi_version field, the APISpec.todict
places schemas either directly in "definitions" (v2) or in
"components/schemas" (v3)

References for nested Marshmallow schemas are also handled

Begins work on #165

See [https://blog.readme.io/an-example-filled-guide-to-swagger-3-2/](https://blog.readme.io/an-example-filled-guide-to-swagger-3-2/)