### PR TITLE
Make yaml features optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,8 @@ Features:
   and optionally mutate the `operations` dictionary (:pr:`238`).
 - [apispec.core]: *Backwards-incompatible*: YAML support is optional. To
   install with YAML support, use ``pip install 'apispec[yaml]'``. You
-  will need to do this if you use the ``apispec.ext.flask`` or
-  ``apispec.ext.tornado`` plugins.
+  will need to do this if you use ``FlaskPlugin``,
+  ``BottlePlugin``, or ``TornadoPlugin``.
 - [apispec.ext.marshmallow]: Allow overriding the documentation for
   a field's default. This is especially useful for documenting
   callable defaults (:issue:`196`).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Features:
 - [apispec.core]: *Backwards-incompatible*: Remove `Path` class.
   Plugins' `path_helper` methods should now return a path as a string
   and optionally mutate the `operations` dictionary (:pr:`238`).
+- [apispec.core]: *Backwards-incompatible*: YAML support is optional. To
+  install with YAML support, use ``pip install 'apispec[yaml]'``. You
+  will need to do this if you use the ``apispec.ext.flask`` or
+  ``apispec.ext.tornado`` plugins.
 
 0.39.0 (2018-06-28)
 +++++++++++++++++++

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -159,6 +159,8 @@ class APISpec(object):
         return ret
 
     def to_yaml(self):
+        """Render the spec to YAML. Requires PyYAML to be installed.
+        """
         from .yaml_utils import dict_to_yaml
         return dict_to_yaml(self.to_dict())
 

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -5,10 +5,7 @@ import warnings
 from collections import OrderedDict
 import copy
 
-import yaml
-
-from apispec.compat import iterkeys, iteritems, PY2, unicode
-from apispec.lazy_dict import LazyDict
+from apispec.compat import iterkeys, iteritems
 from .exceptions import PluginError, APISpecError, PluginMethodNotImplementedError
 from .utils import OpenAPIVersion
 
@@ -162,7 +159,8 @@ class APISpec(object):
         return ret
 
     def to_yaml(self):
