### PR TITLE
Get generic docstring utils back from yaml_utils.py to utils.py

### DIFF
--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -2,6 +2,7 @@
 """Various utilities for parsing OpenAPI operations from docstrings and validating against
 the OpenAPI spec.
 """
+import re
 import json
 import warnings
 
@@ -91,3 +92,36 @@ class OpenAPIVersion(version.LooseVersion, object):
     @property
     def patch(self):
         return self.version[2]
+
+# from django.contrib.admindocs.utils
+def trim_docstring(docstring):
+    """Uniformly trims leading/trailing whitespace from docstrings.
+
+    Based on http://www.python.org/peps/pep-0257.html#handling-docstring-indentation
+    """
+    if not docstring or not docstring.strip():
+        return ''
+    # Convert tabs to spaces and split into lines
+    lines = docstring.expandtabs().splitlines()
+    indent = min(len(line) - len(line.lstrip()) for line in lines if line.lstrip())
+    trimmed = [lines[0].lstrip()] + [line[indent:].rstrip() for line in lines[1:]]
+    return '\n'.join(trimmed).strip()
+
+# from rest_framework.utils.formatting
+def dedent(content):
+    """
+    Remove leading indent from a block of text.
+    Used when generating descriptions from docstrings.
+    Note that python's `textwrap.dedent` doesn't quite cut it,
+    as it fails to dedent multiline docstrings that include
+    unindented text on the initial line.
+    """
+    whitespace_counts = [len(line) - len(line.lstrip(' '))
+                         for line in content.splitlines()[1:] if line.lstrip()]
+
+    # unindent the content if needed
+    if whitespace_counts:
+        whitespace_pattern = '^' + (' ' * min(whitespace_counts))
+        content = re.sub(re.compile(whitespace_pattern, re.MULTILINE), '', content)
+
+    return content.strip()

--- a/apispec/yaml_utils.py
+++ b/apispec/yaml_utils.py
@@ -2,11 +2,11 @@
 """YAML utilities"""
 
 from collections import OrderedDict
-import re
 import yaml
 
 from apispec.lazy_dict import LazyDict
 from apispec.compat import PY2, unicode, iteritems
+from apispec.utils import trim_docstring, dedent
 
 
 class YAMLDumper(yaml.Dumper):
@@ -30,39 +30,6 @@ yaml.add_representer(LazyDict, YAMLDumper._represent_dict, Dumper=YAMLDumper)
 def dict_to_yaml(dic):
     return yaml.dump(dic, Dumper=YAMLDumper)
 
-
-# from django.contrib.admindocs.utils
-def trim_docstring(docstring):
-    """Uniformly trims leading/trailing whitespace from docstrings.
-
-    Based on http://www.python.org/peps/pep-0257.html#handling-docstring-indentation
-    """
-    if not docstring or not docstring.strip():
-        return ''
-    # Convert tabs to spaces and split into lines
-    lines = docstring.expandtabs().splitlines()
-    indent = min(len(line) - len(line.lstrip()) for line in lines if line.lstrip())
-    trimmed = [lines[0].lstrip()] + [line[indent:].rstrip() for line in lines[1:]]
-    return '\n'.join(trimmed).strip()
-
-# from rest_framework.utils.formatting
-def dedent(content):
-    """
-    Remove leading indent from a block of text.
-    Used when generating descriptions from docstrings.
-    Note that python's `textwrap.dedent` doesn't quite cut it,
-    as it fails to dedent multiline docstrings that include
-    unindented text on the initial line.
-    """
-    whitespace_counts = [len(line) - len(line.lstrip(' '))
-                         for line in content.splitlines()[1:] if line.lstrip()]
-
-    # unindent the content if needed
-    if whitespace_counts:
-        whitespace_pattern = '^' + (' ' * min(whitespace_counts))
-        content = re.sub(re.compile(whitespace_pattern, re.MULTILINE), '', content)
-
-    return content.strip()
 
 def load_yaml_from_docstring(docstring):
     """Loads YAML from docstring."""


### PR DESCRIPTION
There was no need to move those to yaml_utils.py are they have no yaml dependency.