### PR TITLE
Rework APISpec signature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+1.0.0b3 (unreleased)
+++++++++++++++++++++
+
+Features:
+
+- [apispec.core]: *Backwards-incompatible*: ``openapi_version`` parameter of
+  ``APISpec`` class does not default to `'2.0'` anymore and ``info`` parameter
+  is merged with ``**options`` kwargs.
+
 1.0.0b2 (2018-09-09)
 ++++++++++++++++++++
 

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -78,15 +78,11 @@ class APISpec(object):
     def __init__(
         self, title, version, plugins=(), openapi_version='2.0', **options
     ):
-        self.info = {
-            'title': title,
-            'version': version,
-        }
-        self.info.update(options.pop('info', {}))
-
+        self.title = title
+        self.version = version
         self.openapi_version = OpenAPIVersion(openapi_version)
-
         self.options = options
+
         # Metadata
         self._definitions = {}
         self._parameters = {}
@@ -100,7 +96,6 @@ class APISpec(object):
 
     def to_dict(self):
         ret = {
-            'info': self.info,
             'paths': self._paths,
             'tags': self._tags,
         }
@@ -119,6 +114,11 @@ class APISpec(object):
             components = ret.setdefault('components', {})
             components.setdefault('schemas', {}).update(self._definitions)
             components.setdefault('parameters', {}).update(self._parameters)
+
+        # Add title and version unless those were provided in options['info']
+        info = ret.setdefault('info', {})
+        info.setdefault('title', self.title)
+        info.setdefault('version', self.version)
 
         return ret
 

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -69,7 +69,6 @@ class APISpec(object):
     :param str title: API title
     :param str version: API version
     :param list|tuple plugins: Plugin instances.
-    :param dict info: Optional dict to add to `info`
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#infoObject
     :param str|OpenAPIVersion openapi_version: The OpenAPI version to use.
         Should be in the form '2.x' or '3.x.x' to comply with the OpenAPI standard.
@@ -77,13 +76,13 @@ class APISpec(object):
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object
     """
     def __init__(
-        self, title, version, plugins=(), info=None, openapi_version='2.0', **options
+        self, title, version, plugins=(), openapi_version='2.0', **options
     ):
         self.info = {
             'title': title,
             'version': version,
         }
-        self.info.update(info or {})
+        self.info.update(options.pop('info', {}))
 
         self.openapi_version = OpenAPIVersion(openapi_version)
 

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -75,9 +75,7 @@ class APISpec(object):
     :param dict options: Optional top-level keys
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object
     """
-    def __init__(
-        self, title, version, plugins=(), openapi_version='2.0', **options
-    ):
+    def __init__(self, title, version, openapi_version, plugins=(), **options):
         self.title = title
         self.version = version
         self.openapi_version = OpenAPIVersion(openapi_version)