-        return yaml.dump(self.to_dict(), Dumper=YAMLDumper)
+        from .yaml_utils import dict_to_yaml
+        return dict_to_yaml(self.to_dict())
 
     def add_parameter(self, param_id, location, **kwargs):
         """ Add a parameter which can be referenced.
@@ -405,21 +403,3 @@ class APISpec(object):
         if method not in self._response_helpers:
             self._response_helpers[method] = {}
         self._response_helpers[method].setdefault(status_code, []).append(func)
-
-
-class YAMLDumper(yaml.Dumper):
-
-    @staticmethod
-    def _represent_dict(dumper, instance):
-        return dumper.represent_mapping('tag:yaml.org,2002:map', instance.items())
-
-    if PY2:
-        @staticmethod
-        def _represent_unicode(_, uni):
-            return yaml.ScalarNode(tag=u'tag:yaml.org,2002:str', value=uni)
-
-
-if PY2:
-    yaml.add_representer(unicode, YAMLDumper._represent_unicode, Dumper=YAMLDumper)
-yaml.add_representer(OrderedDict, YAMLDumper._represent_dict, Dumper=YAMLDumper)
-yaml.add_representer(LazyDict, YAMLDumper._represent_dict, Dumper=YAMLDumper)

--- a/apispec/ext/bottle.py
+++ b/apispec/ext/bottle.py
@@ -26,7 +26,7 @@ import re
 
 from bottle import default_app
 
-from apispec import BasePlugin, utils
+from apispec import BasePlugin, yaml_utils
 from apispec.exceptions import APISpecError
 
 
@@ -55,7 +55,7 @@ class BottlePlugin(BasePlugin):
 
     def path_helper(self, operations, view, **kwargs):
         """Path helper that allows passing a bottle view function."""
-        operations.update(utils.load_operations_from_docstring(view.__doc__) or {})
+        operations.update(yaml_utils.load_operations_from_docstring(view.__doc__) or {})
         app = kwargs.get('app', _default_app)
         route = self._route_for_view(app, view)
         return self.bottle_path_to_openapi(route.rule)

--- a/apispec/ext/bottle.py
+++ b/apispec/ext/bottle.py
@@ -55,7 +55,7 @@ class BottlePlugin(BasePlugin):
 
     def path_helper(self, operations, view, **kwargs):
         """Path helper that allows passing a bottle view function."""
-        operations.update(yaml_utils.load_operations_from_docstring(view.__doc__) or {})
+        operations.update(yaml_utils.load_operations_from_docstring(view.__doc__))
         app = kwargs.get('app', _default_app)
         route = self._route_for_view(app, view)
         return self.bottle_path_to_openapi(route.rule)

--- a/apispec/ext/flask.py
+++ b/apispec/ext/flask.py
@@ -75,7 +75,7 @@ from flask import current_app
 from flask.views import MethodView
 
 from apispec.compat import iteritems
-from apispec import BasePlugin, utils
+from apispec import BasePlugin, yaml_utils
 from apispec.exceptions import APISpecError
 
 
@@ -111,13 +111,13 @@ class FlaskPlugin(BasePlugin):
     def path_helper(self, operations, view, **kwargs):
         """Path helper that allows passing a Flask view function."""
         rule = self._rule_for_view(view)
-        operations.update(utils.load_operations_from_docstring(view.__doc__) or {})
+        operations.update(yaml_utils.load_operations_from_docstring(view.__doc__) or {})
         if hasattr(view, 'view_class') and issubclass(view.view_class, MethodView):
             for method in view.methods:
                 if method in rule.methods:
                     method_name = method.lower()
                     method = getattr(view.view_class, method_name)
-                    docstring_yaml = utils.load_yaml_from_docstring(method.__doc__)
+                    docstring_yaml = yaml_utils.load_yaml_from_docstring(method.__doc__)
                     operations[method_name] = docstring_yaml or dict()
         path = self.flaskpath2openapi(rule.rule)
         app_root = current_app.config['APPLICATION_ROOT'] or '/'

--- a/apispec/ext/flask.py
+++ b/apispec/ext/flask.py
@@ -111,14 +111,13 @@ class FlaskPlugin(BasePlugin):
     def path_helper(self, operations, view, **kwargs):
         """Path helper that allows passing a Flask view function."""
         rule = self._rule_for_view(view)
-        operations.update(yaml_utils.load_operations_from_docstring(view.__doc__) or {})
+        operations.update(yaml_utils.load_operations_from_docstring(view.__doc__))
         if hasattr(view, 'view_class') and issubclass(view.view_class, MethodView):
             for method in view.methods:
                 if method in rule.methods:
                     method_name = method.lower()
                     method = getattr(view.view_class, method_name)
-                    docstring_yaml = yaml_utils.load_yaml_from_docstring(method.__doc__)
-                    operations[method_name] = docstring_yaml or dict()
+                    operations[method_name] = yaml_utils.load_yaml_from_docstring(method.__doc__)
         path = self.flaskpath2openapi(rule.rule)
         app_root = current_app.config['APPLICATION_ROOT'] or '/'
         return urljoin(app_root.rstrip('/') + '/', path.lstrip('/'))

--- a/apispec/ext/tornado.py
+++ b/apispec/ext/tornado.py
@@ -87,8 +87,7 @@ class TornadoPlugin(BasePlugin):
         :param handler_class:
         :type handler_class: RequestHandler descendant
         """
-        extensions = yaml_utils.load_yaml_from_docstring(handler_class.__doc__) or {}
-        return extensions
+        return yaml_utils.load_yaml_from_docstring(handler_class.__doc__)
 
     def path_helper(self, operations, urlspec, **kwargs):
         """Path helper that allows passing a Tornado URLSpec or tuple."""

--- a/apispec/ext/tornado.py
+++ b/apispec/ext/tornado.py
@@ -34,7 +34,7 @@ import inspect
 import sys
 from tornado.web import URLSpec
 
-from apispec import BasePlugin, utils
+from apispec import BasePlugin, yaml_utils
 from apispec.exceptions import APISpecError
 
 
