### PR TITLE
OneOf Polymorphism

### DIFF
--- a/apispec/ext/marshmallow/polymorphic.py
+++ b/apispec/ext/marshmallow/polymorphic.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+def is_oneof(schema):
+    """Function to determine if a schema matches the oneOf api
+
+    :param Schema schema: A marshmallow Schema instance or a class object
+    :rtype: bool, True if the schema matches the oneOf API False otherwise
+    """
+    return hasattr(schema, 'type_field') and hasattr(schema, 'type_schemas')
+
+
+def oneof_schema_2_schema_object(spec, oneof_schema):
+    """Function to generate an OpenAPI schema object based on a oneOf Schema
+    This function will add all of the Schemas to the spec and then return a
+    dictionary containing references to those Schemas
+
+    :param APISpec spec: Current `APISpec` instance
+    :param OneOfSchema oneof_schema: A OneOfSchema instance or a class object
+    """
+    mapping = {}
+    oneof = []
+    for name, schema in oneof_schema.type_schemas.items():
+        spec.definition(name, schema=schema)
+        ref = '#/components/schemas/{}'.format(name)
+        mapping.update({name: ref})
+        oneof.append({'$ref': ref})
+
+    ret = {
+        'oneOf': oneof,
+        'discriminator': {
+            'propertyName': oneof_schema.type_field,
+            'mapping': mapping
+        }
+    }
+    return ret

--- a/apispec/ext/marshmallow/polymorphic.py
+++ b/apispec/ext/marshmallow/polymorphic.py
@@ -20,6 +20,7 @@ def oneof_schema_2_schema_object(spec, oneof_schema):
     mapping = {}
     oneof = []
     for name, schema in oneof_schema.type_schemas.items():
+        name = name.replace(' ', '_')
         spec.definition(name, schema=schema)
         ref = '#/components/schemas/{}'.format(name)
         mapping.update({name: ref})

--- a/apispec/ext/marshmallow/polymorphic.py
+++ b/apispec/ext/marshmallow/polymorphic.py
@@ -20,9 +20,9 @@ def oneof_schema_2_schema_object(spec, oneof_schema):
     mapping = {}
     oneof = []
     for name, schema in oneof_schema.type_schemas.items():
-        name = name.replace(' ', '_')
-        spec.definition(name, schema=schema)
-        ref = '#/components/schemas/{}'.format(name)
+        component_name = name.replace(' ', '_')
+        spec.definition(component_name, schema=schema)
+        ref = '#/components/schemas/{}'.format(component_name)
         mapping.update({name: ref})
         oneof.append({'$ref': ref})
 

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -17,6 +17,7 @@ from marshmallow.compat import text_type, binary_type, iteritems
 from marshmallow.orderedset import OrderedSet
 
 from apispec.lazy_dict import LazyDict
+from . import polymorphic
 
 ##### marshmallow #####
 
