### PR TITLE
Use a Python library for validating specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ env:
   - MARSHMALLOW_VERSION=""
 
 install:
-- travis_retry pip install -U .
-- travis_retry npm install -g check_api
 - travis_retry pip install -r dev-requirements.txt
 - travis_retry pip install -U marshmallow"$MARSHMALLOW_VERSION" --pre
 script: invoke test

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Features:
 - [apispec.ext.marshmallow]: Deep update components instead of
   overwriting components for OpenAPI 3 (:issue:`222`). Thanks
   :user:`Guoli-Lyu`.
+- [apispec.core]: ``apispec.utils.validate_swagger`` no longer relies on
+  the ``check_api`` NPM module. ``prance`` and
+  ``openapi-spec-validator`` are required for validation, and can be
+  installed using ``pip install 'apispec[validation]'`` (:issue:`224`).
 
 Bug fixes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,17 @@ Changelog
 
 Features:
 
-- [apispec.ext.marshmallow]: Deep update components instead of
-  overwriting components for OpenAPI 3 (:issue:`222`). Thanks
-  :user:`Guoli-Lyu`.
-- [apispec.core]: ``apispec.utils.validate_swagger`` no longer relies on
+- [apispec.core]: *Backwards-incompatible*: Rename ``apispec.utils.validate_swagger``
+  to ``apispec.utils.validate_spec`` and
+  ``apispec.exceptions.SwaggerError`` to ``apispec.exceptions.OpenAPIError``. 
+  Using ``validate_swagger`` will raise a ``DeprecationWarning`` (:issue:`224`).
+- [apispec.core]: ``apispec.utils.validate_spec`` no longer relies on
   the ``check_api`` NPM module. ``prance`` and
   ``openapi-spec-validator`` are required for validation, and can be
   installed using ``pip install 'apispec[validation]'`` (:issue:`224`).
+- [apispec.ext.marshmallow]: Deep update components instead of
+  overwriting components for OpenAPI 3 (:issue:`222`). Thanks
+  :user:`Guoli-Lyu`.
 
 Bug fixes:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -32,11 +32,6 @@ Setting Up for Local Development
 
     # After activating your virtualenv
     $ pip install -r dev-requirements.txt
-    $ npm install -g check_api
-
-3. Install apispec in develop mode. ::
-
-   $ pip install -e .
 
 Git Branch Structure
 ++++++++++++++++++++

--- a/apispec/exceptions.py
+++ b/apispec/exceptions.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Exception classes."""
+import warnings
 
 class APISpecError(Exception):
     """Base class for all apispec-related errors."""
@@ -9,6 +10,19 @@ class PluginError(APISpecError):
     """Raised when a plugin cannot be found or is invalid."""
     pass
 
-class SwaggerError(APISpecError):
-    """Raised when a swagger validation fails"""
+class OpenAPIError(APISpecError):
+    """Raised when a OpenAPI spec validation fails."""
     pass
+
+
+class SwaggerError(OpenAPIError):
+    """
+    .. deprecated:: 0.38.0
+        Use `apispec.exceptions.OpenAPIError` instead.
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            'SwaggerError is deprecated. Use OpenAPIError instead.',
+            DeprecationWarning
+        )
+        super(SwaggerError, self).__init__(*args, **kwargs)

--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -91,7 +91,15 @@ def validate_swagger(spec):
 
     :raise: SwaggerError if validation fails.
     """
-    import prance
+    try:
+        import prance
+    except ImportError as error:  # re-raise with a more verbose message
+        exc_class = type(error)
+        raise exc_class(
+            'validate_swagger requires prance to be installed. '
+            'You can install all validation requirements using:\n'
+            "    pip install 'apispec[validation]'"
+        )
     parser_kwargs = {}
     if spec.openapi_version.version[0] == 3:
         parser_kwargs['backend'] = 'openapi-spec-validator'

--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -4,6 +4,7 @@ the OpenAPI spec.
 """
 import re
 import json
