### PR TITLE
Deep update components instead of overwriting components for OpenAPI 3

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -156,15 +156,26 @@ class APISpec(object):
             ret['swagger'] = self.openapi_version.vstring
             ret['definitions'] = self._definitions
             ret['parameters'] = self._parameters
+            ret.update(self.options)
 
         elif self.openapi_version.version[0] == 3:
             ret['openapi'] = self.openapi_version.vstring
-            ret['components'] = {
-                'schemas': self._definitions,
-                'parameters': self._parameters,
-            }
+            options = self.options.copy()
+            components = options.pop('components', {})
 
-        ret.update(self.options)
+            # deep update components object
+            definitions = components.pop('schemas', {})
+            definitions.update(self._definitions)
+            parameters = components.pop('parameters', {})
+            parameters.update(self._parameters)
+
+            ret['components'] = dict(
+                schemas=definitions,
+                parameters=parameters,
+                **components
+            )
+            ret.update(options)
+
         return ret
 
     def to_yaml(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,11 +26,28 @@ def spec():
 
 @pytest.fixture()
 def spec_3():
+    components = {
+        'securitySchemes': {
+            'bearerAuth':
+                dict(type='http', scheme='bearer', bearerFormat='JWT')
+        },
+        'schemas': {
+            'ErrorResponse': {
+                'type': 'object',
+                'properties': {
+                    'ok': {
+                        'type': 'boolean', 'description': 'status indicator', 'example': False
+                    }
+                },
+                'required': ['ok']
+            }
+        }
+    }
     return APISpec(
         title='Swagger Petstore',
         version='1.0.0',
         info={'description': description},
-        security=[{'apiKey': []}],
+        components=components,
         openapi_version='3.0.0'
     )
 
@@ -63,6 +80,26 @@ class TestMetadata:
         assert metadata['info']['title'] == 'Swagger Petstore'
         assert metadata['info']['version'] == '1.0.0'
         assert metadata['info']['description'] == description
+
+    def test_swagger_metadata_v3(self, spec_3):
+        metadata = spec_3.to_dict()
+        security_schemes = {'bearerAuth': dict(type='http', scheme='bearer', bearerFormat='JWT')}
+        assert metadata['components']['securitySchemes'] == security_schemes
+        assert metadata['components']['schemas'].get('ErrorResponse', False)
+        assert metadata['info']['title'] == 'Swagger Petstore'
+        assert metadata['info']['version'] == '1.0.0'
+        assert metadata['info']['description'] == description
+
+    def test_swagger_metadata_merge_v3(self, spec_3):
+        properties = {
+            'ok': {
+                'type': 'boolean', 'description': 'property description', 'example': True
+            }
+        }
+        spec_3.definition('definition', properties=properties, description='definiton description')
+        metadata = spec_3.to_dict()
+        assert metadata['components']['schemas'].get('ErrorResponse', False)
+        assert metadata['components']['schemas'].get('definition', False)
 
 
 class TestTags:


### PR DESCRIPTION
In my case, I would like to specify securitySchemes in components
object. However, currently there is no predefined function to meet my
need. So I would like to specify components object when initialize
APISpec object.
```python
doc_string = """
components:
  securitySchemes:
    bearerAuth:
      type: http
      scheme: bearer
      bearerFormat: JWT
"""
setting = yaml.load(doc_string)
spec = APISpec(
    plugins=(
        'apispec.ext.marshmallow',
    ),
    openapi_version='3.0.1',
    **settings
)
```

The document says that the keyword arguments are optional top-level
keys. And I have managed to add optional top-level keys like server
objects.

However, the components objects I specified is shadowing components that is generated by apispec code. Relevant code locates in to_dict function in apispec.core:
```python
...
elif self.openapi_version.version[0] == 3:
    ...
    components = {
        'schemas': self._definitions,
        'parameters': self._parameters,
    }
ret.update(self.options)
```

I think it better to **update** component objects instead of
**overwriting** component objects. In this way, we can take advantages of both
custom settings and apispec functions.

Furthermore, I am rewriting relevant code to deep update components objects. In other words, the definitions defined by APISpec are merged with given schemas defined in top-level components objects. So do parameters in components objects.