### PR TITLE
Don't let Path inherit from dict

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -54,7 +54,7 @@ def clean_operations(operations, openapi_major_version):
                                        for p in parameters]
 
 
-class Path(dict):
+class Path(object):
     """Represents an OpenAPI Path object.
 
     https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#pathsObject
@@ -68,7 +68,7 @@ class Path(dict):
         standard.
     """
 
-    def __init__(self, path=None, operations=None, openapi_version='2.0', **kwargs):
+    def __init__(self, path=None, operations=None, openapi_version='2.0'):
         self.path = path
         operations = operations or {}
         openapi_version = validate_openapi_version(openapi_version)
@@ -81,8 +81,6 @@ class Path(dict):
                 'One or more HTTP methods are invalid: {0}'.format(", ".join(invalid))
             )
         self.operations = operations
-        kwargs.update(self.operations)
-        super(Path, self).__init__(**kwargs)
 
     def to_dict(self):
         if not self.path:
@@ -91,11 +89,10 @@ class Path(dict):
             self.path: self.operations
         }
 
-    def update(self, path, **kwargs):
+    def update(self, path):
         if path.path:
             self.path = path.path
         self.operations.update(path.operations)
-        super(Path, self).update(path.operations)
 
 
 class APISpec(object):
@@ -260,7 +257,7 @@ class APISpec(object):
                         func(self, **kwargs)
                     )
 
-        self._paths.setdefault(path.path, path).update(path)
+        self._paths.setdefault(path.path, path.operations).update(path.operations)
 
     def definition(self, name, properties=None, enum=None, description=None, extra_fields=None,
                    **kwargs):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -274,7 +274,7 @@ class TestPath:
         spec.add_path(path)
 
         p = spec._paths[path.path]
-        assert path.path == p.path
+        assert p == path.operations
         assert 'get' in p
 
     def test_add_path_strips_path_base_path(self, spec):
@@ -419,7 +419,7 @@ class TestPathHelpers:
 
     def test_path_helper_is_used(self, spec):
         def path_helper(spec, view_func, **kwargs):
-            return Path(path=view_func['path'], method='get')
+            return Path(path=view_func['path'])
         spec.register_path_helper(path_helper)
         spec.add_path(
             view_func={'path': '/pet/{petId}'},


### PR DESCRIPTION
While investigating https://github.com/marshmallow-code/apispec/pull/189, I've been wondering why `Path` inherits from `dict` and in the meantime holds content in its `operations` attribute.

It looks like most content is duplicated in `operations` and in `Path` itself. In fact, inheriting from `dict` seems kinda strange.

This PR removes this inheritance to simplify the code. It makes more sense to me this way. It brings no enhancement, but tries to improve maintainability.

What was the reason for the original design? Any objection to this simplification?

I had to modify 2 tests to get this going. This could mean I'm totally mistaken, but from the name of the tests, I don't think the behaviour I modified is what was being tested, rather a side-effect.

Feedback welcome.

------------------------------------------------------

Note that if this PR is applied, we'll probably need to change

    self.operations = operations or {}

into

    self.operations = operations or OrderedDict

to get the behaviour proposed in https://github.com/marshmallow-code/apispec/pull/189.