### PR TITLE
field2property rework

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -110,7 +110,7 @@ def _get_json_type_for_field(field):
     return json_type, fmt
 
 
-def field2choices(field):
+def field2choices(field, **kwargs):
     """Return the dictionary of swagger field attributes for valid choices definition
 
     :param Field field: A marshmallow field.
@@ -135,7 +135,7 @@ def field2choices(field):
     return attributes
 
 
-def field2dump_only(field):
+def field2dump_only(field, **kwargs):
     """Return the dictionary of swagger field attributes for a dump_only field.
 
     :param Field field: A marshmallow field.
@@ -147,7 +147,7 @@ def field2dump_only(field):
     return attributes
 
 
-def field2nullable(field):
+def field2nullable(field, **kwargs):
     """Return the dictionary of swagger field attributes for a nullable field.
 
     :param Field field: A marshmallow field.
@@ -159,7 +159,7 @@ def field2nullable(field):
     return attributes
 
 
-def field2range(field):
+def field2range(field, **kwargs):
     """Return the dictionary of swagger field attributes for a set of
     :class:`Range <marshmallow.validators.Range>` validators.
 
@@ -195,7 +195,7 @@ def field2range(field):
                 attributes['maximum'] = validator.max
     return attributes
 
-def field2length(field):
+def field2length(field, **kwargs):
     """Return the dictionary of swagger field attributes for a set of
     :class:`Length <marshmallow.validators.Length>` validators.
 
@@ -296,6 +296,12 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
     :param str name: The definition name, if applicable, used to construct the $ref value.
     :rtype: dict, a Property Object
     """
+    if spec:
+        openapi_major_version = spec.openapi_version.version[0]
+    else:
+        # Default to 2 for backward compatibility
+        openapi_major_version = 2
+
     from apispec.ext.marshmallow import resolve_schema_dict
     type_, fmt = _get_json_type_for_field(field)
 
@@ -320,7 +326,8 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
         field2range,
         field2length,
     ):
-        ret.update(attr_func(field))
+        ret.update(attr_func(
+            field, openapi_major_version=openapi_major_version))
 
     if isinstance(field, marshmallow.fields.Nested):
         del ret['type']
@@ -336,7 +343,7 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
                     raise ValueError('Must pass `name` argument for self-referencing Nested fields.')
                 # We need to use the `name` argument when the field is self-referencing and
                 # unbound (doesn't have `parent` set) because we can't access field.schema
-                ref_path = get_ref_path(spec.openapi_version.version[0])
+                ref_path = get_ref_path(openapi_major_version)
                 ref_name =  '#/{ref_path}/{name}'.format(ref_path=ref_path,
                                                          name=name)
             ref_schema = {'$ref': ref_name}

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -135,7 +135,7 @@ def field2choices(field, **kwargs):
     return attributes
 
 
-def field2dump_only(field, **kwargs):
+def field2read_only(field, **kwargs):
     """Return the dictionary of swagger field attributes for a dump_only field.
 
     :param Field field: A marshmallow field.
@@ -144,6 +144,18 @@ def field2dump_only(field, **kwargs):
     attributes = {}
     if field.dump_only:
         attributes['readOnly'] = True
+    return attributes
+
+
+def field2write_only(field, **kwargs):
+    """Return the dictionary of swagger field attributes for a load_only field.
+
+    :param Field field: A marshmallow field.
+    :rtype: dict
+    """
+    attributes = {}
+    if field.load_only and kwargs['openapi_major_version'] >= 3:
+        attributes['writeOnly'] = True
     return attributes
 
 
@@ -322,7 +334,8 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
 
     for attr_func in (
         field2choices,
-        field2dump_only,
+        field2read_only,
+        field2write_only,
         field2nullable,
         field2range,
         field2length,

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -155,7 +155,8 @@ def field2nullable(field, **kwargs):
     """
     attributes = {}
     if field.allow_none:
-        attributes['x-nullable'] = True
+        omv = kwargs['openapi_major_version']
+        attributes['x-nullable' if omv < 3 else 'nullable'] = True
     return attributes
 
 

--- a/tests/test_ext_order.py
+++ b/tests/test_ext_order.py
@@ -20,7 +20,6 @@ def confirm_ext_order_independency(web_framework, **kwargs_for_add_path):
     extensions = [web_framework, 'marshmallow']
     specs = []
     for reverse in (False, True):
-        print(reverse)
         if reverse:
             spec = create_spec(reversed(extensions))
         else:

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -15,7 +15,7 @@ class TestMarshmallowFieldToSwagger:
     def test_field2choices_preserving_order(self):
         choices = ['a', 'b', 'c', 'aa', '0', 'cc']
         field = fields.String(validate=validate.OneOf(choices))
-        assert swagger.field2choices(field) == choices
+        assert swagger.field2choices(field) == {'enum': choices}
 
     @mark.parametrize(('FieldClass', 'jsontype'), [
         (fields.Integer, 'integer'),

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -203,6 +203,17 @@ class TestMarshmallowFieldToSwagger:
         res = swagger.field2property(field)
         assert res['x-nullable'] is True
 
+    def test_field_with_allow_none_v3(self):
+        spec = APISpec(
+            title='Pets',
+            version='0.1',
+            plugins=['apispec.ext.marshmallow'],
+            openapi_version='3.0.0'
+        )
+        field = fields.Str(allow_none=True)
+        res = swagger.field2property(field, spec)
+        assert res['nullable'] is True
+
 class TestMarshmallowSchemaToModelDefinition:
 
     def test_invalid_schema(self):


### PR DESCRIPTION
This PR reworks field2property a bit to provide more consistency to the field2attribute methods. This makes it easier to manage different OpenAPI versions.

It also adds the `x-nullable`/`nullable` and `writeOnly` attributes depending on the version.

It does not address the optional spec attribute issue discussed in https://github.com/marshmallow-code/apispec/pull/197 but it is a first step.

@sloria, @Bangertm Feedback welcome.

