### PR TITLE
Ignore load_only fields when documenting responses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ Features:
   ``APISpec`` class does not default to `'2.0'` anymore and ``info`` parameter
   is merged with ``**options`` kwargs.
 
+Bug fixes:
+
+- [apispec.ext.marshmallow]: Exclude ``load_only`` fields when documenting
+  responses (:issue:`119`). Thanks :user:`luisincrespo` for reporting.
+- [apispec.ext.marshmallow]: Exclude ``dump_only`` fields when documenting
+  request body parameter schema.
+
 1.0.0b2 (2018-09-09)
 ++++++++++++++++++++
 

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -113,7 +113,7 @@ class MarshmallowPlugin(BasePlugin):
         content = request_body['content']
         for content_type in content:
             schema = content[content_type]['schema']
-            content[content_type]['schema'] = self.openapi.resolve_schema_dict(schema)
+            content[content_type]['schema'] = self.openapi.resolve_schema_dict(schema, dump=False, load=True)
 
     def resolve_schema(self, data, dump=True, load=True):
         """Function to resolve a schema in a parameter or response - modifies the

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -102,7 +102,7 @@ class MarshmallowPlugin(BasePlugin):
                         default_in=parameter.pop('in'), **parameter
                     )
                     continue
-            self.resolve_schema(parameter)
+            self.resolve_schema(parameter, dump=False, load=True)
             resolved.append(parameter)
         return resolved
 
@@ -115,21 +115,25 @@ class MarshmallowPlugin(BasePlugin):
             schema = content[content_type]['schema']
             content[content_type]['schema'] = self.openapi.resolve_schema_dict(schema)
 
-    def resolve_schema(self, data):
+    def resolve_schema(self, data, dump=True, load=True):
         """Function to resolve a schema in a parameter or response - modifies the
         corresponding dict to convert Marshmallow Schema object or class into dict
 
         :param APISpec spec: `APISpec` containing refs.
         :param dict data: the parameter or response dictionary that may contain a schema
+        :param bool dump: Introspect dump logic.
+        :param bool load: Introspect load logic.
         """
         if self.openapi_version.major < 3:
             if 'schema' in data:
-                data['schema'] = self.openapi.resolve_schema_dict(data['schema'])
+                data['schema'] = self.openapi.resolve_schema_dict(data['schema'], dump=dump, load=load)
         else:
             if 'content' in data:
                 for content_type in data['content']:
                     schema = data['content'][content_type]['schema']
-                    data['content'][content_type]['schema'] = self.openapi.resolve_schema_dict(schema)
+                    data['content'][content_type]['schema'] = self.openapi.resolve_schema_dict(
+                        schema, dump=dump, load=load,
+                    )
 
     def map_to_openapi_type(self, *args):
         """Decorator to set mapping for custom fields.
@@ -183,4 +187,4 @@ class MarshmallowPlugin(BasePlugin):
                 if 'requestBody' in operation:
                     self.resolve_schema_in_request_body(operation['requestBody'])
             for response in operation.get('responses', {}).values():
-                self.resolve_schema(response)
+                self.resolve_schema(response, dump=True, load=False)

--- a/apispec/ext/marshmallow/common.py
+++ b/apispec/ext/marshmallow/common.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Utilities to get schema instances/classes"""
 
+import copy
+
 import marshmallow
 
 
@@ -28,3 +30,12 @@ def resolve_schema_cls(schema):
     if isinstance(schema, marshmallow.Schema):
         return type(schema)
     return marshmallow.class_registry.get_class(schema)
+
+
+def get_fields(schema):
+    """Return fields from schema"""
+    if hasattr(schema, 'fields'):
+        return schema.fields
+    elif hasattr(schema, '_declared_fields'):
+        return copy.deepcopy(schema._declared_fields)
+    raise ValueError("{0!r} doesn't have either `fields` or `_declared_fields`".format(schema))

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -313,7 +313,7 @@ class TestOperationHelper:
             name = parameter['name']
             assert description == PetSchema.description[name]
         post = p['post']
-        post_schema = spec_fixture.openapi.resolve_schema_dict(PetSchema)
+        post_schema = spec_fixture.openapi.resolve_schema_dict(PetSchema, dump=False, load=True)
         assert post['requestBody']['content']['application/json']['schema'] == post_schema
         assert post['requestBody']['description'] == 'a pet schema'
         assert post['requestBody']['required']

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -213,7 +213,9 @@ class TestOperationHelper:
             },
         )
         get = spec_fixture.spec._paths['/pet']['get']
-        assert get['responses'][200]['schema'] == spec_fixture.openapi.schema2jsonschema(PetSchema)
+        assert get['responses'][200]['schema'] == spec_fixture.openapi.schema2jsonschema(
+            PetSchema, dump=True, load=False,
+        )
         assert get['responses'][200]['description'] == 'successful operation'
 
     @pytest.mark.parametrize('pet_schema', (PetSchema, PetSchema(), 'tests.schemas.PetSchema'))
@@ -238,7 +240,9 @@ class TestOperationHelper:
         )
         get = spec_fixture.spec._paths['/pet']['get']
         resolved_schema = get['responses'][200]['content']['application/json']['schema']
-        assert resolved_schema == spec_fixture.openapi.schema2jsonschema(PetSchema)
+        assert resolved_schema == spec_fixture.openapi.schema2jsonschema(
+            PetSchema, dump=True, load=False,
+        )
         assert get['responses'][200]['description'] == 'successful operation'
 
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -439,6 +439,17 @@ class TestMarshmallowSchemaToModelDefinition:
         else:
             assert 'writeOnly' in props['password']
 
+        res = openapi.schema2jsonschema(UserSchema(), dump=False)
+        props = res['properties']
+        assert 'name' in props
+        assert '_id' not in props
+        assert 'password' in props
+
+        res = openapi.schema2jsonschema(UserSchema(), load=False)
+        props = res['properties']
+        assert 'name' in props
+        assert '_id' in props
+        assert 'password' not in props
 
 class TestMarshmallowSchemaToParameters:
 


### PR DESCRIPTION
Closes https://github.com/marshmallow-code/apispec/issues/119.

Also includes a fix to exclude dump_only fields from request body schemas.