### PR TITLE
Refactor add_path

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -219,7 +219,7 @@ class APISpec(object):
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#pathsObject
 
-        :param str|Path|None path: URL Path component or Path instance
+        :param str|None path: URL path component
         :param dict|None operations: describes the http methods and options for `path`
         :param dict kwargs: parameters used by any path helpers see :meth:`register_path_helper`
         """
@@ -230,6 +230,11 @@ class APISpec(object):
             return path
 
         if isinstance(path, Path):
+            warnings.warn(
+                'Passing a Path instance to add_path is deprecated. '
+                'Pass path as string and operations as dict.',
+                DeprecationWarning,
+            )
             path.path = normalize_path(path.path)
             if operations:
                 path.operations.update(operations)

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -81,13 +81,6 @@ class Path(object):
                 'One or more HTTP methods are invalid: {0}'.format(', '.join(invalid)),
             )
 
-    def to_dict(self):
-        if not self.path:
-            raise APISpecError('Path template is not specified')
-        return {
-            self.path: self.operations,
-        }
-
     def update(self, path):
         if path.path:
             self.path = path.path

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -318,19 +318,9 @@ class TestPath:
         assert '/pets' in spec._paths
         assert '/v1/pets' not in spec._paths
 
-    def test_add_path_accepts_path(self, spec):
-        route = '/pet/{petId}'
-        route_spec = self.paths[route]
-        path = Path(path=route, operations={'get': route_spec['get']})
-        spec.add_path(path)
-
-        p = spec._paths[path.path]
-        assert p == path.operations
-        assert 'get' in p
-
     def test_add_path_strips_path_base_path(self, spec):
         spec.options['basePath'] = '/v1'
-        path = Path(path='/v1/pets')
+        path = '/v1/pets'
         spec.add_path(path)
         assert '/pets' in spec._paths
         assert '/v1/pets' not in spec._paths
@@ -358,6 +348,10 @@ class TestPath:
         else:
             assert p['parameters'][0] == {'$ref': '#/components/parameters/test_parameter'}
             assert route_spec['parameters'][0] == metadata['components']['parameters']['test_parameter']
+
+    def test_add_path_passed_path_deprecation_message(self, spec):
+        with pytest.deprecated_call():
+            spec.add_path(Path(path='/pet/{petId}'))
 
 
 class TestPlugins:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -353,6 +353,13 @@ class TestPath:
         with pytest.deprecated_call():
             spec.add_path(Path(path='/pet/{petId}'))
 
+    def test_add_path_check_invalid_http_method(self, spec):
+        spec.add_path('/pet/{petId}', operations={'get': {}})
+        spec.add_path('/pet/{petId}', operations={'x-dummy': {}})
+        with pytest.raises(APISpecError) as excinfo:
+            spec.add_path('/pet/{petId}', operations={'dummy': {}})
+        assert 'One or more HTTP methods are invalid' in str(excinfo)
+
 
 class TestPlugins:
 


### PR DESCRIPTION
Refactoring core.py.

For now, this is (almost) non-breaking.

At this point, `Path` class is almost useless. It is rather a structure than a class. I'm tempted to take this a bit further and remove it. This will be a breaking change.