### PR TITLE
Refactor add_path even more

### DIFF
--- a/apispec/__init__.py
+++ b/apispec/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Contains the main `APISpec` class.
 """
-from .core import APISpec, Path
+from .core import APISpec
 from .plugin import BasePlugin
 
 __version__ = '0.39.0'
@@ -11,6 +11,5 @@ __license__ = 'MIT'
 
 __all__ = [
     'APISpec',
-    'Path',
     'BasePlugin',
 ]

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -219,7 +219,7 @@ class APISpec(object):
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#pathsObject
 
-        :param str|Path|None path: URL Path component or Path instance
+        :param str|None path: URL path component
         :param dict|None operations: describes the http methods and options for `path`
         :param dict kwargs: parameters used by any path helpers see :meth:`register_path_helper`
         """
@@ -230,6 +230,11 @@ class APISpec(object):
             return path
 
         if isinstance(path, Path):
+            warnings.warn(
+                'Passing a Path instance to add_path is deprecated. '
+                'Pass path as string and operations as dict.',
+                DeprecationWarning,
+            )
             path.path = normalize_path(path.path)
             if operations:
                 path.operations.update(operations)

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -68,25 +68,6 @@ def clean_operations(operations, openapi_major_version):
             ]
 
 
-class Path(object):
-    """Represents an OpenAPI Path object.
-
-    https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#pathsObject
-
-    :param str path: The path template, e.g. ``"/pet/{petId}"``
-    :param dict operations: A `dict` mapping methods to operations objects. See
-        https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operationObject
-    """
-    def __init__(self, path=None, operations=None):
-        self.path = path
-        self.operations = operations or OrderedDict()
-
-    def update(self, path):
-        if path.path:
-            self.path = path.path
-        self.operations.update(path.operations)
-
-
 class APISpec(object):
     """Stores metadata that describes a RESTful API using the OpenAPI specification.
 
@@ -217,57 +198,43 @@ class APISpec(object):
                 path = re.sub(pattern, '', path)
             return path
 
-        if isinstance(path, Path):
-            warnings.warn(
-                'Passing a Path instance to add_path is deprecated. '
-                'Pass path as string and operations as dict.',
-                DeprecationWarning,
-            )
-            path.path = normalize_path(path.path)
-            if operations:
-                path.operations.update(operations)
-        else:
-            path = Path(
-                path=normalize_path(path),
-                operations=operations,
-            )
+        path = normalize_path(path)
+        operations = operations or OrderedDict()
 
         # Execute path helpers
         for plugin in self.plugins:
             try:
-                ret = plugin.path_helper(path=path, operations=path.operations, **kwargs)
+                ret = plugin.path_helper(path=path, operations=operations, **kwargs)
             except PluginMethodNotImplementedError:
                 continue
-            if isinstance(ret, Path):
-                ret.path = normalize_path(ret.path)
-                path.update(ret)
+            if ret is not None:
+                path = normalize_path(ret)
         # Deprecated interface
         for func in self._path_helpers:
             try:
                 ret = func(
-                    self, path=path, operations=path.operations, **kwargs
+                    self, path=path, operations=operations, **kwargs
                 )
             except TypeError:
                 continue
-            if isinstance(ret, Path):
-                ret.path = normalize_path(ret.path)
-                path.update(ret)
-        if not path.path:
+            if ret is not None:
+                path = normalize_path(ret)
+        if not path:
             raise APISpecError('Path template is not specified')
 
         # Execute operation helpers
         for plugin in self.plugins:
             try:
-                plugin.operation_helper(path=path, operations=path.operations, **kwargs)
+                plugin.operation_helper(path=path, operations=operations, **kwargs)
             except PluginMethodNotImplementedError:
                 continue
         # Deprecated interface
         for func in self._operation_helpers:
-            func(self, path=path, operations=path.operations, **kwargs)
+            func(self, path=path, operations=operations, **kwargs)
 
         # Execute response helpers
         # TODO: cache response helpers output for each (method, status_code) couple
-        for method, operation in iteritems(path.operations):
+        for method, operation in iteritems(operations):
             if method in VALID_METHODS and 'responses' in operation:
                 for status_code, response in iteritems(operation['responses']):
                     for plugin in self.plugins:
@@ -277,9 +244,9 @@ class APISpec(object):
                             continue
         # Deprecated interface
         # Rule is that method + http status exist in both operations and helpers
-        methods = set(iterkeys(path.operations)) & set(iterkeys(self._response_helpers))
+        methods = set(iterkeys(operations)) & set(iterkeys(self._response_helpers))
         for method in methods:
-            responses = path.operations[method]['responses']
+            responses = operations[method]['responses']
             statuses = set(iterkeys(responses)) & set(iterkeys(self._response_helpers[method]))
             for status_code in statuses:
                 for func in self._response_helpers[method][status_code]:
@@ -287,9 +254,9 @@ class APISpec(object):
                         func(self, **kwargs),
                     )
 
-        clean_operations(path.operations, self.openapi_version.major)
+        clean_operations(operations, self.openapi_version.major)
 
-        self._paths.setdefault(path.path, path.operations).update(path.operations)
+        self._paths.setdefault(path, operations).update(operations)
 
     def definition(
         self, name, properties=None, enum=None, description=None, extra_fields=None,
@@ -393,7 +360,7 @@ class APISpec(object):
 
         - Receive the `APISpec` instance as the first argument.
         - Include ``**kwargs`` in signature.
-        - Return a `apispec.core.Path` object.
+        - Return a path as `str` or `None` and mutates ``operations`` `dict` kwarg.
 
         The helper may define any named arguments in its signature.
         """
