### PR TITLE
Fix flake8 issues

### DIFF
--- a/apispec/ext/marshmallow/openapi.py
+++ b/apispec/ext/marshmallow/openapi.py
@@ -603,10 +603,12 @@ class OpenAPIConverter(object):
             ):
                 continue
 
+            def prop_func(field_obj=field_obj):
+                return self.field2property(
+                    field_obj, use_refs=use_refs, dump=dump, load=load, name=name,
+                )
+
             observed_field_name = self._observed_name(field_obj, field_name)
-            prop_func = lambda field_obj=field_obj: self.field2property(  # flake8: noqa
-                field_obj, use_refs=use_refs, dump=dump, load=load, name=name,
-            )
             jsonschema['properties'][observed_field_name] = prop_func
 
             partial = getattr(schema, 'partial', None)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath('..'))
-import apispec  # flake8: noqa
+import apispec  # noqa: E402
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,9 @@ universal=1
 # E128: continuation line under-indented for visual indent
 # E265: block comment should start with #
 # E302: expected 2 blank lines, found 0
+# E266: too many leading ‘#’ for block comment
+# W504: line break after binary operator
 [flake8]
-ignore = E127,E128,E265,E302,E266
+ignore = E127,E128,E265,E302,E266,W504
 max-line-length = 110
-exclude=.git,docs,env,venv,.ropeproject,build,.tox
+exclude = .git,docs,env,venv,.ropeproject,build,.tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,3 @@ universal=1
 [flake8]
 ignore = E127,E128,E265,E302,E266,W504
 max-line-length = 110
-exclude = .git,docs,env,venv,.ropeproject,build,.tox


### PR DESCRIPTION
There were new flake8 issues.

This PR fixes E731 and configures flake8 to ignore W504.

Regarding W503 / W504, it is still a bit blurry to me but in [this bug report](https://gitlab.com/pycqa/flake8/issues/463), @asottile says pycodestyle now reports both. Since they are incompatible, I think it is up to us to choose our convention.

---------------------------------------------------------------------------------------------------------------------------------

And now we have another CI failure because flake8 did not exclude the docs directory.

I don't get it. Here's the config.

```
# E127: continuation line over-indented for visual indent
# E128: continuation line under-indented for visual indent
# E265: block comment should start with #
# E302: expected 2 blank lines, found 0
# E266: too many leading ‘#’ for block comment
# W504: line break after binary operator
[flake8]
ignore = E127,E128,E265,E302,E266,W504
max-line-length = 110
exclude = .git,docs,env,venv,.ropeproject,build,.tox
```

I can't even reproduce the failure on my local setup.