### PR TITLE
Identify local object definitions and recurse over the properties

### DIFF
--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -238,8 +238,11 @@ def resolve_schema_in_response(spec, response):
 
 def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
     if isinstance(schema, dict):
-        if (schema.get('type') == 'array' and 'items' in schema):
+        if schema.get('type') == 'array' and 'items' in schema:
             schema['items'] = resolve_schema_dict(spec, schema['items'], use_instances=use_instances)
+        if schema.get('type') == 'object' and 'properties' in schema:
+            schema['properties'] = {k: resolve_schema_dict(spec, v, dump=dump, use_instances=use_instances)
+                                    for k, v in schema['properties'].items()}
         return schema
     plug = spec.plugins[NAME] if spec else {}
     if isinstance(schema, marshmallow.Schema) and use_instances:

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -452,6 +452,35 @@ class TestOperationHelper:
             'items': {'$ref': '#/definitions/Pet'}
         }
 
+    def test_schema_partially_in_docstring(self, spec):
+        spec.definition('Pet', schema=PetSchema)
+
+        def pet_parents_view():
+            """Not much to see here.
+
+            ---
+            get:
+                responses:
+                    200:
+                        schema:
+                            type: object
+                            properties:
+                                mother: tests.schemas.PetSchema
+                                father: tests.schemas.PetSchema
+            """
+            return '...'
+
+        spec.add_path(path='/parents', view=pet_parents_view)
+        p = spec._paths['/parents']
+        op = p['get']
+        assert op['responses'][200]['schema'] == {
+            'type': 'object',
+            'properties': {
+                "mother": {'$ref': '#/definitions/Pet'},
+                "father": {'$ref': '#/definitions/Pet'},
+            },
+        }
+
     def test_other_than_http_method_in_docstring(self, spec):
         def pet_view():
             """Not much to see here.


### PR DESCRIPTION
This adds a little bit of consistency allowing object definitions as part of the response - not only arrays. My primary case for this is to wrap all of our responses in a data property without having to declare a custom schema for each data type individually.