### PR TITLE
Rework spec: add Components class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,37 @@ Changelog
 1.0.0b5 (unreleased)
 ++++++++++++++++++++
 
+Features:
+
+- ``apispec.core.Components`` is added. Each ``APISpec`` instance has a
+  ``Components`` object used to define components such as schemas, parameters
+  or reponses. "Components" is the OpenAPI v3 terminology for those reusable
+  top-level objects.
+- ``apispec.core.Components.parameter`` and ``apispec.core.Components.response``
+  are added.
+- *Backwards-incompatible*: ``apispec.APISpec.add_path`` and
+  ``apispec.APISpec.add_tag`` are renamed to ``apispec.APISpec.path`` and
+  ``apispec.APISpec.tag``.
+- *Backwards-incompatible*: ``apispec.APISpec.definition`` is moved to the
+  ``Components`` class and renamed to ``apispec.core.Components.schema``.
+
+::
+
+    # apispec<1.0.0b5
+    spec.add_tag({'name': 'Pet', 'description': 'Operations on pets'})
+    spec.add_path('/pets/', operations=...)
+    spec.definition('Pet')
+    def PetSchema(Schema)
+        ...
+
+    # apispec>=1.0.0b5
+    spec.tag({'name': 'Pet', 'description': 'Operations on pets'})
+    spec.path('/pets/', operations=...)
+    spec.components.schema('Pet')
+    def PetSchema(Schema)
+        ...
+
+
 Deprecations/Removals:
 
 - The ``response_helper`` feature is removed. The same can be achieved from
@@ -12,7 +43,7 @@ Deprecations/Removals:
 1.0.0b4 (2018-10-28)
 ++++++++++++++++++++
 
-* *Backwards-incompatible*: ``apispec.ext.flask``,
+- *Backwards-incompatible*: ``apispec.ext.flask``,
   ``apispec.ext.bottle``, and ``apispec.ext.tornado`` are moved to
   a separate package, `apispec-webframeworks <https://github.com/marshmallow-code/apispec-webframeworks>`_.
   (:issue:`302`).

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Example Application
     spec.definition('Category', schema=CategorySchema)
     spec.definition('Pet', schema=PetSchema)
     with app.test_request_context():
-        spec.add_path(view=random_pet)
+        spec.path(view=random_pet)
 
 
 Generated OpenAPI Spec

--- a/apispec/__init__.py
+++ b/apispec/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Contains the main `APISpec` class.
-"""
+"""Contains main apispec classes: `APISpec` and `BasePlugin`"""
+
 from .core import APISpec
 from .plugin import BasePlugin
 

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -181,19 +181,6 @@ class APISpec(object):
         ret = deepupdate(ret, self.options)
         return ret
 
-    # Backward compatigility
-    def add_parameter(self, param_id, location, **kwargs):
-        self.components.add_parameter(param_id, location, **kwargs)
-
-    # Backward compatigility
-    def definition(
-            self, name, properties=None, enum=None, description=None, extra_fields=None,
-            **kwargs
-    ):
-        self.components.add_schema(
-            name, properties=properties, enum=enum, description=description, extra_fields=extra_fields,
-            **kwargs)
-
     def to_yaml(self):
         """Render the spec to YAML. Requires PyYAML to be installed."""
         from .yaml_utils import dict_to_yaml

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -102,7 +102,7 @@ class Components(object):
             schemas_key: self._schemas,
         }
 
-    def add_schema(
+    def schema(
             self, name, properties=None, enum=None, description=None, extra_fields=None,
             **kwargs
     ):
@@ -140,7 +140,7 @@ class Components(object):
             ret.update(extra_fields)
         self._schemas[name] = ret
 
-    def add_parameter(self, param_id, location, **kwargs):
+    def parameter(self, param_id, location, **kwargs):
         """ Add a parameter which can be referenced.
 
         :param str param_id: identifier by which parameter may be referenced.
@@ -158,7 +158,7 @@ class Components(object):
                 continue
         self._parameters[param_id] = ret
 
-    def add_response(self, ref_id, **kwargs):
+    def response(self, ref_id, **kwargs):
         """Add a response which can be referenced.
 
         :param str ref_id: ref_id to use as reference
@@ -227,14 +227,14 @@ class APISpec(object):
         from .yaml_utils import dict_to_yaml
         return dict_to_yaml(self.to_dict())
 
-    def add_tag(self, tag):
+    def tag(self, tag):
         """ Store information about a tag.
 
         :param dict tag: the dictionary storing information about the tag.
         """
         self._tags.append(tag)
 
-    def add_path(self, path=None, operations=None, **kwargs):
+    def path(self, path=None, operations=None, **kwargs):
         """Add a new path object to the spec.
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#pathsObject

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -127,7 +127,7 @@ class Components(object):
         # Execute all helpers from plugins
         for plugin in self._plugins:
             try:
-                ret.update(plugin.definition_helper(name, definition=ret, **kwargs))
+                ret.update(plugin.schema_helper(name, definition=ret, **kwargs))
             except PluginMethodNotImplementedError:
                 continue
         if properties:

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -158,7 +158,14 @@ class Components(object):
         :param str ref_id: ref_id to use as reference
         :param dict kwargs: response fields
         """
-        self._responses[ref_id] = kwargs
+        ret = kwargs.copy()
+        # Execute all helpers from plugins
+        for plugin in self._plugins:
+            try:
+                ret.update(plugin.response_helper(**kwargs))
+            except PluginMethodNotImplementedError:
+                continue
+        self._responses[ref_id] = ret
 
 
 class APISpec(object):

--- a/apispec/core.py
+++ b/apispec/core.py
@@ -147,10 +147,16 @@ class Components(object):
         :param str location: location of the parameter.
         :param dict kwargs: parameter fields.
         """
-        if 'name' not in kwargs:
-            kwargs['name'] = param_id
-        kwargs['in'] = location
-        self._parameters[param_id] = kwargs
+        ret = kwargs.copy()
+        ret.setdefault('name', param_id)
+        ret['in'] = location
+        # Execute all helpers from plugins
+        for plugin in self._plugins:
+            try:
+                ret.update(plugin.parameter_helper(**kwargs))
+            except PluginMethodNotImplementedError:
+                continue
+        self._parameters[param_id] = ret
 
     def add_response(self, ref_id, **kwargs):
         """Add a response which can be referenced.

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -21,7 +21,7 @@ Requires marshmallow>=2.15.2.
             default_doc="The current datetime"
         )
 
-    spec.definition('User', schema=UserSchema)
+    spec.components.add_schema('User', schema=UserSchema)
     pprint(spec.to_dict()['definitions'])
     # {'User': {'properties': {'id': {'format': 'int32', 'type': 'integer'},
     #                         'name': {'description': "The user's name",
@@ -85,7 +85,7 @@ class MarshmallowPlugin(BasePlugin):
                     nested_schema_class,
                 )
                 if definition_name:
-                    self.spec.definition(
+                    self.spec.components.add_schema(
                         definition_name,
                         schema=nested_schema_class,
                     )

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Marshmallow plugin for apispec. Allows passing a marshmallow
 `Schema` to `APISpec.definition <apispec.APISpec.definition>`
-and `APISpec.add_path <apispec.APISpec.add_path>` (for responses).
+and `APISpec.path <apispec.APISpec.path>` (for responses).
 
 Requires marshmallow>=2.15.2.
 
@@ -21,7 +21,7 @@ Requires marshmallow>=2.15.2.
             default_doc="The current datetime"
         )
 
-    spec.components.add_schema('User', schema=UserSchema)
+    spec.components.schema('User', schema=UserSchema)
     pprint(spec.to_dict()['definitions'])
     # {'User': {'properties': {'id': {'format': 'int32', 'type': 'integer'},
     #                         'name': {'description': "The user's name",
@@ -85,7 +85,7 @@ class MarshmallowPlugin(BasePlugin):
                     nested_schema_class,
                 )
                 if definition_name:
-                    self.spec.components.add_schema(
+                    self.spec.components.schema(
                         definition_name,
                         schema=nested_schema_class,
                     )

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -155,7 +155,7 @@ class MarshmallowPlugin(BasePlugin):
         """
         return self.openapi.map_to_openapi_type(*args)
 