--- a/docs/writing_plugins.rst
+++ b/docs/writing_plugins.rst
@@ -87,6 +87,7 @@ To use the plugin:
     spec = APISpec(
         title='Gisty',
         version='1.0.0',
+        openapi_version='2.0',
         plugins=[Docplugin()]
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@ def spec_fixture(request):
     spec = APISpec(
         title='Validation',
         version='0.1',
-        plugins=(ma_plugin, ),
         openapi_version=request.param,
+        plugins=(ma_plugin, ),
     )
     return namedtuple(
         'Spec', ('spec', 'marshmallow_plugin', 'openapi'),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,8 +44,8 @@ def spec(request):
     return APISpec(
         title='Swagger Petstore',
         version='1.0.0',
-        info={'description': description},
         openapi_version=openapi_version,
+        info={'description': description},
         **security_kwargs
     )
 
@@ -57,9 +57,9 @@ class TestAPISpecInit:
             APISpec(
                 'Swagger Petstore',
                 version='1.0.0',
+                openapi_version='4.0',  # 4.0 is not supported
                 info={'description': description},
                 security=[{'apiKey': []}],
-                openapi_version='4.0',  # 4.0 is not supported
             )
         assert 'Not a valid OpenAPI version number:' in str(excinfo)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -362,6 +362,7 @@ class TestPlugins:
         spec = APISpec(
             title='Swagger Petstore',
             version='1.0.0',
+            openapi_version='3.0.0',
             plugins=(self.TestPlugin(), ),
         )
         spec.definition('Pet', {})
@@ -371,6 +372,7 @@ class TestPlugins:
         spec = APISpec(
             title='Swagger Petstore',
             version='1.0.0',
+            openapi_version='3.0.0',
             plugins=(self.TestPlugin(), ),
         )
         spec.add_path('/path_1')
@@ -381,6 +383,7 @@ class TestPlugins:
         spec = APISpec(
             title='Swagger Petstore',
             version='1.0.0',
+            openapi_version='3.0.0',
             plugins=(self.TestPlugin(), ),
         )
         spec.add_path('/path_2', operations={'post': {'responses': {'200': {}}}})
@@ -391,6 +394,7 @@ class TestPlugins:
         spec = APISpec(
             title='Swagger Petstore',
             version='1.0.0',
+            openapi_version='3.0.0',
             plugins=(self.TestPlugin(), ),
         )
         spec.add_path('/path_3', operations={'delete': {'responses': {'204': {'content': {}}}}})
@@ -428,6 +432,7 @@ class TestPluginsOrder:
         spec = APISpec(
             title='Swagger Petstore',
             version='1.0.0',
+            openapi_version='3.0.0',
             plugins=(self.OrderedPlugin(1, output), self.OrderedPlugin(2, output)),
         )
         spec.add_path('/path', operations={'get': {'responses': {200: {}}}})

--- a/tests/test_ext_bottle.py
+++ b/tests/test_ext_bottle.py
@@ -2,19 +2,17 @@
 import pytest
 
 from bottle import route
+
 from apispec import APISpec
 from apispec.ext.bottle import BottlePlugin
 
 
-@pytest.fixture
+@pytest.fixture(params=('2.0', '3.0.0'))
 def spec(request):
     return APISpec(
         title='Swagger Petstore',
         version='1.0.0',
-        description='This is a sample Petstore server.  You can find out more '
-                    'about Swagger at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> '
-                    'or on irc.freenode.net, #swagger.  For this sample, you can use the api '
-                    'key \"special-key\" to test the authorization filters',
+        openapi_version=request.param,
         plugins=(BottlePlugin(), ),
     )
 

--- a/tests/test_ext_flask.py
+++ b/tests/test_ext_flask.py
@@ -3,19 +3,17 @@ import pytest
 
 from flask import Flask
 from flask.views import MethodView
+
 from apispec import APISpec
 from apispec.ext.flask import FlaskPlugin
 
 
-@pytest.fixture
+@pytest.fixture(params=('2.0', '3.0.0'))
 def spec(request):
     return APISpec(
         title='Swagger Petstore',
         version='1.0.0',
-        description='This is a sample Petstore server.  You can find out more '
-        'about Swagger at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> '
-        'or on irc.freenode.net, #swagger.  For this sample, you can use the api '
-        'key \"special-key\" to test the authorization filters',
+        openapi_version=request.param,
         plugins=(FlaskPlugin(), ),
     )
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -41,7 +41,7 @@ class TestDefinitionHelper:
         spec = APISpec(
             title='Test auto-reference',
             version='0.1',
-            description='Test auto-reference',
+            openapi_version='2.0',
             plugins=(
                 MarshmallowPlugin(schema_name_resolver=resolver),
             ),
@@ -76,7 +76,7 @@ class TestDefinitionHelper:
         spec = APISpec(
             title='Test auto-reference',
             version='0.1',
-            description='Test auto-reference',
+            openapi_version='2.0',
             plugins=(
                 MarshmallowPlugin(schema_name_resolver=resolver,),
             ),
@@ -112,7 +112,7 @@ class TestDefinitionHelper:
         spec = APISpec(
             title='Test auto-reference',
             version='0.1',
-            description='Test auto-reference',
+            openapi_version='2.0',
             plugins=(
                 MarshmallowPlugin(schema_name_resolver=resolver,),
             ),

--- a/tests/test_ext_tornado.py
+++ b/tests/test_ext_tornado.py
@@ -1,22 +1,19 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from apispec import APISpec
-from apispec.ext.tornado import TornadoPlugin
 from tornado.web import RequestHandler
 import tornado.gen
 
+from apispec import APISpec
+from apispec.ext.tornado import TornadoPlugin
 
-@pytest.fixture
+
+@pytest.fixture(params=('2.0', '3.0.0'))
 def spec(request):
     return APISpec(
         title='Swagger Petstore',
         version='1.0.0',
-        description='This is a sample Petstore server.  You can find out more '
-        'about Swagger at <a href=\"http://swagger.wordnik.com\">'
-        'http://swagger.wordnik.com</a> or on irc.freenode.net, #swagger.'
-        'For this sample, you can use the api key \"special-key\" to test the'
-        'authorization filters',
+        openapi_version=request.param,
         plugins=(TornadoPlugin(), ),
     )
 


### PR DESCRIPTION
Remove `info`: this is already covered by `**options` anyway, so it is redundant. This change is almost not breaking (only if all parameters are passed as positional).

Make `openapi_version` mandatory, no default version. There is no reason the version should default to `2.0`.

In the tests, I also removed `description=...` in the calls to `APISpec` because this is wrong. It should go in `info={'description': ...}`. Anyway, it is not needed for the test.

TODO:

- [x] Changelog
- [x] Docs: almost ready, just double-check. Bottom of writing_plugins the call to `APISpec` misses `openapi_version`...