@@ -456,4 +423,3 @@ if PY2:
     yaml.add_representer(unicode, YAMLDumper._represent_unicode, Dumper=YAMLDumper)
 yaml.add_representer(OrderedDict, YAMLDumper._represent_dict, Dumper=YAMLDumper)
 yaml.add_representer(LazyDict, YAMLDumper._represent_dict, Dumper=YAMLDumper)
-yaml.add_representer(Path, YAMLDumper._represent_dict, Dumper=YAMLDumper)

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -81,13 +81,6 @@ class Path(object):
                 'One or more HTTP methods are invalid: {0}'.format(', '.join(invalid)),
             )
 
-    def to_dict(self):
-        if not self.path:
-            raise APISpecError('Path template is not specified')
-        return {
-            self.path: self.operations,
-        }
-
     def update(self, path):
         if path.path:
             self.path = path.path

--- a/apispec/ext/bottle.py
+++ b/apispec/ext/bottle.py
@@ -26,7 +26,7 @@ import re
 
 from bottle import default_app
 
-from apispec import Path, BasePlugin, utils
+from apispec import BasePlugin, utils
 from apispec.exceptions import APISpecError
 
 
@@ -53,13 +53,12 @@ class BottlePlugin(BasePlugin):
             raise APISpecError('Could not find endpoint for route {0}'.format(view))
         return endpoint
 
-    def path_helper(self, view, operations, **kwargs):
+    def path_helper(self, operations, view, **kwargs):
         """Path helper that allows passing a bottle view function."""
-        operations = utils.load_operations_from_docstring(view.__doc__)
+        operations.update(utils.load_operations_from_docstring(view.__doc__) or {})
         app = kwargs.get('app', _default_app)
         route = self._route_for_view(app, view)
-        bottle_path = self.bottle_path_to_openapi(route.rule)
-        return Path(path=bottle_path, operations=operations)
+        return self.bottle_path_to_openapi(route.rule)
 
 
 # Deprecated interface

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 
 import marshmallow
 
-from apispec import Path, BasePlugin, utils
+from apispec import BasePlugin, utils
 from .common import resolve_schema_cls, resolve_schema_instance
 from .openapi import OpenAPIConverter
 
@@ -167,7 +167,7 @@ class MarshmallowPlugin(BasePlugin):
 
         return json_schema
 
-    def path_helper(self, view=None, **kwargs):
+    def path_helper(self, operations, view=None, **kwargs):
         """Path helper that allows passing a Schema as a response. Responses can be
         defined in a view's docstring.
         ::
@@ -228,14 +228,8 @@ class MarshmallowPlugin(BasePlugin):
             #                                                    'items': {'$ref': '#/definitions/User'}}}}}}}
 
         """