-    def definition_helper(self, name, schema, **kwargs):
+    def schema_helper(self, name, schema, **kwargs):
         """Definition helper that allows using a marshmallow
         :class:`Schema <marshmallow.Schema>` to provide OpenAPI
         metadata.

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -177,6 +177,16 @@ class MarshmallowPlugin(BasePlugin):
 
         return json_schema
 
+    def parameter_helper(self, **kwargs):
+        """Parameter component helper that allows using a marshmallow
+        :class:`Schema <marshmallow.Schema>` in parameter definition.
+
+        :param type|Schema schema: A marshmallow Schema class or instance.
+        """
+        # In OpenAPIv3, this only works when using the complex form using "content"
+        self.resolve_schema(kwargs, dump=False, load=True)
+        return kwargs
+
     def response_helper(self, **kwargs):
         """Response component helper that allows using a marshmallow
         :class:`Schema <marshmallow.Schema>` in response definition.

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -177,6 +177,15 @@ class MarshmallowPlugin(BasePlugin):
 
         return json_schema
 
+    def response_helper(self, **kwargs):
+        """Response component helper that allows using a marshmallow
+        :class:`Schema <marshmallow.Schema>` in response definition.
+
+        :param type|Schema schema: A marshmallow Schema class or instance.
+        """
+        self.resolve_schema(kwargs, dump=True, load=False)
+        return kwargs
+
     def operation_helper(self, operations, **kwargs):
         for operation in operations.values():
             if not isinstance(operation, dict):

--- a/apispec/plugin.py
+++ b/apispec/plugin.py
@@ -12,7 +12,7 @@ class BasePlugin(object):
         :param APISpec spec: APISpec object this plugin instance is attached to
         """
 
-    def definition_helper(self, name, definition, **kwargs):
+    def schema_helper(self, name, definition, **kwargs):
         """Must return definition as a dict."""
         raise PluginMethodNotImplementedError
 

--- a/apispec/plugin.py
+++ b/apispec/plugin.py
@@ -16,6 +16,10 @@ class BasePlugin(object):
         """Must return definition as a dict."""
         raise PluginMethodNotImplementedError
 
+    def parameter_helper(self, **kwargs):
+        """Must return parameter component description as a dict."""
+        raise PluginMethodNotImplementedError
+
     def response_helper(self, **kwargs):
         """Must return response component description as a dict."""
         raise PluginMethodNotImplementedError

--- a/apispec/plugin.py
+++ b/apispec/plugin.py
@@ -16,6 +16,10 @@ class BasePlugin(object):
         """Must return definition as a dict."""
         raise PluginMethodNotImplementedError
 
+    def response_helper(self, **kwargs):
+        """Must return response component description as a dict."""
+        raise PluginMethodNotImplementedError
+
     def path_helper(self, path=None, operations=None, **kwargs):
         """May return a path as string and mutate operations dict.
 

--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -113,3 +113,17 @@ def dedent(content):
         content = re.sub(re.compile(whitespace_pattern, re.MULTILINE), '', content)
 
     return content.strip()
+
+
+# http://stackoverflow.com/a/8310229
+def deepupdate(original, update):
+    """Recursively update a dict.
+
+    Subdict's won't be overwritten but also updated.
+    """
+    for key, value in original.items():
+        if key not in update:
+            update[key] = value
+        elif isinstance(value, dict):
+            deepupdate(value, update[key])
+    return update

--- a/docs/api_core.rst
+++ b/docs/api_core.rst
@@ -7,11 +7,12 @@ apispec
 .. automodule:: apispec
     :members:
 
-apispec.plugin
---------------
 
-.. automodule:: apispec.plugin
-    :members:
+apispec.core
+------------
+
+.. automodule:: apispec.core
+    :members: Components
 
 apispec.exceptions
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,10 +65,10 @@ Example Application
         return jsonify(PetSchema().dump(pet).data)
 
     # Register entities and paths
-    spec.definition('Category', schema=CategorySchema)
-    spec.definition('Pet', schema=PetSchema)
+    spec.components.schema('Category', schema=CategorySchema)
+    spec.components.schema('Pet', schema=PetSchema)
     with app.test_request_context():
-        spec.add_path(view=random_pet)
+        spec.path(view=random_pet)
 
 
 Generated OpenAPI Spec

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,22 +19,22 @@ First, create an `APISpec <apispec.APISpec>` object, passing basic information a
         )
     )
 
-Add definitions to your spec using `definition <apispec.APISpec.definition>`.
+Add schemas to your spec using `schema <apispec.core.Components.schema>`.
 
 .. code-block:: python
 