@@ -48,9 +48,9 @@ class TornadoPlugin(BasePlugin):
         :param handler_class:
         :type handler_class: RequestHandler descendant
         """
-        for httpmethod in utils.PATH_KEYS:
+        for httpmethod in yaml_utils.PATH_KEYS:
             method = getattr(handler_class, httpmethod)
-            operation_data = utils.load_yaml_from_docstring(method.__doc__)
+            operation_data = yaml_utils.load_yaml_from_docstring(method.__doc__)
             if operation_data:
                 operation = {httpmethod: operation_data}
                 yield operation
@@ -87,7 +87,7 @@ class TornadoPlugin(BasePlugin):
         :param handler_class:
         :type handler_class: RequestHandler descendant
         """
-        extensions = utils.load_yaml_from_docstring(handler_class.__doc__) or {}
+        extensions = yaml_utils.load_yaml_from_docstring(handler_class.__doc__) or {}
         return extensions
 
     def path_helper(self, operations, urlspec, **kwargs):

--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -2,90 +2,12 @@
 """Various utilities for parsing OpenAPI operations from docstrings and validating against
 the OpenAPI spec.
 """
-import re
 import json
 import warnings
 
 from distutils import version
 
-import yaml
-
-from apispec.compat import iteritems
 from apispec import exceptions
-
-# from django.contrib.admindocs.utils
-def trim_docstring(docstring):
-    """Uniformly trims leading/trailing whitespace from docstrings.
-
-    Based on http://www.python.org/peps/pep-0257.html#handling-docstring-indentation
-    """
-    if not docstring or not docstring.strip():
-        return ''
-    # Convert tabs to spaces and split into lines
-    lines = docstring.expandtabs().splitlines()
-    indent = min(len(line) - len(line.lstrip()) for line in lines if line.lstrip())
-    trimmed = [lines[0].lstrip()] + [line[indent:].rstrip() for line in lines[1:]]
-    return '\n'.join(trimmed).strip()
-
-# from rest_framework.utils.formatting
-def dedent(content):
-    """
-    Remove leading indent from a block of text.
-    Used when generating descriptions from docstrings.
-    Note that python's `textwrap.dedent` doesn't quite cut it,
-    as it fails to dedent multiline docstrings that include
-    unindented text on the initial line.
-    """
-    whitespace_counts = [len(line) - len(line.lstrip(' '))
-                         for line in content.splitlines()[1:] if line.lstrip()]
-
-    # unindent the content if needed
-    if whitespace_counts:
-        whitespace_pattern = '^' + (' ' * min(whitespace_counts))
-        content = re.sub(re.compile(whitespace_pattern, re.MULTILINE), '', content)
-
-    return content.strip()
-
-def load_yaml_from_docstring(docstring):
-    """Loads YAML from docstring."""
-    split_lines = trim_docstring(docstring).split('\n')
-
-    # Cut YAML from rest of docstring
-    for index, line in enumerate(split_lines):
-        line = line.strip()
-        if line.startswith('---'):
-            cut_from = index
-            break
-    else:
-        return None
-
-    yaml_string = '\n'.join(split_lines[cut_from:])
-    yaml_string = dedent(yaml_string)
-    return yaml.load(yaml_string)
-
-
-PATH_KEYS = set([
-    'get',
-    'put',
-    'post',
-    'delete',
-    'options',
-    'head',
-    'patch',
-])
-
-def load_operations_from_docstring(docstring):
-    """Return a dictionary of OpenAPI operations parsed from a
-    a docstring.
-    """
-    doc_data = load_yaml_from_docstring(docstring)
-    if doc_data:
-        return {
-            key: val for key, val in iteritems(doc_data)
-            if key in PATH_KEYS or key.startswith('x-')
-        }
-    else:
-        return None
 
 def validate_spec(spec):
     """Validate the output of an :class:`APISpec` object against the

--- a/apispec/yaml_utils.py
+++ b/apispec/yaml_utils.py
@@ -75,11 +75,11 @@ def load_yaml_from_docstring(docstring):
             cut_from = index
             break
     else:
-        return None
+        return {}
 
     yaml_string = '\n'.join(split_lines[cut_from:])
     yaml_string = dedent(yaml_string)
-    return yaml.load(yaml_string)
+    return yaml.load(yaml_string) or {}
 
 
 PATH_KEYS = set([
@@ -97,10 +97,7 @@ def load_operations_from_docstring(docstring):
     a docstring.
     """
     doc_data = load_yaml_from_docstring(docstring)
