### PR TITLE
Generalize schema resolution for arrays

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -48,3 +48,4 @@ Contributors (chronological)
 - `@mathewmarcus <https://github.com/mathewmarcus>`_
 - Louis-Philippe Huberdeau `@lphuberdeau <https://github.com/lphuberdeau>`_
 - Urban `@UrKr <https://github.com/UrKr>`_
+- Christina Long `@cvlong <https://github.com/cvlong>`_

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -189,7 +189,7 @@ def schema_operation_resolver(spec, operations, **kwargs):
         if 'requestBody' in operation:  # OpenAPI 3
             resolve_schema_in_request_body(spec, operation['requestBody'])
         for response in operation.get('responses', {}).values():
-            resolve_schema_in_response(spec, response)
+            resolve_schema(spec, response)
 
 def resolve_parameters(spec, parameters):
     resolved = []
@@ -201,6 +201,7 @@ def resolve_parameters(spec, parameters):
                 resolved += swagger.schema2parameters(
                     schema_cls, default_in=parameter.pop('in'), spec=spec, **parameter)
                 continue
+        resolve_schema(spec, parameter)
         resolved.append(parameter)
     return resolved
 
@@ -217,19 +218,19 @@ def resolve_schema_in_request_body(spec, request_body):
         content[content_type]['schema'] = resolve_schema_dict(spec, schema)
 
 
-def resolve_schema_in_response(spec, response):
-    """Function to resolve a schema in a response - modifies the response
-    dict to convert Marshmallow Schema object or class into dict
+def resolve_schema(spec, data):
+    """Function to resolve a schema in a parameter or response - modifies the
+    corresponding dict to convert Marshmallow Schema object or class into dict
 
     :param APISpec spec: `APISpec` containing refs.
-    :param dict response: the response dictionary that may contain a schema
+    :param dict data: the parameter or response dictionary that may contain a schema
     """
-    if 'schema' in response:  # OpenAPI 2
-        response['schema'] = resolve_schema_dict(spec, response['schema'])
-    if 'content' in response:  # OpenAPI 3
-        for content_type in response['content']:
-            schema = response['content'][content_type]['schema']
-            response['content'][content_type]['schema'] = resolve_schema_dict(spec, schema)
+    if 'schema' in data:  # OpenAPI 2
+        data['schema'] = resolve_schema_dict(spec, data['schema'])
+    if 'content' in data:  # OpenAPI 3
+        for content_type in data['content']:
+            schema = data['content'][content_type]['schema']
+            data['content'][content_type]['schema'] = resolve_schema_dict(spec, schema)
 
 def resolve_schema_dict(spec, schema, dump=True, use_instances=False):
     if isinstance(schema, dict):

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -466,6 +466,42 @@ class TestOperationHelper:
         assert op['parameters'][0]['schema'] == resolved_schema
         assert op['responses'][200]['schema'] == resolved_schema
 
+    def test_schema_array_in_docstring_uses_ref_if_available_v3(self, spec_3):
+        def pet_view():
+            """Not much to see here.
+
+            ---
+            get:
+                parameters:
+                    - in: body
+                      content:
+                        application/json:
+                            schema:
+                                type: array
+                                items: tests.schemas.PetSchema
+                responses:
+                    200:
+                        content:
+                            application/json:
+                                schema:
+                                    type: array
+                                    items: tests.schemas.PetSchema
+            """
+            return '...'
+
+        spec_3.add_path(path='/pet', view=pet_view)
+        p = spec_3._paths['/pet']
+        assert 'get' in p
+        op = p['get']
+        resolved_schema = {
+            'type': 'array',
+            'items': swagger.schema2jsonschema(PetSchema),
+        }
+        request_schema = op['parameters'][0]['content']['application/json']['schema']
+        assert request_schema == resolved_schema
+        response_schema = op['responses'][200]['content']['application/json']['schema']
+        assert response_schema == resolved_schema
+
     def test_schema_partially_in_docstring(self, spec):
         spec.definition('Pet', schema=PetSchema)
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -439,6 +439,11 @@ class TestOperationHelper:
 
             ---
             get:
+                parameters:
+                    - in: body
+                      schema:
+                        type: array
+                        items: tests.schemas.PetSchema
                 responses:
                     200:
                         schema:
@@ -451,11 +456,15 @@ class TestOperationHelper:
         p = spec._paths['/pet']
         assert 'get' in p
         op = p['get']
+        assert 'parameters' in op
+        len(op['parameters']) == 1
         assert 'responses' in op
-        assert op['responses'][200]['schema'] == {
+        resolved_schema = {
             'type': 'array',
             'items': {'$ref': '#/definitions/Pet'}
         }
+        assert op['parameters'][0]['schema'] == resolved_schema
+        assert op['responses'][200]['schema'] == resolved_schema
 
     def test_schema_partially_in_docstring(self, spec):
         spec.definition('Pet', schema=PetSchema)


### PR DESCRIPTION
Updates the marshmallow plugin to resolve an array of schema items in the request parameters. Generalizes `resolve_schema` to handle arrays defined in `parameters` or `responses`.