### PR TITLE
Call resolve_schema_cls throught OpenAPIConverter

### DIFF
--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -74,11 +74,11 @@ class MarshmallowPlugin(BasePlugin):
             nested_schema_class = None
 
             if isinstance(field, marshmallow.fields.Nested):
-                nested_schema_class = resolve_schema_cls(field.schema)
+                nested_schema_class = self.openapi.resolve_schema_class(field.schema)
 
             elif isinstance(field, marshmallow.fields.List) \
                     and isinstance(field.container, marshmallow.fields.Nested):
-                nested_schema_class = resolve_schema_cls(field.container.schema)
+                nested_schema_class = self.openapi.resolve_schema_class(field.container.schema)
 
             if nested_schema_class and nested_schema_class not in self.openapi.refs:
                 definition_name = self.schema_name_resolver(

--- a/apispec/ext/marshmallow/openapi.py
+++ b/apispec/ext/marshmallow/openapi.py
@@ -660,7 +660,7 @@ class OpenAPIConverter(object):
         if isinstance(schema, marshmallow.Schema) and use_instances:
             schema_cls = schema
         else:
-            schema_cls = resolve_schema_cls(schema)
+            schema_cls = self.resolve_schema_class(schema)
 
         if schema_cls in self.refs:
             ref_path = self.get_ref_path()
@@ -674,3 +674,11 @@ class OpenAPIConverter(object):
         if not isinstance(schema, marshmallow.Schema):
             schema = schema_cls
         return self.schema2jsonschema(schema, dump=dump, load=load)
+
+    def resolve_schema_class(self, schema):
+        """Return schema class for given schema (instance or class)
+
+        :param type|Schema|str: instance, class or class name of marshmallow.Schema
+        :return: schema class of given schema (instance or class)
+        """
+        return resolve_schema_cls(schema)


### PR DESCRIPTION
Hello,

We start writing apispec plugins and this change could be appreciated: You can see in following methods:

* `apispec.ext.marshmallow.MarshmallowPlugin#inspect_schema_for_auto_referencing`
* `apispec.ext.marshmallow.openapi.OpenAPIConverter#resolve_schema_dict`

`resolve_schema_cls` is directly called. In our plugins, we want override this method. For now, we have to completely override these method:

* https://github.com/algoo/apispec_plugins/blob/develop/apispec_hapic_marshmallow/apispec_hapic_marshmallow/__init__.py#L14
* https://github.com/algoo/apispec_plugins/blob/develop/apispec_hapic_marshmallow/apispec_hapic_marshmallow/openapi.py#L13

With these changes, we will be able to override only the concerned part:

* https://github.com/algoo/apispec_plugins/blob/feature/use_openapi_resolve_schema_cls_method/apispec_hapic_marshmallow/apispec_hapic_marshmallow/openapi.py#L12

Thank's,
bux.