-    if doc_data:
-        return {
-            key: val for key, val in iteritems(doc_data)
-            if key in PATH_KEYS or key.startswith('x-')
-        }
-    else:
-        return None
+    return {
+        key: val for key, val in iteritems(doc_data)
+        if key in PATH_KEYS or key.startswith('x-')
+    }

--- a/apispec/yaml_utils.py
+++ b/apispec/yaml_utils.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+"""YAML utilities"""
+
+from collections import OrderedDict
+import re
+import yaml
+
+from apispec.lazy_dict import LazyDict
+from apispec.compat import PY2, unicode, iteritems
+
+
+class YAMLDumper(yaml.Dumper):
+
+    @staticmethod
+    def _represent_dict(dumper, instance):
+        return dumper.represent_mapping('tag:yaml.org,2002:map', instance.items())
+
+    if PY2:
+        @staticmethod
+        def _represent_unicode(_, uni):
+            return yaml.ScalarNode(tag=u'tag:yaml.org,2002:str', value=uni)
+
+
+if PY2:
+    yaml.add_representer(unicode, YAMLDumper._represent_unicode, Dumper=YAMLDumper)
+yaml.add_representer(OrderedDict, YAMLDumper._represent_dict, Dumper=YAMLDumper)
+yaml.add_representer(LazyDict, YAMLDumper._represent_dict, Dumper=YAMLDumper)
+
+
+def dict_to_yaml(dic):
+    return yaml.dump(dic, Dumper=YAMLDumper)
+
+
+# from django.contrib.admindocs.utils
+def trim_docstring(docstring):
+    """Uniformly trims leading/trailing whitespace from docstrings.
+
+    Based on http://www.python.org/peps/pep-0257.html#handling-docstring-indentation
+    """
+    if not docstring or not docstring.strip():
+        return ''
+    # Convert tabs to spaces and split into lines
+    lines = docstring.expandtabs().splitlines()
+    indent = min(len(line) - len(line.lstrip()) for line in lines if line.lstrip())
+    trimmed = [lines[0].lstrip()] + [line[indent:].rstrip() for line in lines[1:]]
+    return '\n'.join(trimmed).strip()
+
+# from rest_framework.utils.formatting
+def dedent(content):
+    """
+    Remove leading indent from a block of text.
+    Used when generating descriptions from docstrings.
+    Note that python's `textwrap.dedent` doesn't quite cut it,
+    as it fails to dedent multiline docstrings that include
+    unindented text on the initial line.
+    """
+    whitespace_counts = [len(line) - len(line.lstrip(' '))
+                         for line in content.splitlines()[1:] if line.lstrip()]
+
+    # unindent the content if needed
+    if whitespace_counts:
+        whitespace_pattern = '^' + (' ' * min(whitespace_counts))
+        content = re.sub(re.compile(whitespace_pattern, re.MULTILINE), '', content)
+
+    return content.strip()
+
+def load_yaml_from_docstring(docstring):
+    """Loads YAML from docstring."""
+    split_lines = trim_docstring(docstring).split('\n')
+
+    # Cut YAML from rest of docstring
+    for index, line in enumerate(split_lines):
+        line = line.strip()
+        if line.startswith('---'):
+            cut_from = index
+            break
+    else:
+        return None
+
+    yaml_string = '\n'.join(split_lines[cut_from:])
+    yaml_string = dedent(yaml_string)
+    return yaml.load(yaml_string)
+
+
+PATH_KEYS = set([
+    'get',
+    'put',
+    'post',
+    'delete',
+    'options',
+    'head',
+    'patch',
+])
+
+def load_operations_from_docstring(docstring):
+    """Return a dictionary of OpenAPI operations parsed from a
+    a docstring.
+    """
+    doc_data = load_yaml_from_docstring(docstring)
+    if doc_data:
+        return {
+            key: val for key, val in iteritems(doc_data)
+            if key in PATH_KEYS or key.startswith('x-')
+        }
+    else:
+        return None

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 invoke==1.1.0
-pyyaml==3.13  # pyup: <4.0
 
 # Syntax checking
 flake8==3.5.0
