### PR TITLE
Add handling for marshmallow Dict values metadata

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -380,7 +380,8 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
     elif isinstance(field, marshmallow.fields.List):
         ret['items'] = field2property(field.container, spec=spec, use_refs=use_refs, dump=dump)
     elif isinstance(field, marshmallow.fields.Dict):
-        ret['additionalProperties'] = field2property(field.metadata['values'], spec=spec, use_refs=use_refs, dump=dump)
+        if 'values' in field.metadata:
+            ret['additionalProperties'] = field2property(field.metadata['values'], spec=spec, use_refs=use_refs, dump=dump)
         
     # Dasherize metadata that starts with x_
     metadata = {

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -380,8 +380,9 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
     elif isinstance(field, marshmallow.fields.List):
         ret['items'] = field2property(field.container, spec=spec, use_refs=use_refs, dump=dump)
     elif isinstance(field, marshmallow.fields.Dict):
-        if MARSHMALLOW_VERSION_INFO[0] >= 3:            
-            ret['additionalProperties'] = field2property(field.value_container, spec=spec, use_refs=use_refs, dump=dump)
+        if MARSHMALLOW_VERSION_INFO[0] >= 3:
+            if field.value_container:
+                ret['additionalProperties'] = field2property(field.value_container, spec=spec, use_refs=use_refs, dump=dump)
 
     # Dasherize metadata that starts with x_
     metadata = {

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -379,7 +379,9 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
             ret.update(schema2jsonschema(field.schema, dump=dump))
     elif isinstance(field, marshmallow.fields.List):
         ret['items'] = field2property(field.container, spec=spec, use_refs=use_refs, dump=dump)
-
+    elif isinstance(field, marshmallow.fields.Dict):
+        ret['additionalProperties'] = field2property(field.metadata['values'], spec=spec, use_refs=use_refs, dump=dump)
+        
     # Dasherize metadata that starts with x_
     metadata = {
         key.replace('_', '-') if key.startswith('x_') else key: value

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -380,9 +380,9 @@ def field2property(field, spec=None, use_refs=True, dump=True, name=None):
     elif isinstance(field, marshmallow.fields.List):
         ret['items'] = field2property(field.container, spec=spec, use_refs=use_refs, dump=dump)
     elif isinstance(field, marshmallow.fields.Dict):
-        if 'values' in field.metadata:
-            ret['additionalProperties'] = field2property(field.metadata['values'], spec=spec, use_refs=use_refs, dump=dump)
-        
+        if MARSHMALLOW_VERSION_INFO[0] >= 3:            
+            ret['additionalProperties'] = field2property(field.value_container, spec=spec, use_refs=use_refs, dump=dump)
+
     # Dasherize metadata that starts with x_
     metadata = {
         key.replace('_', '-') if key.startswith('x_') else key: value

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -24,10 +24,6 @@ class AnalysisWithListSchema(Schema):
     samples = fields.List(fields.Nested(SampleSchema))
 
 
-class AnalysisWithDictSchema(Schema):
-    samplesDict = fields.Dict(values=fields.Nested(SampleSchema))
-
-
 class PatternedObjectSchema(Schema):
     count = fields.Int(dump_only=True, **{'x-count': 1})
     count2 = fields.Int(dump_only=True, x_count2=2)

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -24,6 +24,10 @@ class AnalysisWithListSchema(Schema):
     samples = fields.List(fields.Nested(SampleSchema))
 
 
+class AnalysisWithDictSchema(Schema):
+    samplesDict = fields.Dict(values=fields.Nested(SampleSchema))
+
+
 class PatternedObjectSchema(Schema):
     count = fields.Int(dump_only=True, **{'x-count': 1})
     count2 = fields.Int(dump_only=True, x_count2=2)

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -597,5 +597,13 @@ class TestDictValues:
 
         spec.definition('SchemaWithDict', schema=SchemaWithDict)
         result = spec._definitions['SchemaWithDict']['properties']['dict_field']
-        assert 'additionalProperties' in result
-        assert result['additionalProperties']['type'] == 'string'
+        assert result == {'type': 'object', 'additionalProperties': {'type': 'string'}}
+
+    def test_dict_with_empty_values_field(self, spec):
+
+        class SchemaWithDict(Schema):
+            dict_field = Dict()
+
+        spec.definition('SchemaWithDict', schema=SchemaWithDict)
+        result = spec._definitions['SchemaWithDict']['properties']['dict_field']
+        assert result == {'type': 'object'}

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -585,7 +585,8 @@ class TestDefaultCanBeCallable:
         result = spec._definitions['DefaultCallableSchema']['properties']['numbers']
         assert result['default'] == []
 
-
+@pytest.mark.skipif(swagger.MARSHMALLOW_VERSION_INFO[0] < 3,
+                    reason='Values ignored in marshmallow 2')
 class TestDictValues:
     def test_dict_values_resolve_to_additional_properties(self, spec):
         spec.definition('SampleSchema', schema=SampleSchema)

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -8,7 +8,7 @@ from apispec import APISpec
 from apispec.ext.marshmallow import swagger
 from .schemas import PetSchema, AnalysisSchema, SampleSchema, RunSchema, \
     SelfReferencingSchema, OrderedSchema, PatternedObjectSchema, \
-    DefaultCallableSchema, AnalysisWithListSchema
+    DefaultCallableSchema, AnalysisWithListSchema, AnalysisWithDictSchema
 
 
 description = 'This is a sample Petstore server.  You can find out more '
@@ -584,3 +584,12 @@ class TestDefaultCanBeCallable:
         spec.definition('DefaultCallableSchema', schema=DefaultCallableSchema)
         result = spec._definitions['DefaultCallableSchema']['properties']['numbers']
         assert result['default'] == []
+
+
+class TestDictValues:
+    def test_dict_values_resolve_to_additional_properties(self, spec):
+        spec.definition('SampleSchema', schema=SampleSchema)
+        spec.definition('AnalysisWithDictSchema', schema=AnalysisWithDictSchema)
+        dict_schema_definition = spec._definitions['AnalysisWithDictSchema']
+        additional_props = dict_schema_definition['properties']['samplesDict']['additionalProperties']
+        assert additional_props['$ref'] == '#/definitions/SampleSchema'

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -598,4 +598,4 @@ class TestDictValues:
         spec.definition('SchemaWithDict', schema=SchemaWithDict)
         result = spec._definitions['SchemaWithDict']['properties']['dict_field']
         assert 'additionalProperties' in result
-        assert result['additionalProperties'] == 'string'
+        assert result['additionalProperties']['type'] == 'string'


### PR DESCRIPTION
For #201 
Previously, even if a Dict field had 'values' metadata, it resolved to:
```
{ type: object }
```
Now the field is checked for the presence of 'values' metadata and an `additionalProperties` property is added to the definition. The vlaue of `additionalProperties` is obtained by a call to field2property