### PR TITLE
Rework plugin order tests

### DIFF
--- a/tests/test_ext_combination.py
+++ b/tests/test_ext_combination.py
@@ -9,33 +9,28 @@ from apispec.ext.flask import FlaskPlugin
 from apispec.ext.tornado import TornadoPlugin
 from apispec.ext.marshmallow import MarshmallowPlugin
 
-def create_spec(plugins):
-    return APISpec(
+
+def check_web_framework_and_marshmallow_plugin(web_framework_plugin, **kwargs_for_add_path):
+    """Check schemas passed in web framework view function docstring are parsed by MarshmallowPlugin"""
+    spec = APISpec(
         title='Swagger Petstore',
         version='1.0.0',
-        description='This is a sample Petstore server.  You can find out more '
-        'about Swagger at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> '
-        'or on irc.freenode.net, #swagger.  For this sample, you can use the api '
-        'key \"special-key\" to test the authorization filters',
-        plugins=plugins,
+        plugins=[web_framework_plugin(), MarshmallowPlugin()],
+        openapi_version='2.0',
     )
+    spec.add_path(**kwargs_for_add_path)
+    expected = {
+        'type': 'object',
+        'properties': {
+            'id': {'type': 'integer', 'format': 'int32', 'description': 'Pet id', 'readOnly': True},
+            'name': {'type': 'string', 'description': 'Pet name'},
+        },
+        'required': ['name'],
+    }
+    assert spec.to_dict()['paths']['/hello']['get']['responses'][200]['schema'] == expected
 
-def confirm_ext_order_independency(web_framework_plugin, **kwargs_for_add_path):
-    extensions = [web_framework_plugin(), MarshmallowPlugin()]
-    specs = []
-    for reverse in (False, True):
-        if reverse:
-            spec = create_spec(reversed(extensions))
-        else:
-            spec = create_spec(extensions)
-        spec.add_path(**kwargs_for_add_path)
-        get_op = spec._paths['/hello']['get']
-        assert get_op['description'] == 'get a greeting'
-        assert isinstance(get_op['responses'][200]['schema'], dict)
-        specs.append(spec)
-    assert specs[0].to_dict() == specs[1].to_dict()
 
-class TestExtOrder:
+class TestWebFrameworkAndMarshmallowPlugin:
     def test_bottle(self):
         @route('/hello')
         def hello():
@@ -43,15 +38,13 @@ class TestExtOrder:
 
             ---
             get:
-                description: get a greeting
                 responses:
                     200:
-                        description: a pet to be returned
                         schema: tests.schemas.PetSchema
             """
             return 'hi'
 
-        confirm_ext_order_independency(BottlePlugin, view=hello)
+        check_web_framework_and_marshmallow_plugin(BottlePlugin, view=hello)
 
     def test_flask(self):
         app = Flask(__name__)
@@ -62,16 +55,14 @@ class TestExtOrder:
 
             ---
             get:
-                description: get a greeting
                 responses:
                     200:
-                        description: a pet to be returned
                         schema: tests.schemas.PetSchema
             """
             return 'hi'
 
         with app.test_request_context():
-            confirm_ext_order_independency(FlaskPlugin, view=hello)
+            check_web_framework_and_marshmallow_plugin(FlaskPlugin, view=hello)
 
     def test_flask_method_view(self):
         app = Flask(__name__)
@@ -81,10 +72,8 @@ class TestExtOrder:
                 """A greeting endpoint.
 
                 ---
-                description: get a greeting
                 responses:
                     200:
-                        description: a pet to be returned
                         schema: tests.schemas.PetSchema
                 """
                 return 'hi'
@@ -92,7 +81,7 @@ class TestExtOrder:
         method_view = HelloApi.as_view('hi')
         app.add_url_rule('/hello', view_func=method_view)
         with app.test_request_context():
-            confirm_ext_order_independency(FlaskPlugin, view=method_view)
+            check_web_framework_and_marshmallow_plugin(FlaskPlugin, view=method_view)
 
     def test_tornado(self):
         class TornadoHelloHandler(RequestHandler):
@@ -100,13 +89,11 @@ class TestExtOrder:
                 """A greeting endpoint.
 
                 ---
-                description: get a greeting
                 responses:
                     200:
-                        description: a pet to be returned
                         schema: tests.schemas.PetSchema
                 """
                 self_.write('hi')
 
         urlspec = (r'/hello', TornadoHelloHandler)
-        confirm_ext_order_independency(TornadoPlugin, urlspec=urlspec)
+        check_web_framework_and_marshmallow_plugin(TornadoPlugin, urlspec=urlspec)


### PR DESCRIPTION
See discussions in https://github.com/marshmallow-code/apispec/issues/246 and https://github.com/marshmallow-code/apispec/pull/249.

- Add tests to show helpers execution order
- Don't test plugin order independency but still test web framework + `MarshmallowPlugin` combination (Note that this test is OpenAPI v2 only. Doing it for v3 would need the docstrings to be written for v3 too.)

