### PR TITLE
Rework documentation of fields default values

### DIFF
--- a/apispec/ext/marshmallow/openapi.py
+++ b/apispec/ext/marshmallow/openapi.py
@@ -319,10 +319,7 @@ class OpenAPIConverter(object):
             ret['format'] = fmt
 
         default = field.missing
-        if default is not marshmallow.missing:
-            if callable(default):
-                ret['default'] = default()
-            else:
+        if default is not marshmallow.missing and not callable(default):
                 ret['default'] = default
 
         for attr_func in (

--- a/apispec/ext/marshmallow/openapi.py
+++ b/apispec/ext/marshmallow/openapi.py
@@ -318,9 +318,12 @@ class OpenAPIConverter(object):
         if fmt:
             ret['format'] = fmt
 
-        default = field.missing
-        if default is not marshmallow.missing and not callable(default):
-                ret['default'] = default
+        if 'doc_default' in field.metadata:
+            ret['default'] = field.metadata['doc_default']
+        else:
+            default = field.missing
+            if default is not marshmallow.missing and not callable(default):
+                    ret['default'] = default
 
         for attr_func in (
                 self.field2choices,

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -51,5 +51,9 @@ class OrderedSchema(Schema):
         ordered = True
 
 
-class DefaultCallableSchema(Schema):
+class DefaultValuesSchema(Schema):
+    number_auto_default = fields.Int(missing=12)
+    number_manual_default = fields.Int(missing=12, doc_default=42)
+    string_callable_default = fields.Str(missing=lambda: 'Callable')
+    string_manual_default = fields.Str(missing=lambda: 'Callable', doc_default='Manual')
     numbers = fields.List(fields.Int, missing=list)

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -779,11 +779,11 @@ class TestFieldWithCustomProps:
         assert result['x-count2'] == 2
 
 
-class TestDefaultCanBeCallable:
-    def test_default_can_be_callable(self, spec):
+class TestDefaultCallableIsIgnored:
+    def test_default_callable_is_ignored(self, spec):
         spec.definition('DefaultCallableSchema', schema=DefaultCallableSchema)
         result = spec._definitions['DefaultCallableSchema']['properties']['numbers']
-        assert result['default'] == []
+        assert 'default' not in result
 
 
 @pytest.mark.skipif(

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -13,7 +13,7 @@ from apispec.ext.marshmallow.openapi import MARSHMALLOW_VERSION_INFO
 from .schemas import (
     PetSchema, AnalysisSchema, SampleSchema, RunSchema,
     SelfReferencingSchema, OrderedSchema, PatternedObjectSchema,
-    DefaultCallableSchema, AnalysisWithListSchema
+    DefaultValuesSchema, AnalysisWithListSchema
 )
 
 
@@ -779,11 +779,15 @@ class TestFieldWithCustomProps:
         assert result['x-count2'] == 2
 
 
-class TestDefaultCallableIsIgnored:
-    def test_default_callable_is_ignored(self, spec):
-        spec.definition('DefaultCallableSchema', schema=DefaultCallableSchema)
-        result = spec._definitions['DefaultCallableSchema']['properties']['numbers']
-        assert 'default' not in result
+class TestSchemaWithDefaultValues:
+    def test_schema_with_default_values(self, spec):
+        spec.definition('DefaultValuesSchema', schema=DefaultValuesSchema)
+        props = spec._definitions['DefaultValuesSchema']['properties']
+        assert props['number_auto_default']['default'] == 12
+        assert props['number_manual_default']['default'] == 42
+        assert 'default' not in props['string_callable_default']
+        assert props['string_manual_default']['default'] == 'Manual'
+        assert 'default' not in props['numbers']
 
 
 @pytest.mark.skipif(

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -95,6 +95,11 @@ class TestMarshmallowFieldToOpenAPI:
         res = openapi.field2property(field, dump=False)
         assert res['default'] is False
 
+    def test_field_with_missing_callable(self, openapi):
+        field = fields.Str(missing=lambda: 'dummy')
+        res = openapi.field2property(field)
+        assert 'default' not in res
+
     def test_fields_with_missing_load(self, openapi):
         field_dict = {'field': fields.Str(default='foo', missing='bar')}
         res = openapi.fields2parameters(field_dict, default_in='query')

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -100,6 +100,16 @@ class TestMarshmallowFieldToOpenAPI:
         res = openapi.field2property(field)
         assert 'default' not in res
 
+    def test_field_with_doc_default(self, openapi):
+        field = fields.Str(doc_default='Manual default')
+        res = openapi.field2property(field)
+        assert res['default'] == 'Manual default'
+
+    def test_field_with_doc_default_and_missing(self, openapi):
+        field = fields.Int(doc_default=42, missing=12)
+        res = openapi.field2property(field)
+        assert res['default'] == 42
+
     def test_fields_with_missing_load(self, openapi):
         field_dict = {'field': fields.Str(default='foo', missing='bar')}
         res = openapi.fields2parameters(field_dict, default_in='query')


### PR DESCRIPTION
Closes #196.

I couldn't come up with a better name than `doc_default`.