### PR TITLE
Refactor schema2 fields2

### DIFF
--- a/apispec/ext/marshmallow/common.py
+++ b/apispec/ext/marshmallow/common.py
@@ -21,7 +21,13 @@ def resolve_schema_instance(schema):
         return schema()
     if isinstance(schema, marshmallow.Schema):
         return schema
-    return marshmallow.class_registry.get_class(schema)()
+    try:
+        return marshmallow.class_registry.get_class(schema)()
+    except marshmallow.exceptions.RegistryError:
+        raise ValueError(
+            '{!r} is not a marshmallow.Schema subclass or instance and has not'
+            ' been registered in the Marshmallow class registry.'.format(schema),
+        )
 
 
 def resolve_schema_cls(schema):
@@ -34,25 +40,42 @@ def resolve_schema_cls(schema):
         return schema
     if isinstance(schema, marshmallow.Schema):
         return type(schema)
-    return marshmallow.class_registry.get_class(schema)
+    try:
+        return marshmallow.class_registry.get_class(schema)
+    except marshmallow.exceptions.RegistryError:
+        raise ValueError(
+            '{!r} is not a marshmallow.Schema subclass or instance and has not'
+            ' been registered in the Marshmallow class registry.'.format(schema),
+        )
 
 
-def get_fields(schema):
-    """Return fields from schema"""
+def get_fields(schema, exclude_dump_only=False):
+    """Return fields from schema
+
+    :param Schema schema: A marshmallow Schema instance or a class object
+    :param bool exclude_dump_only: whether to filter fields in Meta.dump_only
+    :rtype: dict, of field name field object pairs
+    """
     if hasattr(schema, 'fields'):
         fields = schema.fields
     elif hasattr(schema, '_declared_fields'):
         fields = copy.deepcopy(schema._declared_fields)
     else:
-        raise ValueError("{0!r} doesn't have either `fields` or `_declared_fields`.".format(schema))
-
-    return filter_excluded_fields(fields, schema)
-
-
-def filter_excluded_fields(fields, schema):
+        raise ValueError("{!r} doesn't have either `fields` or `_declared_fields`.".format(schema))
     Meta = getattr(schema, 'Meta', None)
+    warn_if_fields_defined_in_meta(fields, Meta)
+    return filter_excluded_fields(fields, Meta, exclude_dump_only)
+
+
+def warn_if_fields_defined_in_meta(fields, Meta):
+    """Warns user that fields defined in Meta.fields or Meta.additional will
+    be ignored
+
+    :param dict fields: A dictionary of of fields name field object pairs
+    :param Meta: the schema's Meta class
+    """
     if getattr(Meta, 'fields', None) or getattr(Meta, 'additional', None):
-        declared_fields = set(schema._declared_fields.keys())
+        declared_fields = set(fields.keys())
         if (
             set(getattr(Meta, 'fields', set())) > declared_fields or
             set(getattr(Meta, 'additional', set())) > declared_fields
@@ -62,7 +85,17 @@ def filter_excluded_fields(fields, schema):
                 'Fields defined in Meta.fields or Meta.additional are ignored.',
             )
 
+
+def filter_excluded_fields(fields, Meta, exclude_dump_only):
+    """Filter fields that should be ignored in the OpenAPI spec
+
+    :param dict fields: A dictionary of of fields name field object pairs
+    :param Meta: the schema's Meta class
+    :param bool exclude_dump_only: whether to filter fields in Meta.dump_only
+    """
     exclude = getattr(Meta, 'exclude', [])
+    if exclude_dump_only:
+        exclude += getattr(Meta, 'dump_only', [])
 
     filtered_fields = OrderedDict(
         (key, value) for key, value in fields.items() if key not in exclude

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -167,7 +167,7 @@ class TestMarshmallowFieldToOpenAPI:
             id = fields.Int()
 
         schema = ExampleSchema(many=True)
-        res = openapi.fields2parameters(schema.fields, schema=schema, default_in='json')
+        res = openapi.schema2parameters(schema=schema, default_in='json')
         assert res[0]['in'] == 'body'
 
     def test_fields_with_dump_only(self, openapi):
@@ -183,12 +183,8 @@ class TestMarshmallowFieldToOpenAPI:
 
             class Meta:
                 dump_only = ('name',)
-        res = openapi.fields2parameters(
-            UserSchema._declared_fields, schema=UserSchema, default_in='query',
-        )
-        assert len(res) == 0
-        res = openapi.fields2parameters(
-            UserSchema().fields, schema=UserSchema, default_in='query',
+        res = openapi.schema2parameters(
+            schema=UserSchema, default_in='query',
         )
         assert len(res) == 0
 


### PR DESCRIPTION
Redistributes logic between `schema2jsonschema` and `fields2jsonschema` and between `schema2parameters` and `fields2parameters`.  Now the `fields2` methods only use a `fields` parameter instead of both `fields` and `schema`.  

Factors logic for filtering fields and warning the user about fields defined in `Meta.fields` and `Meta.additional` into common functions.

I think this helps to understand what is going on in these functions.