### PR TITLE
Fix an error running utils.validate_swagger on Windows

### DIFF
--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -96,6 +96,7 @@ def validate_swagger(spec):
             subprocess.check_output(
                 ['swagger-tools', 'validate', fp.name],
                 stderr=subprocess.STDOUT,
+                shell=True,
             )
         except subprocess.CalledProcessError as error:
             raise exceptions.SwaggerError(error.output.decode('utf-8'))


### PR DESCRIPTION
The result was a WindowsError.

The arguments for subprocess.check_output are hard coded so running
in shell is safe.