@@ -9,6 +8,7 @@ Flask==1.0.2
 marshmallow==2.15.3
 tornado==5.1
 bottle==0.12.13
+pyyaml==3.13  # pyup: <4.0
 
 # testing
 pytest==3.6.3

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,6 +13,20 @@ To install the latest version from the PyPI:
    pip install -U apispec
 
 
+To install with validation support:
+
+
+::
+
+   pip install -U 'apispec[validation]'
+
+To install with YAML support:
+
+::
+
+   pip install -U 'apispec[yaml]'
+
+
 Get the Bleeding Edge Version
 -----------------------------
 
@@ -20,4 +34,4 @@ To install the latest development version:
 
 ::
 
-    $ pip install -U git+https://github.com/marshmallow-code/apispec@dev
+    pip install -U git+https://github.com/marshmallow-code/apispec@dev

--- a/docs/special_topics.rst
+++ b/docs/special_topics.rst
@@ -33,6 +33,13 @@ YAML
     spec.to_yaml()
 
 
+.. note::
+    `to_yaml <apispec.APISpec.to_yaml>` requires `PyYAML` to be installed. You can install
+    apispec with YAML support using: ::
+
+        pip install 'apispec[yaml]'
+
+
 JSON
 ++++
 

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,6 @@ import re
 from setuptools import setup, find_packages
 
 
-REQUIRES = [
-    'PyYAML>=3.10',
-]
-
-
 def find_version(fname):
     """Attempts to find the version number in the file names fname.
     Raises RuntimeError if not found.
@@ -46,8 +41,10 @@ setup(
     packages=find_packages(exclude=('test*', )),
     package_dir={'apispec': 'apispec'},
     include_package_data=True,
-    install_requires=REQUIRES,
     extras_require={
+        'yaml': [
+            'PyYAML>=3.10',
+        ],
         'validation': [
             'prance[osv]>=0.11',
         ],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,20 +4,6 @@ import pytest
 from apispec import utils, APISpec
 from apispec.exceptions import APISpecError
 
-def test_load_yaml_from_docstring():
-    def f():
-        """
-        Foo
-            bar
-            baz quux
-
-        ---
-        herp: 1
-        derp: 2
-        """
-    result = utils.load_yaml_from_docstring(f.__doc__)
-    assert result == {'herp': 1, 'derp': 2}
-
 def test_validate_swagger_is_deprecated():
     spec = APISpec(
         title='Pets',

--- a/tests/test_yaml_utils.py
+++ b/tests/test_yaml_utils.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from apispec import yaml_utils
+
+def test_load_yaml_from_docstring():
+    def f():
+        """
+        Foo
+            bar
+            baz quux
+
+        ---
+        herp: 1
+        derp: 2
+        """
+    result = yaml_utils.load_yaml_from_docstring(f.__doc__)
+    assert result == {'herp': 1, 'derp': 2}

--- a/tests/test_yaml_utils.py
+++ b/tests/test_yaml_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pytest
 from apispec import yaml_utils
 
 def test_load_yaml_from_docstring():
@@ -14,3 +15,11 @@ def test_load_yaml_from_docstring():
         """
     result = yaml_utils.load_yaml_from_docstring(f.__doc__)
     assert result == {'herp': 1, 'derp': 2}
+
+@pytest.mark.parametrize('docstring', (None, '', '---'))
+def test_load_yaml_from_docstring_empty_docstring(docstring):
+    assert yaml_utils.load_yaml_from_docstring(docstring) == {}
+
+@pytest.mark.parametrize('docstring', (None, '', '---'))
+def test_load_operations_from_docstring_empty_docstring(docstring):
+    assert yaml_utils.load_operations_from_docstring(docstring) == {}


### PR DESCRIPTION
Addresses part of #246.

TODO:

- [x] Update docs
- [x] Update changelog


Points to check:

setup.py: I added `'yaml'` in `extra_requires`

In `APISpec` class, yaml stuff is imported when calling `to_yaml` and `ImportError` is not caught:

```python
    def to_yaml(self):
        from .yaml_utils import dict_to_yaml
        return dict_to_yaml(self.to_dict())
```