@@ -480,6 +481,8 @@ def property2parameter(prop, name='body', required=False, multiple=False, locati
 
 
 def schema2jsonschema(schema, spec=None, use_refs=True, dump=True, name=None):
+    if is_v3(spec) and polymorphic.is_oneof(schema):
+        return polymorphic.oneof_schema_2_schema_object(spec, schema)
     if hasattr(schema, 'fields'):
         fields = schema.fields
     elif hasattr(schema, '_declared_fields'):
@@ -579,6 +582,10 @@ def fields2jsonschema(fields, schema=None, spec=None, use_refs=True, dump=True, 
         }
 
     return jsonschema
+
+
+def is_v3(spec):
+    return spec and spec.openapi_version.version[0] == 3
 
 
 def get_ref_path(openapi_major_version):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ Flask
 marshmallow
 tornado
 bottle
+marshmallow-oneofschema
 
 # testing
 pytest>=2.8.0

--- a/tests/test_ext_marshmallow_polymorphic.py
+++ b/tests/test_ext_marshmallow_polymorphic.py
@@ -18,10 +18,13 @@ description = 'This is a sample Petstore server.  You can find out more '
 
 @pytest.fixture()
 def spec_3():
+    def resolver(schema):
+        return schema.__name__
     return APISpec(
         title='Swagger Petstore',
         version='1.0.0',
         info={'description': description},
+        schema_name_resolver=resolver,
         openapi_version='3.0.0',
         plugins=[
             'apispec.ext.marshmallow'
@@ -110,7 +113,7 @@ class TestOneOfSchema2SchemaObject:
                                                   'mapping': {
                                                       'cat': '#/components/schemas/cat',
                                                       'dog': '#/components/schemas/dog',
-                                                      'lizard_schema': '#/components/schemas/lizard_schema',
+                                                      'lizard schema': '#/components/schemas/lizard_schema',
                                                   }
                                                   }
 
@@ -141,6 +144,7 @@ class TestOneOfFunctional:
 
         spec_3.definition('Pet', schema=Pet)
 
+        utils.validate_swagger(spec_3)
         pet_oneof = spec_3._definitions['Pet']['oneOf']
         assert {'$ref': '#/components/schemas/cat'} in pet_oneof
 
@@ -166,5 +170,7 @@ class TestOneOfFunctional:
 
         spec_3.definition('Home', schema=Home)
 
-        pet_oneof = spec_3._definitions['Home']['properties']['pet']['oneOf']
+        utils.validate_swagger(spec_3)
+
+        pet_oneof = spec_3._definitions['Pet']['oneOf']
         assert {'$ref': '#/components/schemas/cat'} in pet_oneof

--- a/tests/test_ext_marshmallow_polymorphic.py
+++ b/tests/test_ext_marshmallow_polymorphic.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+import pytest
+from marshmallow import Schema, fields
+from marshmallow.validate import Equal
+from marshmallow_oneofschema import OneOfSchema
+
+from apispec import APISpec
+from apispec import utils
+from apispec.ext.marshmallow import polymorphic
+
+description = 'This is a sample Petstore server.  You can find out more '
+'about Swagger at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> '
+'or on irc.freenode.net, #swagger.  For this sample, you can use the api '
+'key \"special-key\" to test the authorization filters'
+
+
+@pytest.fixture()
+def spec_3():
+    return APISpec(
+        title='Swagger Petstore',
+        version='1.0.0',
+        info={'description': description},
+        openapi_version='3.0.0',
+        plugins=[
+            'apispec.ext.marshmallow'
+        ]
+    )
+
+
+class Cat(Schema):
+    pet_type = fields.Str(
+        validate=Equal('cat'),
+        required=True,
+        load_from='petType',
+        dump_to='petType'
+    )
+    name = fields.Str()
+
+
+class Dog(Schema):
+    pet_type = fields.Str(
+        validate=Equal('dog'),
+        required=True,
+        load_from='petType',
+        dump_to='petType',
+    )
+    bark = fields.Str()
+
+
+class Lizard(Schema):
+    pet_type = fields.Str(
+        validate=Equal('lizard'),
+        required=True,
+        load_from='petType',
+        dump_to='petType',
+    )
+    loves_rocks = fields.Boolean(
+        load_from='lovesRocks',
+        dump_to='lovesRocks',
+    )
+
+class Pet(OneOfSchema):
+    type_schemas = {
+        'cat': Cat,
+        'dog': Dog,
+        'lizard': Lizard,
+    }
+    type_field = 'petType'
+
+
+class TestIsOneofSchema:
+    def test_is_oneof(self):
+        assert polymorphic.is_oneof(Pet) is True
+
+    def test_is_not_oneof(self):
+        assert polymorphic.is_oneof(Cat) is False
+
+class TestOneOfSchema2SchemaObject:
+    def test(self, spec_3):
+        def pet_view():
+            """not much to see here
+            ---
+            post:
+              requestBody:
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/Pet'
+              responses:
+                '201':
+                  content:
+                    application/json:
+                      schema:
+                        $ref: '#/components/schemas/Pet'
+                  description: created
+            """
+        spec_3.add_path(path='/pet', view=pet_view)
+
+        schema_object = polymorphic.oneof_schema_2_schema_object(spec_3, Pet)
+
+        assert {'$ref': '#/components/schemas/cat'} in schema_object['oneOf']
+        assert {'$ref': '#/components/schemas/dog'} in schema_object['oneOf']
+        assert {'$ref': '#/components/schemas/lizard'} in schema_object['oneOf']
+
+        assert schema_object['discriminator'] == {'propertyName': 'petType',
+                                                  'mapping': {
+                                                      'cat': '#/components/schemas/cat',
+                                                      'dog': '#/components/schemas/dog',
+                                                      'lizard': '#/components/schemas/lizard',
+                                                  }
+                                                  }
+
+        spec_3._definitions['Pet'] = schema_object
+        import json
+        print(json.dumps(spec_3.to_dict(), indent=4))
+        utils.validate_swagger(spec_3)

--- a/tests/test_ext_marshmallow_polymorphic.py
+++ b/tests/test_ext_marshmallow_polymorphic.py
@@ -65,7 +65,7 @@ class Pet(OneOfSchema):
     type_schemas = {
         'cat': Cat,
         'dog': Dog,
-        'lizard': Lizard,
+        'lizard schema': Lizard,
     }
     type_field = 'petType'
 
@@ -104,13 +104,13 @@ class TestOneOfSchema2SchemaObject:
 
         assert {'$ref': '#/components/schemas/cat'} in schema_object['oneOf']
         assert {'$ref': '#/components/schemas/dog'} in schema_object['oneOf']
-        assert {'$ref': '#/components/schemas/lizard'} in schema_object['oneOf']
+        assert {'$ref': '#/components/schemas/lizard_schema'} in schema_object['oneOf']
 
         assert schema_object['discriminator'] == {'propertyName': 'petType',
                                                   'mapping': {
                                                       'cat': '#/components/schemas/cat',
                                                       'dog': '#/components/schemas/dog',
-                                                      'lizard': '#/components/schemas/lizard',
+                                                      'lizard_schema': '#/components/schemas/lizard_schema',
                                                   }
                                                   }
 


### PR DESCRIPTION
One of the nice features in OpenAPI 3 is support for [oneOf polymorphism](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#discriminator-object).  In one of our API's we are using [marshmallow-oneofschema](https://github.com/maximkulkin/marshmallow-oneofschema) to enable serialization/deserialization/validation of multiple schemas on an endpoint or in a nested field.  This merge request enables API's using marshmallow-onofofschema to be described in OpenAPI 3 format.  

A couple notes;

- I'm [testing](https://github.com/marshmallow-code/apispec/compare/dev...Bangertm:polymorphic?expand=1#diff-36818c01919e762abcc4b32dfdd1b61fR484) to see if the schema matches the marshmallow-onofschema API as a determination of if the schema is a oneOf schema.  This seemed cleaner than testing for inheritance. 
- I think the most user friendly behavior when apispec encounters a marshmallow-oneofschea is to add a oneOf schema object to the spec _and also_ add each of the referenced schemas to the spec.  This way the user doesn't have to add them separately.  The potential concern I encountered is that by default nested fields are not resolved right away and `json.dumps` serialization of the spec results in a `RuntimeError: dictionary changed size during iteration`.  (Oddly this doesn't happen with print)  I was able to work around this by using the new `schema_name_resolver` functionality, but I'm not 100% sure this is the right thing to do.
- I added most of the new code and tests to new modules because swagger.py was getting pretty long.  
- [Marshmallow-Polyfield](https://github.com/Bachmann1234/marshmallow-polyfield) provides similar functionality, but would require additional work to represent in a spec.