### PR TITLE
fix description for parameters in OpenAPI 3

### DIFF
--- a/apispec/ext/marshmallow/swagger.py
+++ b/apispec/ext/marshmallow/swagger.py
@@ -544,6 +544,8 @@ def property2parameter(prop, name='body', required=False, multiple=False, locati
             if multiple:
                 ret['explode'] = True
                 ret['style'] = 'form'
+            if prop.get('description', None):
+                ret['description'] = prop.pop('description')
             ret['schema'] = prop
     return ret
 

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -2,7 +2,7 @@ from marshmallow import Schema, fields
 
 
 class PetSchema(Schema):
-    description = dict(id="Pet id", name="Pet name")
+    description = dict(id='Pet id', name='Pet name')
     id = fields.Int(dump_only=True, description=description['id'])
     name = fields.Str(description=description['name'], required=True, deprecated=False, allowEmptyValue=False)
 

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -2,8 +2,9 @@ from marshmallow import Schema, fields
 
 
 class PetSchema(Schema):
-    id = fields.Int(dump_only=True)
-    name = fields.Str()
+    description = dict(id="Pet id", name="Pet name")
+    id = fields.Int(dump_only=True, description=description['id'])
+    name = fields.Str(description=description['name'], required=True, deprecated=False, allowEmptyValue=False)
 
 
 class SampleSchema(Schema):


### PR DESCRIPTION
In OpenAPI3, desired output for query parameters is like this:
```yaml
parameters:
- description: Password
  in: query
  name: password
  required: true
  schema: 
    type: string
```

However,  only properties *in*, *name* and *required* are defined in the top level, while all other properties is moved under property *schema*, which conflicts with OpenAPI 3 specification.

Current output:
```yaml
parameters:
- in: query
  name: password
  required: true
  schema: 
    type: string
    description: Password
```

So before moving all properties to schema, it's reasonable to check for *description* property and define description in top level of parameter object.