-    spec.definition('Gist', properties={
+    spec.components.schema('Gist', properties={
         'id': {'type': 'integer', 'format': 'int64'},
         'name': {'type': 'string'}
     })
 
 
-Add paths to your spec using `add_path <apispec.APISpec.add_path>`.
+Add paths to your spec using `path <apispec.APISpec.path>`.
 
 .. code-block:: python
 
 
-    spec.add_path(
+    spec.path(
         path='/gist/{gist_id}',
         operations=dict(
             get=dict(

--- a/docs/special_topics.rst
+++ b/docs/special_topics.rst
@@ -7,7 +7,7 @@ Solutions to specific problems are documented here.
 Adding Additional Fields To Schema Objects
 ------------------------------------------
 
-To add additional fields (e.g. ``"discriminator"``) to Schema objects generated from `APISpec.definition <apispec.APISpec.definition>` , pass the ``extra_fields`` argument.
+To add additional fields (e.g. ``"discriminator"``) to Schema objects generated from `spec.components.schema <apispec.core.Components.schema>` , pass the ``extra_fields`` argument.
 
 .. code-block:: python
 
@@ -16,7 +16,7 @@ To add additional fields (e.g. ``"discriminator"``) to Schema objects generated 
         'name': {'type': 'string', 'example': 'doggie'},
     }
 
-    spec.definition('Pet', properties=properties, extra_fields={'discriminator': 'petType'})
+    spec.components.schema('Pet', properties=properties, extra_fields={'discriminator': 'petType'})
 
 
 .. note::
@@ -52,8 +52,16 @@ JSON
 Documenting Top-level Components
 --------------------------------
 
-To add objects within the top-level ``components`` object, pass the
-components to the ``APISpec`` as a keyword argument.
+The ``APISpec`` object contains helpers to add top-level components.
+
+To add a schema (a.k.a. "definition" in OpenAPI v2 termionology), use
+`spec.components.schema <apispec.core.Components.schema>`.
+
+Likewise, parameters and responses can be added using
+`spec.components.parameter <apispec.core.Components.parameter>` and
+`spec.components.response <apispec.core.Components.response>`.
+
+To add other top-level objects, pass them to the ``APISpec`` as keyword arguments.
 
 Here is an example that includes a `Security Scheme Object <https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject>`_.
 
@@ -104,3 +112,9 @@ Here is an example that includes a `Security Scheme Object <https://github.com/O
     )
 
     validate_swagger(spec)
+
+
+When adding components, the main advantage of using dedicated methods over
+passing them as kwargs is the ability to use plugin helpers. For instance,
+`MarshmallowPlugin <apispec.ext.marshmallow.MarshmallowPlugin>` has helpers to
+resolve schemas in parameters and responses.

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -81,14 +81,14 @@ Our application will have a marshmallow `Schema <marshmallow.Schema>` for gists.
 
 
 The marshmallow plugin allows us to pass this `Schema` to
-`spec.definition <apispec.APISpec.definition>`.
+`spec.components.schema <apispec.core.Components.schema>`.
 
 
 .. code-block:: python
 
-    spec.definition('Gist', schema=GistSchema)
+    spec.components.schema('Gist', schema=GistSchema)
 
-The definition is now added to the spec.
+The schema is now added to the spec.
 
 .. code-block:: python
     :emphasize-lines: 4,5,6,7
@@ -133,15 +133,15 @@ We'll add some YAML in the docstring to add response information.
         """
         return 'details about gist {}'.format(gist_id)
 
-The Flask plugin allows us to pass this view to `spec.add_path <apispec.APISpec.add_path>`.
+The Flask plugin allows us to pass this view to `spec.path <apispec.APISpec.path>`.
 
 
 .. code-block:: python
 
-    # Since add_path inspects the view and its route,
+    # Since path inspects the view and its route,
     # we need to be in a Flask request context
     with app.test_request_context():
-        spec.add_path(view=gist_detail)
+        spec.path(view=gist_detail)
 
 
 Our OpenAPI spec now looks like this:
@@ -190,7 +190,7 @@ If your API uses `method-based dispatching <http://flask.pocoo.org/docs/0.12/vie
     method_view = GistApi.as_view('gist')
     app.add_url_rule("/gist", view_func=method_view)
     with app.test_request_context():
-        spec.add_path(view=method_view)
+        spec.path(view=method_view)
     print(spec.to_dict()['paths'])
     # {'/gist': {'get': {'description': 'get a gist',
     #                    'responses': {200: {'schema': {'$ref': '#/definitions/Gist'}}}},

--- a/docs/writing_plugins.rst
+++ b/docs/writing_plugins.rst
@@ -9,14 +9,15 @@ Helper Methods
 
 Plugins provide "helper" methods that augment the behavior of `apispec.APISpec` methods.
 
-There are four types of helper methods:
+There are five types of helper methods:
 
-* Definition helpers
+* Schema helpers
+* Parameter helpers
+* Response helpers
 * Path helpers
 * Operation helpers
-* Response helpers
 
-Each helper function type modifies a different `apispec.APISpec` method. For example, path helpers modify `apispec.APISpec.add_path`.
+Helper functions modify `apispec.APISpec` methods. For example, path helpers modify `apispec.APISpec.path`.
 
 
 A plugin with a path helper function may look something like this:
@@ -30,7 +31,7 @@ A plugin with a path helper function may look something like this:
 
         def path_helper(self, path, func, **kwargs):
             """Path helper that parses docstrings for operations. Adds a
-            ``func`` parameter to `apispec.APISpec.add_path`.
+            ``func`` parameter to `apispec.APISpec.path`.
             """
             operations = load_operations_from_docstring(func.__doc__)
             return Path(path=path, operations=operations)
@@ -66,7 +67,7 @@ Here's a plugin example involving conditional processing depending on the OpenAP
 
         def operation_helper(self, operations, func, **kwargs):
             """Operation helper that parses docstrings for operations. Adds a
-            ``func`` parameter to `apispec.APISpec.add_path`.
+            ``func`` parameter to `apispec.APISpec.path`.
             """
             doc_operations = load_operations_from_docstring(func.__doc__))
             # Apply conditional processing
@@ -101,7 +102,7 @@ To use the plugin:
         """
         pass
 
-    spec.add_path(path='/gists/{gist_id}', func=gist_detail)
+    spec.path(path='/gists/{gist_id}', func=gist_detail)
     print(spec.to_dict()['paths'])
     # {'/gists/{gist_id}': {'get': {'responses': {200: {'schema': '#/definitions/Gist'}}}}}
 
@@ -111,6 +112,6 @@ Next Steps
 
 To learn more about how to write plugins
 
-* Consult the :doc:`Core API docs <api_core>` for `BasePlugin <apispec.plugin.BasePlugin>`
+* Consult the :doc:`Core API docs <api_core>` for `BasePlugin <apispec.BasePlugin>`
 * View the source for an existing apispec plugin, e.g. `FlaskPlugin <https://github.com/marshmallow-code/apispec-webframeworks/blob/master/apispec_webframeworks/flask.py>`_.
 * Check out some projects using apispec: https://github.com/marshmallow-code/apispec/wiki/Ecosystem

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -2,9 +2,10 @@ from marshmallow import Schema, fields
 
 
 class PetSchema(Schema):
-    description = dict(id='Pet id', name='Pet name')
+    description = dict(id='Pet id', name='Pet name', password='Password')
     id = fields.Int(dump_only=True, description=description['id'])
-    name = fields.Str(description=description['name'], required=True, deprecated=False, allowEmptyValue=False)
+    name = fields.Str(required=True, deprecated=False, allowEmptyValue=False, description=description['name'])
+    password = fields.Str(load_only=True, description=description['password'])
 
 
 class SampleSchema(Schema):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -310,11 +310,7 @@ class TestPath:
 
         spec.add_path(
             path='/pet/{petId}',
-            operations=dict(
-                get=dict(
-                    parameters=['test_parameter'],
-                ),
-            ),
+            operations={'get': {'parameters': ['test_parameter']}},
         )
 
         metadata = spec.to_dict()
@@ -326,6 +322,26 @@ class TestPath:
         else:
             assert p['parameters'][0] == {'$ref': '#/components/parameters/test_parameter'}
             assert route_spec['parameters'][0] == metadata['components']['parameters']['test_parameter']
+
+    def test_add_response(self, spec):
+        route_spec = self.paths['/pet/{petId}']['get']
+
+        spec.components.add_response('test_response', **route_spec['responses']['200'])
+
+        spec.add_path(
+            path='/pet/{petId}',
+            operations={'get': {'responses': {'200': 'test_response'}}},
+        )
+
+        metadata = spec.to_dict()
+        p = get_paths(spec)['/pet/{petId}']['get']
+
+        if spec.openapi_version.major < 3:
+            assert p['responses']['200'] == {'$ref': '#/responses/test_response'}
+            assert route_spec['responses']['200'] == metadata['responses']['test_response']
+        else:
+            assert p['responses']['200'] == {'$ref': '#/components/responses/test_response'}
+            assert route_spec['responses']['200'] == metadata['components']['responses']['test_response']
 
     def test_add_path_check_invalid_http_method(self, spec):
         spec.add_path('/pet/{petId}', operations={'get': {}})

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -92,7 +92,7 @@ class TestMetadata:
                 'type': 'boolean', 'description': 'property description', 'example': True,
             },
         }
-        spec.definition('definition', properties=properties, description='definiton description')
+        spec.components.add_schema('definition', properties=properties, description='definiton description')
         metadata = spec.to_dict()
         assert metadata['components']['schemas'].get('ErrorResponse', False)
         assert metadata['components']['schemas'].get('definition', False)
@@ -119,7 +119,7 @@ class TestDefinitions:
     }
 
     def test_definition(self, spec):
-        spec.definition('Pet', properties=self.properties)
+        spec.components.add_schema('Pet', properties=self.properties)
         if spec.openapi_version.major < 3:
             defs = spec.to_dict()['definitions']
         else:
@@ -129,7 +129,7 @@ class TestDefinitions:
 
     def test_definition_description(self, spec):
         model_description = 'An animal which lives with humans.'
-        spec.definition('Pet', properties=self.properties, description=model_description)
+        spec.components.add_schema('Pet', properties=self.properties, description=model_description)
         if spec.openapi_version.major < 3:
             defs = spec.to_dict()['definitions']
         else:
@@ -138,7 +138,7 @@ class TestDefinitions:
 
     def test_definition_stores_enum(self, spec):
         enum = ['name', 'photoUrls']
-        spec.definition(
+        spec.components.add_schema(
             'Pet',
             properties=self.properties,
             enum=enum,
@@ -151,7 +151,7 @@ class TestDefinitions:
 
     def test_definition_extra_fields(self, spec):
         extra_fields = {'discriminator': 'name'}
-        spec.definition('Pet', properties=self.properties, extra_fields=extra_fields)
+        spec.components.add_schema('Pet', properties=self.properties, extra_fields=extra_fields)
         if spec.openapi_version.major < 3:
             defs = spec.to_dict()['definitions']
         else:
@@ -160,7 +160,7 @@ class TestDefinitions:
 
     def test_to_yaml(self, spec):
         enum = ['name', 'photoUrls']
-        spec.definition(
+        spec.components.add_schema(
             'Pet',
             properties=self.properties,
             enum=enum,
@@ -303,10 +303,10 @@ class TestPath:
         assert '/pets' in paths
         assert '/v1/pets' not in paths
 
-    def test_add_parameters(self, spec):
+    def test_add_parameter(self, spec):
         route_spec = self.paths['/pet/{petId}']['get']
 
-        spec.add_parameter('test_parameter', 'path', **route_spec['parameters'][0])
+        spec.components.add_parameter('test_parameter', 'path', **route_spec['parameters'][0])
 
         spec.add_path(
             path='/pet/{petId}',
@@ -358,7 +358,7 @@ class TestPlugins:
             openapi_version=openapi_version,
             plugins=(self.TestPlugin(), ),
         )
-        spec.definition('Pet', {})
+        spec.components.add_schema('Pet', {})
         definitions = get_definitions(spec)
         assert definitions['Pet'] == {'properties': {'name': {'type': 'string'}}}
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -354,7 +354,7 @@ class TestPath:
 class TestPlugins:
 
     class TestPlugin(BasePlugin):
-        def definition_helper(self, name, definition, **kwargs):
+        def schema_helper(self, name, definition, **kwargs):
             return {'properties': {'name': {'type': 'string'}}}
 
         def path_helper(self, path, operations, **kwargs):
@@ -367,7 +367,7 @@ class TestPlugins:
                 operations['post'] = {'responses': {'201': {}}}
 
     @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.0', ))
-    def test_plugin_definition_helper_is_used(self, openapi_version):
+    def test_plugin_schema_helper_is_used(self, openapi_version):
         spec = APISpec(
             title='Swagger Petstore',
             version='1.0.0',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -92,7 +92,7 @@ class TestMetadata:
                 'type': 'boolean', 'description': 'property description', 'example': True,
             },
         }
-        spec.components.add_schema('definition', properties=properties, description='definiton description')
+        spec.components.schema('definition', properties=properties, description='definiton description')
         metadata = spec.to_dict()
         assert metadata['components']['schemas'].get('ErrorResponse', False)
         assert metadata['components']['schemas'].get('definition', False)
@@ -106,7 +106,7 @@ class TestTags:
     }
 
     def test_tag(self, spec):
-        spec.add_tag(self.tag)
+        spec.tag(self.tag)
         tags_json = spec.to_dict()['tags']
         assert self.tag in tags_json
 
@@ -119,7 +119,7 @@ class TestDefinitions:
     }
 
     def test_definition(self, spec):
-        spec.components.add_schema('Pet', properties=self.properties)
+        spec.components.schema('Pet', properties=self.properties)
         if spec.openapi_version.major < 3:
             defs = spec.to_dict()['definitions']
         else:
@@ -129,7 +129,7 @@ class TestDefinitions:
 
     def test_definition_description(self, spec):
         model_description = 'An animal which lives with humans.'
-        spec.components.add_schema('Pet', properties=self.properties, description=model_description)
+        spec.components.schema('Pet', properties=self.properties, description=model_description)
         if spec.openapi_version.major < 3:
             defs = spec.to_dict()['definitions']
         else:
@@ -138,7 +138,7 @@ class TestDefinitions:
 
     def test_definition_stores_enum(self, spec):
         enum = ['name', 'photoUrls']
-        spec.components.add_schema(
+        spec.components.schema(
             'Pet',
             properties=self.properties,
             enum=enum,
@@ -151,7 +151,7 @@ class TestDefinitions:
 
     def test_definition_extra_fields(self, spec):
         extra_fields = {'discriminator': 'name'}
-        spec.components.add_schema('Pet', properties=self.properties, extra_fields=extra_fields)
+        spec.components.schema('Pet', properties=self.properties, extra_fields=extra_fields)
         if spec.openapi_version.major < 3:
             defs = spec.to_dict()['definitions']
         else:
@@ -160,7 +160,7 @@ class TestDefinitions:
 
     def test_to_yaml(self, spec):
         enum = ['name', 'photoUrls']
-        spec.components.add_schema(
+        spec.components.schema(
             'Pet',
             properties=self.properties,
             enum=enum,
@@ -208,9 +208,9 @@ class TestPath:
         },
     }
 
-    def test_add_path(self, spec):
+    def test_path(self, spec):
         route_spec = self.paths['/pet/{petId}']['get']
-        spec.add_path(
+        spec.path(
             path='/pet/{petId}',
             operations=dict(
                 get=dict(
@@ -234,30 +234,30 @@ class TestPath:
         assert p['tags'] == route_spec['tags']
 
     def test_paths_maintain_order(self, spec):
-        spec.add_path(path='/path1')
-        spec.add_path(path='/path2')
-        spec.add_path(path='/path3')
-        spec.add_path(path='/path4')
+        spec.path(path='/path1')
+        spec.path(path='/path2')
+        spec.path(path='/path3')
+        spec.path(path='/path4')
         assert list(spec.to_dict()['paths'].keys()) == ['/path1', '/path2', '/path3', '/path4']
 
     def test_methods_maintain_order(self, spec):
         methods = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options']
         for method in methods:
-            spec.add_path(path='/path', operations=OrderedDict({method: {}}))
+            spec.path(path='/path', operations=OrderedDict({method: {}}))
         assert list(spec.to_dict()['paths']['/path']) == methods
 
-    def test_add_path_merges_paths(self, spec):
+    def test_path_merges_paths(self, spec):
         """Test that adding a second HTTP method to an existing path performs
         a merge operation instead of an overwrite"""
         path = '/pet/{petId}'
         route_spec = self.paths[path]['get']
-        spec.add_path(
+        spec.path(
             path=path,
             operations=dict(
                 get=route_spec,
             ),
         )
-        spec.add_path(
+        spec.path(
             path=path,
             operations=dict(
                 put=dict(
@@ -276,9 +276,9 @@ class TestPath:
         assert 'get' in p
         assert 'put' in p
 
-    def test_add_path_ensures_path_parameters_required(self, spec):
+    def test_path_ensures_path_parameters_required(self, spec):
         path = '/pet/{petId}'
-        spec.add_path(
+        spec.path(
             path=path,
             operations=dict(
                 put=dict(
@@ -291,24 +291,24 @@ class TestPath:
         )
         assert get_paths(spec)[path]['put']['parameters'][0]['required'] is True
 
-    def test_add_path_with_no_path_raises_error(self, spec):
+    def test_path_with_no_path_raises_error(self, spec):
         with pytest.raises(APISpecError) as excinfo:
-            spec.add_path()
+            spec.path()
         assert 'Path template is not specified' in str(excinfo)
 
-    def test_add_path_strips_base_path(self, spec):
+    def test_path_strips_base_path(self, spec):
         spec.options['basePath'] = '/v1'
-        spec.add_path('/v1/pets')
+        spec.path('/v1/pets')
         paths = get_paths(spec)
         assert '/pets' in paths
         assert '/v1/pets' not in paths
 
-    def test_add_parameter(self, spec):
+    def test_parameter(self, spec):
         route_spec = self.paths['/pet/{petId}']['get']
 
-        spec.components.add_parameter('test_parameter', 'path', **route_spec['parameters'][0])
+        spec.components.parameter('test_parameter', 'path', **route_spec['parameters'][0])
 
-        spec.add_path(
+        spec.path(
             path='/pet/{petId}',
             operations={'get': {'parameters': ['test_parameter']}},
         )
@@ -323,12 +323,12 @@ class TestPath:
             assert p['parameters'][0] == {'$ref': '#/components/parameters/test_parameter'}
             assert route_spec['parameters'][0] == metadata['components']['parameters']['test_parameter']
 
-    def test_add_response(self, spec):
+    def test_response(self, spec):
         route_spec = self.paths['/pet/{petId}']['get']
 
-        spec.components.add_response('test_response', **route_spec['responses']['200'])
+        spec.components.response('test_response', **route_spec['responses']['200'])
 
-        spec.add_path(
+        spec.path(
             path='/pet/{petId}',
             operations={'get': {'responses': {'200': 'test_response'}}},
         )
@@ -343,11 +343,11 @@ class TestPath:
             assert p['responses']['200'] == {'$ref': '#/components/responses/test_response'}
             assert route_spec['responses']['200'] == metadata['components']['responses']['test_response']
 
-    def test_add_path_check_invalid_http_method(self, spec):
-        spec.add_path('/pet/{petId}', operations={'get': {}})
-        spec.add_path('/pet/{petId}', operations={'x-dummy': {}})
+    def test_path_check_invalid_http_method(self, spec):
+        spec.path('/pet/{petId}', operations={'get': {}})
+        spec.path('/pet/{petId}', operations={'x-dummy': {}})
         with pytest.raises(APISpecError) as excinfo:
-            spec.add_path('/pet/{petId}', operations={'dummy': {}})
+            spec.path('/pet/{petId}', operations={'dummy': {}})
         assert 'One or more HTTP methods are invalid' in str(excinfo)
 
 
@@ -374,7 +374,7 @@ class TestPlugins:
             openapi_version=openapi_version,
             plugins=(self.TestPlugin(), ),
         )
-        spec.components.add_schema('Pet', {})
+        spec.components.schema('Pet', {})
         definitions = get_definitions(spec)
         assert definitions['Pet'] == {'properties': {'name': {'type': 'string'}}}
 
@@ -386,7 +386,7 @@ class TestPlugins:
             openapi_version=openapi_version,
             plugins=(self.TestPlugin(), ),
         )
-        spec.add_path('/path_1')
+        spec.path('/path_1')
         paths = get_paths(spec)
         assert len(paths) == 1
         assert paths['/path_1_modified'] == {'get': {'responses': {'200': {}}}}
@@ -399,7 +399,7 @@ class TestPlugins:
             openapi_version=openapi_version,
             plugins=(self.TestPlugin(), ),
         )
-        spec.add_path('/path_2', operations={'post': {'responses': {'200': {}}}})
+        spec.path('/path_2', operations={'post': {'responses': {'200': {}}}})
         paths = get_paths(spec)
         assert len(paths) == 1
         assert paths['/path_2'] == {'post': {'responses': {'201': {}}}}
@@ -421,7 +421,7 @@ class TestPluginsOrder:
             self.output.append('plugin_{}_operations'.format(self.index))
 
     def test_plugins_order(self):
-        """Test plugins execution order in APISpec.add_path
+        """Test plugins execution order in APISpec.path
 
         - All path helpers are called, then all operation helpers, then all response helpers.
         - At each step, helpers are executed in the order the plugins are passed to APISpec.
@@ -433,7 +433,7 @@ class TestPluginsOrder:
             openapi_version='3.0.0',
             plugins=(self.OrderedPlugin(1, output), self.OrderedPlugin(2, output)),
         )
-        spec.add_path('/path', operations={'get': {'responses': {200: {}}}})
+        spec.path('/path', operations={'get': {'responses': {200: {}}}})
         assert output == [
             'plugin_1_path', 'plugin_2_path',
             'plugin_1_operations', 'plugin_2_operations',

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -29,7 +29,7 @@ class TestDefinitionHelper:
 
     @pytest.mark.parametrize('schema', [PetSchema, PetSchema()])
     def test_can_use_schema_as_definition(self, spec, schema):
-        spec.definition('Pet', schema=schema)
+        spec.components.add_schema('Pet', schema=schema)
         definitions = get_definitions(spec)
         assert 'Pet' in definitions
         props = definitions['Pet']['properties']
@@ -51,7 +51,7 @@ class TestDefinitionHelper:
         )
         assert {} == get_definitions(spec)
 
-        spec.definition('analysis', schema=schema)
+        spec.components.add_schema('analysis', schema=schema)
         spec.add_path(
             '/test', operations={
                 'get': {
@@ -86,7 +86,7 @@ class TestDefinitionHelper:
         )
         assert {} == get_definitions(spec)
 
-        spec.definition('analysis', schema=schema)
+        spec.components.add_schema('analysis', schema=schema)
         spec.add_path(
             '/test', operations={
                 'get': {
@@ -122,7 +122,7 @@ class TestDefinitionHelper:
         )
         assert {} == get_definitions(spec)
 
-        spec.definition('analysis', schema=schema)
+        spec.components.add_schema('analysis', schema=schema)
         spec.add_path(
             '/test', operations={
                 'get': {
@@ -171,9 +171,9 @@ class TestCustomField:
         class CustomPetBSchema(PetSchema):
             name = CustomNameB()
 
-        spec_fixture.spec.definition('Pet', schema=PetSchema)
-        spec_fixture.spec.definition('CustomPetA', schema=CustomPetASchema)
-        spec_fixture.spec.definition('CustomPetB', schema=CustomPetBSchema)
+        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
+        spec_fixture.spec.components.add_schema('CustomPetA', schema=CustomPetASchema)
+        spec_fixture.spec.components.add_schema('CustomPetB', schema=CustomPetBSchema)
 
         props_0 = get_definitions(spec_fixture.spec)['Pet']['properties']
         props_a = get_definitions(spec_fixture.spec)['CustomPetA']['properties']
@@ -321,7 +321,7 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
     def test_schema_uses_ref_if_available_v2(self, spec_fixture):
-        spec_fixture.spec.definition('Pet', schema=PetSchema)
+        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
         spec_fixture.spec.add_path(
             path='/pet',
             operations={
@@ -339,7 +339,7 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
     def test_schema_uses_ref_if_available_v3(self, spec_fixture):
-        spec_fixture.spec.definition('Pet', schema=PetSchema)
+        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
         spec_fixture.spec.add_path(
             path='/pet',
             operations={
@@ -363,7 +363,7 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
     def test_schema_uses_ref_in_parameters_and_request_body_if_available_v2(self, spec_fixture):
-        spec_fixture.spec.definition('Pet', schema=PetSchema)
+        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
         spec_fixture.spec.add_path(
             path='/pet',
             operations={
@@ -389,7 +389,7 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
     def test_schema_uses_ref_in_parameters_and_request_body_if_available_v3(self, spec_fixture):
-        spec_fixture.spec.definition('Pet', schema=PetSchema)
+        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
         spec_fixture.spec.add_path(
             path='/pet',
             operations={
@@ -418,7 +418,7 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
     def test_schema_array_uses_ref_if_available_v2(self, spec_fixture):
-        spec_fixture.spec.definition('Pet', schema=PetSchema)
+        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
         spec_fixture.spec.add_path(
             path='/pet',
             operations={
@@ -452,7 +452,7 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
     def test_schema_array_uses_ref_if_available_v3(self, spec_fixture):
-        spec_fixture.spec.definition('Pet', schema=PetSchema)
+        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
         spec_fixture.spec.add_path(
             path='/pet',
             operations={
@@ -497,7 +497,7 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
     def test_schema_partially_v2(self, spec_fixture):
-        spec_fixture.spec.definition('Pet', schema=PetSchema)
+        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
         spec_fixture.spec.add_path(
             path='/parents',
             operations={
@@ -527,7 +527,7 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
     def test_schema_partially_v3(self, spec_fixture):
-        spec_fixture.spec.definition('Pet', schema=PetSchema)
+        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
         spec_fixture.spec.add_path(
             path='/parents',
             operations={
@@ -574,9 +574,9 @@ class TestOperationHelper:
 class TestCircularReference:
 
     def test_circular_referencing_schemas(self, spec):
-        spec.definition('Analysis', schema=AnalysisSchema)
-        spec.definition('Sample', schema=SampleSchema)
-        spec.definition('Run', schema=RunSchema)
+        spec.components.add_schema('Analysis', schema=AnalysisSchema)
+        spec.components.add_schema('Sample', schema=SampleSchema)
+        spec.components.add_schema('Run', schema=RunSchema)
         definitions = get_definitions(spec)
         ref = definitions['Analysis']['properties']['sample']['$ref']
         assert ref == ref_path(spec) + 'Sample'
@@ -585,13 +585,13 @@ class TestCircularReference:
 class TestSelfReference:
 
     def test_self_referencing_field_single(self, spec):
-        spec.definition('SelfReference', schema=SelfReferencingSchema)
+        spec.components.add_schema('SelfReference', schema=SelfReferencingSchema)
         definitions = get_definitions(spec)
         ref = definitions['SelfReference']['properties']['single']['$ref']
         assert ref == ref_path(spec) + 'SelfReference'
 
     def test_self_referencing_field_many(self, spec):
-        spec.definition('SelfReference', schema=SelfReferencingSchema)
+        spec.components.add_schema('SelfReference', schema=SelfReferencingSchema)
         definitions = get_definitions(spec)
         result = definitions['SelfReference']['properties']['many']
         assert result == {
@@ -601,7 +601,7 @@ class TestSelfReference:
 
     def test_self_referencing_with_ref(self, spec):
         version = 'v2' if spec.openapi_version.version[0] < 3 else 'v3'
-        spec.definition('SelfReference', schema=SelfReferencingSchema)
+        spec.components.add_schema('SelfReference', schema=SelfReferencingSchema)
         definitions = get_definitions(spec)
         result = definitions['SelfReference']['properties'][
             'single_with_ref_{}'.format(version)
@@ -616,20 +616,20 @@ class TestSelfReference:
 class TestOrderedSchema:
 
     def test_ordered_schema(self, spec):
-        spec.definition('Ordered', schema=OrderedSchema)
+        spec.components.add_schema('Ordered', schema=OrderedSchema)
         result = get_definitions(spec)['Ordered']['properties']
         assert list(result.keys()) == ['field1', 'field2', 'field3', 'field4', 'field5']
 
 
 class TestFieldWithCustomProps:
     def test_field_with_custom_props(self, spec):
-        spec.definition('PatternedObject', schema=PatternedObjectSchema)
+        spec.components.add_schema('PatternedObject', schema=PatternedObjectSchema)
         result = get_definitions(spec)['PatternedObject']['properties']['count']
         assert 'x-count' in result
         assert result['x-count'] == 1
 
     def test_field_with_custom_props_passed_as_snake_case(self, spec):
-        spec.definition('PatternedObject', schema=PatternedObjectSchema)
+        spec.components.add_schema('PatternedObject', schema=PatternedObjectSchema)
         result = get_definitions(spec)['PatternedObject']['properties']['count2']
         assert 'x-count2' in result
         assert result['x-count2'] == 2
@@ -637,7 +637,7 @@ class TestFieldWithCustomProps:
 
 class TestSchemaWithDefaultValues:
     def test_schema_with_default_values(self, spec):
-        spec.definition('DefaultValuesSchema', schema=DefaultValuesSchema)
+        spec.components.add_schema('DefaultValuesSchema', schema=DefaultValuesSchema)
         definitions = get_definitions(spec)
         props = definitions['DefaultValuesSchema']['properties']
         assert props['number_auto_default']['default'] == 12
@@ -657,7 +657,7 @@ class TestDictValues:
         class SchemaWithDict(Schema):
             dict_field = Dict(values=String())
 
-        spec.definition('SchemaWithDict', schema=SchemaWithDict)
+        spec.components.add_schema('SchemaWithDict', schema=SchemaWithDict)
         result = get_definitions(spec)['SchemaWithDict']['properties']['dict_field']
         assert result == {'type': 'object', 'additionalProperties': {'type': 'string'}}
 
@@ -666,6 +666,6 @@ class TestDictValues:
         class SchemaWithDict(Schema):
             dict_field = Dict()
 
-        spec.definition('SchemaWithDict', schema=SchemaWithDict)
+        spec.components.add_schema('SchemaWithDict', schema=SchemaWithDict)
         result = get_definitions(spec)['SchemaWithDict']['properties']['dict_field']
         assert result == {'type': 'object'}

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -29,7 +29,7 @@ class TestDefinitionHelper:
 
     @pytest.mark.parametrize('schema', [PetSchema, PetSchema()])
     def test_can_use_schema_as_definition(self, spec, schema):
-        spec.components.add_schema('Pet', schema=schema)
+        spec.components.schema('Pet', schema=schema)
         definitions = get_definitions(spec)
         assert 'Pet' in definitions
         props = definitions['Pet']['properties']
@@ -51,8 +51,8 @@ class TestDefinitionHelper:
         )
         assert {} == get_definitions(spec)
 
-        spec.components.add_schema('analysis', schema=schema)
-        spec.add_path(
+        spec.components.schema('analysis', schema=schema)
+        spec.path(
             '/test', operations={
                 'get': {
                     'responses': {
@@ -86,8 +86,8 @@ class TestDefinitionHelper:
         )
         assert {} == get_definitions(spec)
 
-        spec.components.add_schema('analysis', schema=schema)
-        spec.add_path(
+        spec.components.schema('analysis', schema=schema)
+        spec.path(
             '/test', operations={
                 'get': {
                     'responses': {
@@ -122,8 +122,8 @@ class TestDefinitionHelper:
         )
         assert {} == get_definitions(spec)
 
-        spec.components.add_schema('analysis', schema=schema)
-        spec.add_path(
+        spec.components.schema('analysis', schema=schema)
+        spec.path(
             '/test', operations={
                 'get': {
                     'responses': {
@@ -156,7 +156,7 @@ class TestComponentParameterHelper:
             kwargs = {'schema': schema}
         else:
             kwargs = {'content': {'application/json': {'schema': schema}}}
-        spec.components.add_parameter('Pet', 'body', **kwargs)
+        spec.components.parameter('Pet', 'body', **kwargs)
         parameter = get_parameters(spec)['Pet']
         assert parameter['in'] == 'body'
         if spec.openapi_version.major < 3:
@@ -178,7 +178,7 @@ class TestComponentResponseHelper:
             kwargs = {'schema': schema}
         else:
             kwargs = {'content': {'application/json': {'schema': schema}}}
-        spec.components.add_response('GetPetOk', **kwargs)
+        spec.components.response('GetPetOk', **kwargs)
         response = get_responses(spec)['GetPetOk']
         if spec.openapi_version.major < 3:
             schema = response['schema']['properties']
@@ -214,9 +214,9 @@ class TestCustomField:
         class CustomPetBSchema(PetSchema):
             name = CustomNameB()
 
-        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
-        spec_fixture.spec.components.add_schema('CustomPetA', schema=CustomPetASchema)
-        spec_fixture.spec.components.add_schema('CustomPetB', schema=CustomPetBSchema)
+        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.components.schema('CustomPetA', schema=CustomPetASchema)
+        spec_fixture.spec.components.schema('CustomPetB', schema=CustomPetBSchema)
 
         props_0 = get_definitions(spec_fixture.spec)['Pet']['properties']
         props_a = get_definitions(spec_fixture.spec)['CustomPetA']['properties']
@@ -243,7 +243,7 @@ class TestOperationHelper:
     @pytest.mark.parametrize('pet_schema', (PetSchema, PetSchema(), 'tests.schemas.PetSchema'))
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
     def test_schema_v2(self, spec_fixture, pet_schema):
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.path(
             path='/pet',
             operations={
                 'get': {
@@ -265,7 +265,7 @@ class TestOperationHelper:
     @pytest.mark.parametrize('pet_schema', (PetSchema, PetSchema(), 'tests.schemas.PetSchema'))
     @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
     def test_schema_v3(self, spec_fixture, pet_schema):
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.path(
             path='/pet',
             operations={
                 'get': {
@@ -291,7 +291,7 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
     def test_schema_expand_parameters_v2(self, spec_fixture):
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.path(
             path='/pet',
             operations={
                 'get': {
@@ -324,7 +324,7 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
     def test_schema_expand_parameters_v3(self, spec_fixture):
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.path(
             path='/pet',
             operations={
                 'get': {
@@ -364,8 +364,8 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
     def test_schema_uses_ref_if_available_v2(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.path(
             path='/pet',
             operations={
                 'get': {
@@ -382,8 +382,8 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
     def test_schema_uses_ref_if_available_v3(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.path(
             path='/pet',
             operations={
                 'get': {
@@ -406,8 +406,8 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
     def test_schema_uses_ref_in_parameters_and_request_body_if_available_v2(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.path(
             path='/pet',
             operations={
                 'get': {
@@ -432,8 +432,8 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
     def test_schema_uses_ref_in_parameters_and_request_body_if_available_v3(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.path(
             path='/pet',
             operations={
                 'get': {
@@ -461,8 +461,8 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
     def test_schema_array_uses_ref_if_available_v2(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.path(
             path='/pet',
             operations={
                 'get': {
@@ -495,8 +495,8 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
     def test_schema_array_uses_ref_if_available_v3(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.path(
             path='/pet',
             operations={
                 'get': {
@@ -540,8 +540,8 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
     def test_schema_partially_v2(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.path(
             path='/parents',
             operations={
                 'get': {
@@ -570,8 +570,8 @@ class TestOperationHelper:
 
     @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
     def test_schema_partially_v3(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Pet', schema=PetSchema)
-        spec_fixture.spec.add_path(
+        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.path(
             path='/parents',
             operations={
                 'get': {
@@ -617,9 +617,9 @@ class TestOperationHelper:
 class TestCircularReference:
 
     def test_circular_referencing_schemas(self, spec):
-        spec.components.add_schema('Analysis', schema=AnalysisSchema)
-        spec.components.add_schema('Sample', schema=SampleSchema)
-        spec.components.add_schema('Run', schema=RunSchema)
+        spec.components.schema('Analysis', schema=AnalysisSchema)
+        spec.components.schema('Sample', schema=SampleSchema)
+        spec.components.schema('Run', schema=RunSchema)
         definitions = get_definitions(spec)
         ref = definitions['Analysis']['properties']['sample']['$ref']
         assert ref == ref_path(spec) + 'Sample'
@@ -628,13 +628,13 @@ class TestCircularReference:
 class TestSelfReference:
 
     def test_self_referencing_field_single(self, spec):
-        spec.components.add_schema('SelfReference', schema=SelfReferencingSchema)
+        spec.components.schema('SelfReference', schema=SelfReferencingSchema)
         definitions = get_definitions(spec)
         ref = definitions['SelfReference']['properties']['single']['$ref']
         assert ref == ref_path(spec) + 'SelfReference'
 
     def test_self_referencing_field_many(self, spec):
-        spec.components.add_schema('SelfReference', schema=SelfReferencingSchema)
+        spec.components.schema('SelfReference', schema=SelfReferencingSchema)
         definitions = get_definitions(spec)
         result = definitions['SelfReference']['properties']['many']
         assert result == {
@@ -644,7 +644,7 @@ class TestSelfReference:
 
     def test_self_referencing_with_ref(self, spec):
         version = 'v2' if spec.openapi_version.version[0] < 3 else 'v3'
-        spec.components.add_schema('SelfReference', schema=SelfReferencingSchema)
+        spec.components.schema('SelfReference', schema=SelfReferencingSchema)
         definitions = get_definitions(spec)
         result = definitions['SelfReference']['properties'][
             'single_with_ref_{}'.format(version)
@@ -659,20 +659,20 @@ class TestSelfReference:
 class TestOrderedSchema:
 
     def test_ordered_schema(self, spec):
-        spec.components.add_schema('Ordered', schema=OrderedSchema)
+        spec.components.schema('Ordered', schema=OrderedSchema)
         result = get_definitions(spec)['Ordered']['properties']
         assert list(result.keys()) == ['field1', 'field2', 'field3', 'field4', 'field5']
 
 
 class TestFieldWithCustomProps:
     def test_field_with_custom_props(self, spec):
-        spec.components.add_schema('PatternedObject', schema=PatternedObjectSchema)
+        spec.components.schema('PatternedObject', schema=PatternedObjectSchema)
         result = get_definitions(spec)['PatternedObject']['properties']['count']
         assert 'x-count' in result
         assert result['x-count'] == 1
 
     def test_field_with_custom_props_passed_as_snake_case(self, spec):
-        spec.components.add_schema('PatternedObject', schema=PatternedObjectSchema)
+        spec.components.schema('PatternedObject', schema=PatternedObjectSchema)
         result = get_definitions(spec)['PatternedObject']['properties']['count2']
         assert 'x-count2' in result
         assert result['x-count2'] == 2
@@ -680,7 +680,7 @@ class TestFieldWithCustomProps:
 
 class TestSchemaWithDefaultValues:
     def test_schema_with_default_values(self, spec):
-        spec.components.add_schema('DefaultValuesSchema', schema=DefaultValuesSchema)
+        spec.components.schema('DefaultValuesSchema', schema=DefaultValuesSchema)
         definitions = get_definitions(spec)
         props = definitions['DefaultValuesSchema']['properties']
         assert props['number_auto_default']['default'] == 12
@@ -700,7 +700,7 @@ class TestDictValues:
         class SchemaWithDict(Schema):
             dict_field = Dict(values=String())
 
-        spec.components.add_schema('SchemaWithDict', schema=SchemaWithDict)
+        spec.components.schema('SchemaWithDict', schema=SchemaWithDict)
         result = get_definitions(spec)['SchemaWithDict']['properties']['dict_field']
         assert result == {'type': 'object', 'additionalProperties': {'type': 'string'}}
 
@@ -709,6 +709,6 @@ class TestDictValues:
         class SchemaWithDict(Schema):
             dict_field = Dict()
 
-        spec.components.add_schema('SchemaWithDict', schema=SchemaWithDict)
+        spec.components.schema('SchemaWithDict', schema=SchemaWithDict)
         result = get_definitions(spec)['SchemaWithDict']['properties']['dict_field']
         assert result == {'type': 'object'}

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -614,7 +614,7 @@ class TestNesting:
         return '#/components/schemas/'
 
     def test_field2property_nested_spec_metadatas(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Category', schema=CategorySchema)
+        spec_fixture.spec.components.schema('Category', schema=CategorySchema)
         category = fields.Nested(CategorySchema, description='A category')
         result = spec_fixture.openapi.field2property(category)
         assert result == {
@@ -623,14 +623,14 @@ class TestNesting:
         }
 
     def test_field2property_nested_spec(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Category', schema=CategorySchema)
+        spec_fixture.spec.components.schema('Category', schema=CategorySchema)
         category = fields.Nested(CategorySchema)
         assert spec_fixture.openapi.field2property(category) == {
             '$ref': self.ref_path(spec_fixture.spec) + 'Category',
         }
 
     def test_field2property_nested_many_spec(self, spec_fixture):
-        spec_fixture.spec.components.add_schema('Category', schema=CategorySchema)
+        spec_fixture.spec.components.schema('Category', schema=CategorySchema)
         category = fields.Nested(CategorySchema, many=True)
         ret = spec_fixture.openapi.field2property(category)
         assert ret['type'] == 'array'
@@ -747,7 +747,7 @@ class TestNesting:
         category_6 = fields.Nested(CategorySchema, many=True, ref=ref_path + 'Category')
         category_7 = fields.Nested(CategorySchema, many=True, dump_only=True)
         category_8 = fields.Nested(CategorySchema, many=True, dump_only=True, ref=ref_path + 'Category')
-        spec_fixture.spec.components.add_schema('Category', schema=CategorySchema)
+        spec_fixture.spec.components.schema('Category', schema=CategorySchema)
 
         assert spec_fixture.openapi.field2property(category_1) == {
             '$ref': ref_path + 'Category',
@@ -784,10 +784,10 @@ def test_openapi_tools_validate_v2():
     )
     openapi = ma_plugin.openapi
 
-    spec.components.add_schema('Category', schema=CategorySchema)
-    spec.components.add_schema('Pet', schema=PetSchema, extra_fields={'discriminator': 'name'})
+    spec.components.schema('Category', schema=CategorySchema)
+    spec.components.schema('Pet', schema=PetSchema, extra_fields={'discriminator': 'name'})
 
-    spec.add_path(
+    spec.path(
         view=None,
         path='/category/{category_id}',
         operations={
@@ -841,10 +841,10 @@ def test_openapi_tools_validate_v3():
     )
     #openapi = ma_plugin.openapi
 
-    spec.components.add_schema('Category', schema=CategorySchema)
-    spec.components.add_schema('Pet', schema=PetSchemaV3)
+    spec.components.schema('Category', schema=CategorySchema)
+    spec.components.schema('Pet', schema=PetSchemaV3)
 
-    spec.add_path(
+    spec.path(
         view=None,
         path='/category/{category_id}',
         operations={
@@ -934,7 +934,7 @@ class ValidationSchema(Schema):
 class TestFieldValidation:
 
     def test_range(self, spec):
-        spec.components.add_schema('Validation', schema=ValidationSchema)
+        spec.components.schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['range']
 
         assert 'minimum' in result
@@ -943,7 +943,7 @@ class TestFieldValidation:
         assert result['maximum'] == 10
 
     def test_multiple_ranges(self, spec):
-        spec.components.add_schema('Validation', schema=ValidationSchema)
+        spec.components.schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['multiple_ranges']
 
         assert 'minimum' in result
@@ -952,7 +952,7 @@ class TestFieldValidation:
         assert result['maximum'] == 7
 
     def test_list_length(self, spec):
-        spec.components.add_schema('Validation', schema=ValidationSchema)
+        spec.components.schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['list_length']
 
         assert 'minItems' in result
@@ -961,7 +961,7 @@ class TestFieldValidation:
         assert result['maxItems'] == 10
 
     def test_string_length(self, spec):
-        spec.components.add_schema('Validation', schema=ValidationSchema)
+        spec.components.schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['string_length']
 
         assert 'minLength' in result
@@ -970,7 +970,7 @@ class TestFieldValidation:
         assert result['maxLength'] == 10
 
     def test_multiple_lengths(self, spec):
-        spec.components.add_schema('Validation', schema=ValidationSchema)
+        spec.components.schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['multiple_lengths']
 
         assert 'minLength' in result
@@ -979,7 +979,7 @@ class TestFieldValidation:
         assert result['maxLength'] == 7
 
     def test_equal_length(self, spec):
-        spec.components.add_schema('Validation', schema=ValidationSchema)
+        spec.components.schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['equal_length']
 
         assert 'minLength' in result

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -614,7 +614,7 @@ class TestNesting:
         return '#/components/schemas/'
 
     def test_field2property_nested_spec_metadatas(self, spec_fixture):
-        spec_fixture.spec.definition('Category', schema=CategorySchema)
+        spec_fixture.spec.components.add_schema('Category', schema=CategorySchema)
         category = fields.Nested(CategorySchema, description='A category')
         result = spec_fixture.openapi.field2property(category)
         assert result == {
@@ -623,14 +623,14 @@ class TestNesting:
         }
 
     def test_field2property_nested_spec(self, spec_fixture):
-        spec_fixture.spec.definition('Category', schema=CategorySchema)
+        spec_fixture.spec.components.add_schema('Category', schema=CategorySchema)
         category = fields.Nested(CategorySchema)
         assert spec_fixture.openapi.field2property(category) == {
             '$ref': self.ref_path(spec_fixture.spec) + 'Category',
         }
 
     def test_field2property_nested_many_spec(self, spec_fixture):
-        spec_fixture.spec.definition('Category', schema=CategorySchema)
+        spec_fixture.spec.components.add_schema('Category', schema=CategorySchema)
         category = fields.Nested(CategorySchema, many=True)
         ret = spec_fixture.openapi.field2property(category)
         assert ret['type'] == 'array'
@@ -747,7 +747,7 @@ class TestNesting:
         category_6 = fields.Nested(CategorySchema, many=True, ref=ref_path + 'Category')
         category_7 = fields.Nested(CategorySchema, many=True, dump_only=True)
         category_8 = fields.Nested(CategorySchema, many=True, dump_only=True, ref=ref_path + 'Category')
-        spec_fixture.spec.definition('Category', schema=CategorySchema)
+        spec_fixture.spec.components.add_schema('Category', schema=CategorySchema)
 
         assert spec_fixture.openapi.field2property(category_1) == {
             '$ref': ref_path + 'Category',
@@ -784,8 +784,8 @@ def test_openapi_tools_validate_v2():
     )
     openapi = ma_plugin.openapi
 
-    spec.definition('Category', schema=CategorySchema)
-    spec.definition('Pet', schema=PetSchema, extra_fields={'discriminator': 'name'})
+    spec.components.add_schema('Category', schema=CategorySchema)
+    spec.components.add_schema('Pet', schema=PetSchema, extra_fields={'discriminator': 'name'})
 
     spec.add_path(
         view=None,
@@ -841,8 +841,8 @@ def test_openapi_tools_validate_v3():
     )
     #openapi = ma_plugin.openapi
 
-    spec.definition('Category', schema=CategorySchema)
-    spec.definition('Pet', schema=PetSchemaV3)
+    spec.components.add_schema('Category', schema=CategorySchema)
+    spec.components.add_schema('Pet', schema=PetSchemaV3)
 
     spec.add_path(
         view=None,
@@ -934,7 +934,7 @@ class ValidationSchema(Schema):
 class TestFieldValidation:
 
     def test_range(self, spec):
-        spec.definition('Validation', schema=ValidationSchema)
+        spec.components.add_schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['range']
 
         assert 'minimum' in result
@@ -943,7 +943,7 @@ class TestFieldValidation:
         assert result['maximum'] == 10
 
     def test_multiple_ranges(self, spec):
-        spec.definition('Validation', schema=ValidationSchema)
+        spec.components.add_schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['multiple_ranges']
 
         assert 'minimum' in result
@@ -952,7 +952,7 @@ class TestFieldValidation:
         assert result['maximum'] == 7
 
     def test_list_length(self, spec):
-        spec.definition('Validation', schema=ValidationSchema)
+        spec.components.add_schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['list_length']
 
         assert 'minItems' in result
@@ -961,7 +961,7 @@ class TestFieldValidation:
         assert result['maxItems'] == 10
 
     def test_string_length(self, spec):
-        spec.definition('Validation', schema=ValidationSchema)
+        spec.components.add_schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['string_length']
 
         assert 'minLength' in result
@@ -970,7 +970,7 @@ class TestFieldValidation:
         assert result['maxLength'] == 10
 
     def test_multiple_lengths(self, spec):
-        spec.definition('Validation', schema=ValidationSchema)
+        spec.components.add_schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['multiple_lengths']
 
         assert 'minLength' in result
@@ -979,7 +979,7 @@ class TestFieldValidation:
         assert result['maxLength'] == 7
 
     def test_equal_length(self, spec):
-        spec.definition('Validation', schema=ValidationSchema)
+        spec.components.add_schema('Validation', schema=ValidationSchema)
         result = get_definitions(spec)['Validation']['properties']['equal_length']
 
         assert 'minLength' in result

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,11 @@ def get_definitions(spec):
         return spec.to_dict()['definitions']
     return spec.to_dict()['components']['schemas']
 
+def get_parameters(spec):
+    if spec.openapi_version.major < 3:
+        return spec.to_dict()['parameters']
+    return spec.to_dict()['components']['parameters']
+
 def get_responses(spec):
     if spec.openapi_version.major < 3:
         return spec.to_dict()['responses']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,5 +6,10 @@ def get_definitions(spec):
         return spec.to_dict()['definitions']
     return spec.to_dict()['components']['schemas']
 
+def get_responses(spec):
+    if spec.openapi_version.major < 3:
+        return spec.to_dict()['responses']
+    return spec.to_dict()['components']['responses']
+
 def get_paths(spec):
     return spec.to_dict()['paths']


### PR DESCRIPTION
I've been trying to work on https://github.com/marshmallow-code/apispec/issues/245.

This PR adds a `Components` class that stores the components. Components is v3 terminology. In v2, those are just top-level fields.

For now, it only has `add_schema` (formerly `spec.definition`) and `add_parameter` (formerly `spec.add_parameter`). It is a first step before adding other methods like `add_response`, `add_security_scheme`, etc (the point of #245).

I'm using v3 terminology because it is the future (hopefully...), but this is v2 compatible. I could even alias `add_definition` to `add_scheme` but I don't think it is necessary.

There's nothing mandatory in adding this `Components` class, we could keep all `add_xxx` methods in `APISpec`. I just thought it would be nicer this way.

From user perspective, the only difference is that

    spec.add_parameter(...)
    spec.definition(...)

become

    spec.components.add_parameter(...)
    spec.components.add_schema(...)

~The first commit is just a modification to the test to make sure we test the result (the doc that is produced) and not the internals (spec._definitions,...). It can be merged independently.~ (Done.)

Waiting for feedback about this before addressing the other components (reponses,...).

TODO:

- [x] Update changelog
- [x] Update docs