-        operations = (
-            kwargs.get('operations') or
-            (view and utils.load_operations_from_docstring(view.__doc__))
-        )
-        if not operations:
-            return None
-        operations = operations.copy()
-        return Path(operations=operations)
+        if view:
+            operations.update(utils.load_operations_from_docstring(view.__doc__) or {})
 
     def operation_helper(self, operations, **kwargs):
         for operation in operations.values():

--- a/apispec/plugin.py
+++ b/apispec/plugin.py
@@ -17,11 +17,27 @@ class BasePlugin(object):
         raise PluginMethodNotImplementedError
 
     def path_helper(self, path=None, operations=None, **kwargs):
-        """Should return a Path instance. Any other return value type is ignored"""
+        """May return a path as string and mutate operations dict.
+
+        :param str path: Path to the resource
+        :param dict operations: A `dict` mapping HTTP methods to operation object. See
+            https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operationObject
+
+        Return value should be a string or None. If a string is returned, it
+        is set as the path.
+
+        The last path helper returning a string sets the path value. Therefore,
+        the order of plugin registration matters. However, generally, registering
+        several plugins that return a path does not make sense.
+        """
         raise PluginMethodNotImplementedError
 
     def operation_helper(self, path=None, operations=None, **kwargs):
-        """Should mutate operations. Return value ignored."""
+        """Should mutate operations.
+
+        :param str path: Path to the resource
+        :param dict operations: A `dict` mapping HTTP methods to operation object. See
+        """
         raise PluginMethodNotImplementedError
 
     def response_helper(self, method, status_code, **kwargs):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -318,19 +318,9 @@ class TestPath:
         assert '/pets' in spec._paths
         assert '/v1/pets' not in spec._paths
 
-    def test_add_path_accepts_path(self, spec):
-        route = '/pet/{petId}'
-        route_spec = self.paths[route]
-        path = Path(path=route, operations={'get': route_spec['get']})
-        spec.add_path(path)
-
-        p = spec._paths[path.path]
-        assert p == path.operations
-        assert 'get' in p
-
     def test_add_path_strips_path_base_path(self, spec):
         spec.options['basePath'] = '/v1'
-        path = Path(path='/v1/pets')
+        path = '/v1/pets'
         spec.add_path(path)
         assert '/pets' in spec._paths
         assert '/v1/pets' not in spec._paths
@@ -358,6 +348,10 @@ class TestPath:
         else:
             assert p['parameters'][0] == {'$ref': '#/components/parameters/test_parameter'}
             assert route_spec['parameters'][0] == metadata['components']['parameters']['test_parameter']
+
+    def test_add_path_passed_path_deprecation_message(self, spec):
+        with pytest.deprecated_call():
+            spec.add_path(Path(path='/pet/{petId}'))
 
 
 class TestPlugins:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -353,6 +353,13 @@ class TestPath:
         with pytest.deprecated_call():
             spec.add_path(Path(path='/pet/{petId}'))
 
+    def test_add_path_check_invalid_http_method(self, spec):
+        spec.add_path('/pet/{petId}', operations={'get': {}})
+        spec.add_path('/pet/{petId}', operations={'x-dummy': {}})
+        with pytest.raises(APISpecError) as excinfo:
+            spec.add_path('/pet/{petId}', operations={'dummy': {}})
+        assert 'One or more HTTP methods are invalid' in str(excinfo)
+
 
 class TestPlugins:
 


### PR DESCRIPTION
This is based on https://github.com/marshmallow-code/apispec/pull/237 and goes further. `Path` is removed.

Clearer API (IMHO), and almost no test broken.

Probably not perfect, but I think it is a nice improvement.

@sloria, I'd understand your reluctance to introduce breaking changes. Would it make you feel more comfortable to publish a 1.0 version then break everything in 2.x? I don't mind either way. The breaking changes introduced here are not much worse than those introduced with the class interface. They will break every custom path helper, and possibly some operation helpers, marginally, but the fix is easy. It is not as if it made some feature impossible.