### PR TITLE
Mark tests requiring Node JS as "nodetest"

### DIFF
--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -701,6 +701,7 @@ class TestNesting:
         assert swagger.field2property(category_8, spec=spec) == {
             'items': {'$ref': '#/definitions/Category'}, 'readOnly': True, 'type': 'array'}
 
+@pytest.mark.nodetest
 def test_swagger_tools_validate():
     spec = APISpec(
         title='Pets',
@@ -755,6 +756,7 @@ def test_swagger_tools_validate():
     except exceptions.SwaggerError as error:
         pytest.fail(str(error))
 
+@pytest.mark.nodetest
 def test_validate_v3():
     spec = APISpec(
         title='Pets',


### PR DESCRIPTION
This allows to skip those test by running

     py.test -m "not nodetest"

Sometimes I want to run tests and I don't have node installed (and being a node noob, I don't want to struggle though the installation procedure), and the two failing tests clutter the terminal output. Adding this makes it easier to launch quick tests after a small change.

-----------------------------------------------------

For the record, I had found another way to achieve this thanks to https://stackoverflow.com/a/43938191:

Add this to `conftest.py`:

```python
def pytest_addoption(parser):
    parser.addoption('--skip-node', action='store_true', dest='skipnode',
    help='skip tests that require node')
```

And create this decorator in `test_swagger.py`:

```python
# Decorator to skip test that require node if --skip-node is passed
requires_node = pytest.mark.skipif(
    pytest.config.option.skipnode, reason='--skip-node option provided')
```

Then decorate the two node functions with `@requires_node`.

While it makes the command line cleaner 

    py.test --skip-node

I don't like the fact that the decorator can't be defined in conftest.py (at least it didn't find how to do it). Well, I couldn't make it perfect.

-----------------------------------------------------

I don't want to overthink this. I'd just find it practical to be able to exclude those tests, sometimes. And just marking them like I suggest in this PR is harmless.