### PR TITLE
Revise field2properties

### DIFF
--- a/apispec/ext/marshmallow/openapi.py
+++ b/apispec/ext/marshmallow/openapi.py
@@ -407,8 +407,6 @@ class OpenAPIConverter(object):
                     ret['additionalProperties'] = self.field2property(
                         field.value_container, use_refs=use_refs,
                     )
-        # Property "ref" is not valid in this context
-        ret.pop('ref', None)
 
         return ret
 

--- a/apispec/ext/marshmallow/openapi.py
+++ b/apispec/ext/marshmallow/openapi.py
@@ -166,6 +166,26 @@ class OpenAPIConverter(object):
 
         return ret
 
+    def field2default(self, field):
+        """Return the dictionary containing the field's default value
+
+        Will first look for a `doc_default` key in the field's metadata and then
+        fall back on the field's `missing` parameter. A callable passed to the
+        field's missing parameter will be ignored.
+
+        :param Field field: A marshmallow field.
+        :rtype: dict
+        """
+        ret = {}
+        if 'doc_default' in field.metadata:
+            ret['default'] = field.metadata['doc_default']
+        else:
+            default = field.missing
+            if default is not marshmallow.missing and not callable(default):
+                    ret['default'] = default
+
+        return ret
+
     def field2choices(self, field, **kwargs):
         """Return the dictionary of OpenAPI field attributes for valid choices definition
 
@@ -355,15 +375,10 @@ class OpenAPIConverter(object):
         :rtype: dict, a Property Object
         """
         ret = {}
-        if 'doc_default' in field.metadata:
-            ret['default'] = field.metadata['doc_default']
-        else:
-            default = field.missing
-            if default is not marshmallow.missing and not callable(default):
-                    ret['default'] = default
 
         for attr_func in (
                 self.field2type_and_format,
+                self.field2default,
                 self.field2choices,
                 self.field2read_only,
                 self.field2write_only,

--- a/apispec/ext/marshmallow/openapi.py
+++ b/apispec/ext/marshmallow/openapi.py
@@ -148,6 +148,24 @@ class OpenAPIConverter(object):
 
         return inner
 
+    def field2type_and_format(self, field):
+        """Return the dictionary of OpenAPI type and format based on the field
+        type
+
+        :param Field field: A marshmallow field.
+        :rtype: dict
+        """
+        type_, fmt = self.field_mapping.get(type(field), ('string', None))
+
+        ret = {
+            'type': type_,
+        }
+
+        if fmt:
+            ret['format'] = fmt
+
+        return ret
+
     def field2choices(self, field, **kwargs):
         """Return the dictionary of OpenAPI field attributes for valid choices definition
 
@@ -336,16 +354,7 @@ class OpenAPIConverter(object):
         :param str name: The definition name, if applicable, used to construct the $ref value.
         :rtype: dict, a Property Object
         """
-
-        type_, fmt = self.field_mapping.get(type(field), ('string', None))
-
-        ret = {
-            'type': type_,
-        }
-
-        if fmt:
-            ret['format'] = fmt
-
+        ret = {}
         if 'doc_default' in field.metadata:
             ret['default'] = field.metadata['doc_default']
         else:
@@ -354,6 +363,7 @@ class OpenAPIConverter(object):
                     ret['default'] = default
 
         for attr_func in (
+                self.field2type_and_format,
                 self.field2choices,
                 self.field2read_only,
                 self.field2write_only,

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -574,11 +574,17 @@ class TestNesting:
 
     def test_field2property_nested_spec_metadatas(self, spec_fixture):
         spec_fixture.spec.components.schema('Category', schema=CategorySchema)
-        category = fields.Nested(CategorySchema, description='A category')
+        category = fields.Nested(
+            CategorySchema,
+            description='A category',
+            invalid_property='not in the result',
+            x_extension='A great extension',
+        )
         result = spec_fixture.openapi.field2property(category)
         assert result == {
-            '$ref': ref_path(spec_fixture.spec) + 'Category',
+            'allOf': [{'$ref': ref_path(spec_fixture.spec) + 'Category'}],
             'description': 'A category',
+            'x-extension': 'A great extension',
         }
 
     def test_field2property_nested_spec(self, spec_fixture):
@@ -598,11 +604,6 @@ class TestNesting:
     def test_field2property_nested_ref(self, openapi):
         cat_with_ref = fields.Nested(CategorySchema, ref='Category')
         assert openapi.field2property(cat_with_ref) == {'$ref': 'Category'}
-
-    def test_field2property_nested_ref_with_meta(self, openapi):
-        cat_with_ref = fields.Nested(CategorySchema, ref='Category', description='A category')
-        result = openapi.field2property(cat_with_ref)
-        assert result == {'$ref': 'Category', 'description': 'A category'}
 
     def test_field2property_nested_many(self, spec_fixture):
         categories = fields.Nested(CategorySchema, many=True)


### PR DESCRIPTION
Fixes an issue with an invalid reference object being created by extracting properties from field metadata before handling nested schemas.  

Also extracts methods from `field2properties` to make the method smaller and add documentation about each step.