### PR TITLE
Openapi 3.0.X support for shcemas in paramters in marshmallow extension

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -543,7 +543,7 @@ def property2parameter(prop, name='body', required=False, multiple=False, locati
         elif openapi_major_version == 3:
             if multiple:
                 ret['explode'] = True
-                ret['style'] = dict(form='array')
+                ret['style'] = 'form'
             ret['schema'] = prop
     return ret
 

--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -429,6 +429,11 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True,
     https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
     """
     swagger_default_in = __location_map__.get(default_in, default_in)
+    if spec is None:
+        openapi_major_version = 2
+    else:
+        openapi_major_version = spec.openapi_version.version[0]
+
     if swagger_default_in == 'body':
         if schema is not None:
             # Prevent circular import
@@ -464,7 +469,9 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True,
                                 name=_observed_name(field_obj, field_name),
                                 spec=spec,
                                 use_refs=use_refs,
-                                default_in=default_in)
+                                default_in=default_in,
+                                openapi_major_version=openapi_major_version
+                                )
         if param['in'] == 'body' and body_param is not None:
             body_param['schema']['properties'].update(param['schema']['properties'])
             required_fields = param['schema'].get('required', [])
@@ -477,7 +484,7 @@ def fields2parameters(fields, schema=None, spec=None, use_refs=True,
     return parameters
 
 
-def field2parameter(field, name='body', spec=None, use_refs=True, default_in='body'):
+def field2parameter(field, name='body', spec=None, use_refs=True, default_in='body', openapi_major_version=2):
     """Return an OpenAPI parameter as a `dict`, given a marshmallow
     :class:`Field <marshmallow.Field>`.
 
@@ -492,11 +499,12 @@ def field2parameter(field, name='body', spec=None, use_refs=True, default_in='bo
         multiple=isinstance(field, marshmallow.fields.List),
         location=location,
         default_in=default_in,
+        openapi_major_version=openapi_major_version
     )
 
 
 def property2parameter(prop, name='body', required=False, multiple=False, location=None,
-                       default_in='body'):
+                       default_in='body', openapi_major_version=2):
     """Return the Parameter Object definition for a JSON Schema property.
 
     https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
@@ -528,9 +536,15 @@ def property2parameter(prop, name='body', required=False, multiple=False, locati
             ret['schema']['required'] = [name]
     else:
         ret['required'] = required
-        if multiple:
-            ret['collectionFormat'] = 'multi'
-        ret.update(prop)
+        if openapi_major_version == 2:
+            if multiple:
+                ret['collectionFormat'] = 'multi'
+            ret.update(prop)
+        elif openapi_major_version == 3:
+            if multiple:
+                ret['explode'] = True
+                ret['style'] = dict(form='array')
+            ret['schema'] = prop
     return ret
 
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -360,6 +360,37 @@ class TestOperationHelper:
         assert post['parameters'] == swagger.schema2parameters(PetSchema, default_in='body', required=True,
                                                                name='pet', description='a pet schema')
 
+    def test_schema_in_docstring_expand_parameters_v3(self, spec_3):
+        def pet_view():
+            """Not much to see here.
+
+            ---
+            get:
+                parameters:
+                    - in: query
+                      schema: tests.schemas.PetSchema
+            post:
+                parameters:
+                    - in: body
+                      description: "a pet schema"
+                      required: true
+                      name: pet
+                      schema: tests.schemas.PetSchema
+            """
+            return '...'
+
+        spec_3.add_path(path='/pet', view=pet_view)
+        p = spec_3._paths['/pet']
+        assert 'get' in p
+        get = p['get']
+        assert 'parameters' in get
+        assert get['parameters'] == swagger.schema2parameters(PetSchema, default_in='query', spec=spec_3)
+        post = p['post']
+        assert 'parameters' in post
+        post_parameters = swagger.schema2parameters(PetSchema, default_in='body', required=True,
+                                                     name='pet', description='a pet schema', spec=spec_3)
+        assert post['parameters'] == post_parameters
+
     def test_schema_in_docstring_uses_ref_if_available(self, spec):
         spec.definition('Pet', schema=PetSchema)
 


### PR DESCRIPTION
Currently, marshmallow extension only partially supports openapi 3.0.X . In my case, I would like to assign marshmallow schema object in parameters. 

The code below is a demonstration for my case.

```python
from marshmallow import Schema, fields

class PetSchema(Schema):
    id = fields.Int(dump_only=True)
    name = fields.Str()
    age = fields.Int()

def pet_view():
    """Not much to see here.
    ---
    get:
        parameters:
            - in: query
              schema: PetSchema
    """
    return '...'
```

The expected result in Openapi Specification 3.0.X is as below:

```yaml
get:
  parameters:
  - in: query
    name: name
    required: false
    schema: 
      type: string
  - in: query
    name: age
    required: false
    schema: 
      format: int32
      type: integer

```
In short, **format** and **type** field must be inside **schema** object. A parameter object do not allow **format** field nor **type** field.

However, current result is as follow:

```yaml
get:
  parameters:
  - in: query
    name: name
    required: false
    type: string
  - in: query
    name: age
    required: false
    format: int32
    type: integer
```

Thus, I modify the code to fix this behavior. Also, I notice that **collectionFormat** field is now deprecated in Openapi 3.0.X . Instead, an equivalent of collection set to **multi** is that **style** set to **form**, with **explode** set to true.
See [style values](https://swagger.io/specification/#style-values). Below is some important description or examples copied directly from openapi specification.

style | explode | empty | string | array | object
-- | -- | -- | -- | -- | --
form | true | color= | color=blue | color=blue&color=black&color=brown | R=100&G=200&B=150

```yaml
name: id
in: query
description: ID of the object to fetch
required: false
schema:
  type: array
  items:
    type: string
style: form
explode: true
```