+import warnings
 
 import yaml
 
@@ -82,14 +83,16 @@ def load_operations_from_docstring(docstring):
     else:
         return None
 
-def validate_swagger(spec):
-    """Validate the output of an :class:`APISpec` object.
+def validate_spec(spec):
+    """Validate the output of an :class:`APISpec` object against the
+    OpenAPI specification.
+
     Note: Requires installing apispec with the ``[validation]`` extras.
     ::
 
         pip install 'apispec[validation]'
 
-    :raise: SwaggerError if validation fails.
+    :raise: apispec.exceptions.OpenAPIError if validation fails.
     """
     try:
         import prance
@@ -106,4 +109,17 @@ def validate_swagger(spec):
     try:
         prance.BaseParser(spec_string=json.dumps(spec.to_dict()), **parser_kwargs)
     except prance.ValidationError as err:
-        raise exceptions.SwaggerError(*err.args)
+        raise exceptions.OpenAPIError(*err.args)
+    else:
+        return True
+
+def validate_swagger(spec):
+    """
+    .. deprecated:: 0.38.0
+        Use `apispec.utils.validate_spec` instead.
+    """
+    warnings.warn(
+        'apispec.utils.validate_swagger is deprecated. Use apispec.utils.validate_spec instead.',
+        DeprecationWarning
+    )
+    return validate_spec(spec)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,3 +15,6 @@ bottle==0.12.13
 pytest==3.6.1
 tox==3.0.0
 mock==2.0.0
+
+# Install this package in development mode with validation requirements
+-e '.[validation]'

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,11 @@ setup(
     package_dir={'apispec': 'apispec'},
     include_package_data=True,
     install_requires=REQUIRES,
+    extras_require={
+        'validation': [
+            'prance[osv]>=0.11',
+        ],
+    },
     license='MIT',
     zip_safe=False,
     keywords='apispec swagger openapi specification documentation spec rest api',

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -701,7 +701,6 @@ class TestNesting:
         assert swagger.field2property(category_8, spec=spec) == {
             'items': {'$ref': '#/definitions/Category'}, 'readOnly': True, 'type': 'array'}
 
-@pytest.mark.nodetest
 def test_swagger_tools_validate():
     spec = APISpec(
         title='Pets',
@@ -756,7 +755,6 @@ def test_swagger_tools_validate():
     except exceptions.SwaggerError as error:
         pytest.fail(str(error))
 
-@pytest.mark.nodetest
 def test_validate_v3():
     spec = APISpec(
         title='Pets',

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -751,7 +751,7 @@ def test_swagger_tools_validate():
         },
     )
     try:
-        utils.validate_swagger(spec)
+        utils.validate_spec(spec)
     except exceptions.SwaggerError as error:
         pytest.fail(str(error))
 
@@ -823,7 +823,7 @@ def test_validate_v3():
         },
     )
     try:
-        utils.validate_swagger(spec)
+        utils.validate_spec(spec)
     except exceptions.SwaggerError as error:
         pytest.fail(str(error))
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import pytest
+
+from apispec import APISpec
 from apispec import utils
 
 def test_load_yaml_from_docstring():
@@ -14,3 +17,13 @@ def test_load_yaml_from_docstring():
         """
     result = utils.load_yaml_from_docstring(f.__doc__)
     assert result == {'herp': 1, 'derp': 2}
+
+
+def test_validate_swagger_is_deprecated():
+    spec = APISpec(
+        title='Pets',
+        version='0.1',
+        openapi_version='3.0.0'
+    )
+    with pytest.warns(DeprecationWarning, match='validate_spec'):
+        utils.validate_swagger(spec)


### PR DESCRIPTION
Switch from check_api to prance for validating specs to avoid
having to install a global npm package for validation.

Validation requirements can be installed by adding the [validation]
extras, i.e. pip install 'apispec[validation]'