### PR TITLE
Use `yaml.safe_load()` instead of `load()`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,3 +51,4 @@ Contributors (chronological)
 - Christina Long `@cvlong <https://github.com/cvlong>`_
 - Felix Yan `@felixonmars <https://github.com/felixonmars>`_
 - Guoli Lyu `@Guoli-Lyu <https://github.com/Guoli-Lyu>`_
+- Laura Beaufort `@lbeaufort <https://github.com/lbeaufort>`_

--- a/apispec/yaml_utils.py
+++ b/apispec/yaml_utils.py
@@ -46,7 +46,7 @@ def load_yaml_from_docstring(docstring):
 
     yaml_string = '\n'.join(split_lines[cut_from:])
     yaml_string = dedent(yaml_string)
-    return yaml.load(yaml_string) or {}
+    return yaml.safe_load(yaml_string) or {}
 
 
 PATH_KEYS = set([

--- a/docs/special_topics.rst
+++ b/docs/special_topics.rst
@@ -87,7 +87,7 @@ Here is an example that includes a `Security Scheme Object <https://github.com/O
           bearerFormat: JWT
     """
 
-    settings = yaml.load(OPENAPI_SPEC)
+    settings = yaml.safe_load(OPENAPI_SPEC)
     # retrieve  title, version, and openapi version
     title = settings['info'].pop('title')
     spec_version = settings['info'].pop('version')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -163,7 +163,7 @@ class TestDefinitions:
             properties=self.properties,
             enum=enum,
         )
-        assert spec.to_dict() == yaml.load(spec.to_yaml())
+        assert spec.to_dict() == yaml.safe_load(spec.to_yaml())
 
 class TestPath:
     paths = {


### PR DESCRIPTION
Resolves #278

Use `yaml.safe_load()` instead of `load()`. `load()` has known security issues: yaml/pyyaml#189. Tests pass with `invoke test` - please let me know if you'd like me to make any more changes. I wasn't sure if I should add myself to `AUTHORS.rst`.

Thanks!
Laura

cc: @sloria and @lafrech 