### PR TITLE
Use black to format codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,20 @@
 repos:
-- repo: https://github.com/asottile/add-trailing-comma
-  rev: v0.7.1
+- repo: https://github.com/asottile/pyupgrade
+  rev: v1.11.0
   hooks:
-  - id: add-trailing-comma
+  - id: pyupgrade
+    exclude: docopt.py
+- repo: https://github.com/ambv/black
+  rev: 18.9b0
+  hooks:
+  - id: black
+    language_version: python3.6
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v2.1.0
   hooks:
-  - id: trailing-whitespace
-  - id: double-quote-string-fixer
-  - id: end-of-file-fixer
   - id: flake8
+- repo: https://github.com/asottile/blacken-docs
+  rev: v0.3.0
+  hooks:
+  - id: blacken-docs
+    additional_dependencies: [black==18.9b0]

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Example Application
           description: Get a random pet
           responses:
             200:
-            content:
+              content:
                 application/json:
                   schema: PetSchema
         """

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,10 @@ apispec
     :target: https://marshmallow.readthedocs.io/en/latest/upgrading.html
     :alt: marshmallow 2/3 compatible
 
+.. image:: https://badgen.net/badge/code%20style/black/000
+    :target: https://github.com/ambv/black
+    :alt: code style: black
+
 A pluggable API specification generator. Currently supports the `OpenAPI Specification <https://github.com/OAI/OpenAPI-Specification>`_ (f.k.a. the Swagger specification).
 
 Features
@@ -42,13 +46,10 @@ Example Application
 
     # Create an APISpec
     spec = APISpec(
-        title='Swagger Petstore',
-        version='1.0.0',
-        openapi_version='3.0.2',
-        plugins=[
-            FlaskPlugin(),
-            MarshmallowPlugin(),
-        ],
+        title="Swagger Petstore",
+        version="1.0.0",
+        openapi_version="3.0.2",
+        plugins=[FlaskPlugin(), MarshmallowPlugin()],
     )
 
     # Optional marshmallow support
@@ -56,14 +57,17 @@ Example Application
         id = fields.Int()
         name = fields.Str(required=True)
 
+
     class PetSchema(Schema):
         category = fields.Nested(CategorySchema, many=True)
         name = fields.Str()
 
+
     # Optional Flask support
     app = Flask(__name__)
 
-    @app.route('/random')
+
+    @app.route("/random")
     def random_pet():
         """A cute furry animal endpoint.
         ---
@@ -78,9 +82,10 @@ Example Application
         pet = get_random_pet()
         return jsonify(PetSchema().dump(pet).data)
 
+
     # Register entities and paths
-    spec.components.schema('Category', schema=CategorySchema)
-    spec.components.schema('Pet', schema=PetSchema)
+    spec.components.schema("Category", schema=CategorySchema)
+    spec.components.schema("Pet", schema=PetSchema)
     with app.test_request_context():
         spec.path(view=random_pet)
 
@@ -91,6 +96,7 @@ Generated OpenAPI Spec
 .. code-block:: python
 
     import json
+
     print(json.dumps(spec.to_dict(), indent=2))
     # {
     #   "paths": {

--- a/apispec/__init__.py
+++ b/apispec/__init__.py
@@ -4,8 +4,5 @@
 from .core import APISpec
 from .plugin import BasePlugin
 
-__version__ = '1.0.0rc1'
-__all__ = [
-    'APISpec',
-    'BasePlugin',
-]
+__version__ = "1.0.0rc1"
+__all__ = ["APISpec", "BasePlugin"]

--- a/apispec/compat.py
+++ b/apispec/compat.py
@@ -3,7 +3,7 @@
 import re
 import sys
 
-RegexType = type(re.compile(''))
+RegexType = type(re.compile(""))
 
 PY2 = int(sys.version[0]) == 2
 

--- a/apispec/exceptions.py
+++ b/apispec/exceptions.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
 """Exception classes."""
 
+
 class APISpecError(Exception):
     """Base class for all apispec-related errors."""
+
 
 class PluginMethodNotImplementedError(APISpecError, NotImplementedError):
     """Raised when calling an unimplemented helper method in a plugin"""
 
+
 class DuplicateComponentNameError(APISpecError):
     """Raised when registering two components with the same name"""
+
 
 class OpenAPIError(APISpecError):
     """Raised when a OpenAPI spec validation fails."""

--- a/apispec/ext/marshmallow/__init__.py
+++ b/apispec/ext/marshmallow/__init__.py
@@ -41,7 +41,7 @@ def resolver(schema):
     """Default implementation of a schema name resolver function
     """
     name = schema.__name__
-    if name.endswith('Schema'):
+    if name.endswith("Schema"):
         return name[:-6] or name
     return name
 
@@ -59,6 +59,7 @@ class MarshmallowPlugin(BasePlugin):
             def schema_name_resolver(schema):
                 return schema.__name__
     """
+
     def __init__(self, schema_name_resolver=None):
         super(MarshmallowPlugin, self).__init__()
         self.schema_name_resolver = schema_name_resolver or resolver
@@ -79,13 +80,12 @@ class MarshmallowPlugin(BasePlugin):
     def resolve_parameters(self, parameters):
         resolved = []
         for parameter in parameters:
-            if not isinstance(parameter.get('schema', {}), dict):
-                schema_instance = resolve_schema_instance(parameter['schema'])
-                if 'in' in parameter:
-                    del parameter['schema']
+            if not isinstance(parameter.get("schema", {}), dict):
+                schema_instance = resolve_schema_instance(parameter["schema"])
+                if "in" in parameter:
+                    del parameter["schema"]
                     resolved += self.openapi.schema2parameters(
-                        schema_instance,
-                        default_in=parameter.pop('in'), **parameter
+                        schema_instance, default_in=parameter.pop("in"), **parameter
                     )
                     continue
             self.resolve_schema(parameter)
@@ -96,10 +96,10 @@ class MarshmallowPlugin(BasePlugin):
         """Function to resolve a schema in a requestBody object - modifies then
         response dict to convert Marshmallow Schema object or class into dict
         """
-        content = request_body['content']
+        content = request_body["content"]
         for content_type in content:
-            schema = content[content_type]['schema']
-            content[content_type]['schema'] = self.openapi.resolve_schema_dict(schema)
+            schema = content[content_type]["schema"]
+            content[content_type]["schema"] = self.openapi.resolve_schema_dict(schema)
 
     def resolve_schema(self, data):
         """Function to resolve a schema in a parameter or response - modifies the
@@ -109,15 +109,15 @@ class MarshmallowPlugin(BasePlugin):
         :param dict data: the parameter or response dictionary that may contain a schema
         """
         if self.openapi_version.major < 3:
-            if 'schema' in data:
-                data['schema'] = self.openapi.resolve_schema_dict(data['schema'])
+            if "schema" in data:
+                data["schema"] = self.openapi.resolve_schema_dict(data["schema"])
         else:
-            if 'content' in data:
-                for content_type in data['content']:
-                    schema = data['content'][content_type]['schema']
-                    data['content'][content_type]['schema'] = self.openapi.resolve_schema_dict(
-                        schema,
-                    )
+            if "content" in data:
+                for content_type in data["content"]:
+                    schema = data["content"][content_type]["schema"]
+                    data["content"][content_type][
+                        "schema"
+                    ] = self.openapi.resolve_schema_dict(schema)
 
     def map_to_openapi_type(self, *args):
         """Decorator to set mapping for custom fields.
@@ -182,12 +182,14 @@ class MarshmallowPlugin(BasePlugin):
         for operation in operations.values():
             if not isinstance(operation, dict):
                 continue
-            if 'parameters' in operation:
-                operation['parameters'] = self.resolve_parameters(operation['parameters'])
+            if "parameters" in operation:
+                operation["parameters"] = self.resolve_parameters(
+                    operation["parameters"]
+                )
             if self.openapi_version.major >= 3:
-                if 'requestBody' in operation:
-                    self.resolve_schema_in_request_body(operation['requestBody'])
-            for response in operation.get('responses', {}).values():
+                if "requestBody" in operation:
+                    self.resolve_schema_in_request_body(operation["requestBody"])
+            for response in operation.get("responses", {}).values():
                 self.resolve_schema(response)
 
     def warn_if_schema_already_in_spec(self, schema_key):
@@ -196,7 +198,7 @@ class MarshmallowPlugin(BasePlugin):
         """
         if schema_key in self.openapi.refs:
             warnings.warn(
-                '{} has already been added to the spec. Adding it twice may '
-                'cause references to not resove properly'.format(schema_key[0]),
+                "{} has already been added to the spec. Adding it twice may "
+                "cause references to not resove properly".format(schema_key[0]),
                 UserWarning,
             )

--- a/apispec/ext/marshmallow/common.py
+++ b/apispec/ext/marshmallow/common.py
@@ -8,7 +8,7 @@ from collections import namedtuple, OrderedDict
 import marshmallow
 
 
-MODIFIERS = ['only', 'exclude', 'load_only', 'dump_only', 'partial']
+MODIFIERS = ["only", "exclude", "load_only", "dump_only", "partial"]
 
 
 def resolve_schema_instance(schema):
@@ -25,8 +25,8 @@ def resolve_schema_instance(schema):
         return marshmallow.class_registry.get_class(schema)()
     except marshmallow.exceptions.RegistryError:
         raise ValueError(
-            '{!r} is not a marshmallow.Schema subclass or instance and has not'
-            ' been registered in the Marshmallow class registry.'.format(schema),
+            "{!r} is not a marshmallow.Schema subclass or instance and has not"
+            " been registered in the Marshmallow class registry.".format(schema)
         )
 
 
@@ -44,8 +44,8 @@ def resolve_schema_cls(schema):
         return marshmallow.class_registry.get_class(schema)
     except marshmallow.exceptions.RegistryError:
         raise ValueError(
-            '{!r} is not a marshmallow.Schema subclass or instance and has not'
-            ' been registered in the Marshmallow class registry.'.format(schema),
+            "{!r} is not a marshmallow.Schema subclass or instance and has not"
+            " been registered in the Marshmallow class registry.".format(schema)
         )
 
 
@@ -56,13 +56,15 @@ def get_fields(schema, exclude_dump_only=False):
     :param bool exclude_dump_only: whether to filter fields in Meta.dump_only
     :rtype: dict, of field name field object pairs
     """
-    if hasattr(schema, 'fields'):
+    if hasattr(schema, "fields"):
         fields = schema.fields
-    elif hasattr(schema, '_declared_fields'):
+    elif hasattr(schema, "_declared_fields"):
         fields = copy.deepcopy(schema._declared_fields)
     else:
-        raise ValueError("{!r} doesn't have either `fields` or `_declared_fields`.".format(schema))
-    Meta = getattr(schema, 'Meta', None)
+        raise ValueError(
+            "{!r} doesn't have either `fields` or `_declared_fields`.".format(schema)
+        )
+    Meta = getattr(schema, "Meta", None)
     warn_if_fields_defined_in_meta(fields, Meta)
     return filter_excluded_fields(fields, Meta, exclude_dump_only)
 
@@ -74,15 +76,15 @@ def warn_if_fields_defined_in_meta(fields, Meta):
     :param dict fields: A dictionary of of fields name field object pairs
     :param Meta: the schema's Meta class
     """
-    if getattr(Meta, 'fields', None) or getattr(Meta, 'additional', None):
+    if getattr(Meta, "fields", None) or getattr(Meta, "additional", None):
         declared_fields = set(fields.keys())
         if (
-            set(getattr(Meta, 'fields', set())) > declared_fields or
-            set(getattr(Meta, 'additional', set())) > declared_fields
+            set(getattr(Meta, "fields", set())) > declared_fields
+            or set(getattr(Meta, "additional", set())) > declared_fields
         ):
             warnings.warn(
-                'Only explicitly-declared fields will be included in the Schema Object. '
-                'Fields defined in Meta.fields or Meta.additional are ignored.',
+                "Only explicitly-declared fields will be included in the Schema Object. "
+                "Fields defined in Meta.fields or Meta.additional are ignored."
             )
 
 
@@ -93,9 +95,9 @@ def filter_excluded_fields(fields, Meta, exclude_dump_only):
     :param Meta: the schema's Meta class
     :param bool exclude_dump_only: whether to filter fields in Meta.dump_only
     """
-    exclude = getattr(Meta, 'exclude', [])
+    exclude = getattr(Meta, "exclude", [])
     if exclude_dump_only:
-        exclude += getattr(Meta, 'dump_only', [])
+        exclude += getattr(Meta, "dump_only", [])
 
     filtered_fields = OrderedDict(
         (key, value) for key, value in fields.items() if key not in exclude
@@ -106,7 +108,7 @@ def filter_excluded_fields(fields, Meta, exclude_dump_only):
 
 def make_schema_key(schema):
     if not isinstance(schema, marshmallow.Schema):
-        raise TypeError('can only make a schema key based on a Schema instance.')
+        raise TypeError("can only make a schema key based on a Schema instance.")
     modifiers = []
     for modifier in MODIFIERS:
         attribute = getattr(schema, modifier)
@@ -118,7 +120,7 @@ def make_schema_key(schema):
     return SchemaKey(schema.__class__, *modifiers)
 
 
-SchemaKey = namedtuple('SchemaKey', ['SchemaClass'] + MODIFIERS)
+SchemaKey = namedtuple("SchemaKey", ["SchemaClass"] + MODIFIERS)
 
 
 def get_unique_schema_name(components, name, counter=0):
@@ -135,12 +137,12 @@ def get_unique_schema_name(components, name, counter=0):
         return name
     if not counter:  # first time time through recursion
         warnings.warn(
-            'Multiple schemas resolved to the name {} - name has been modified '
-            'either manually add each of the schemas with a different name or '
-            'provide custom schema_name_resolver'.format(name),
+            "Multiple schemas resolved to the name {} - name has been modified "
+            "either manually add each of the schemas with a different name or "
+            "provide custom schema_name_resolver".format(name),
             UserWarning,
         )
     else:  # subsequent recursions
-        name = name[:-len(str(counter))]
+        name = name[: -len(str(counter))]
     counter += 1
     return get_unique_schema_name(components, name + str(counter), counter)

--- a/apispec/ext/marshmallow/openapi.py
+++ b/apispec/ext/marshmallow/openapi.py
@@ -16,46 +16,49 @@ from marshmallow.orderedset import OrderedSet
 from apispec.compat import RegexType
 from apispec.utils import OpenAPIVersion
 from .common import (
-    resolve_schema_cls, get_fields, make_schema_key, resolve_schema_instance,
+    resolve_schema_cls,
+    get_fields,
+    make_schema_key,
+    resolve_schema_instance,
     get_unique_schema_name,
 )
 from apispec.exceptions import APISpecError
 
 
 MARSHMALLOW_VERSION_INFO = tuple(
-    [int(part) for part in marshmallow.__version__.split('.') if part.isdigit()],
+    [int(part) for part in marshmallow.__version__.split(".") if part.isdigit()]
 )
 
 # marshmallow field => (JSON Schema type, format)
 DEFAULT_FIELD_MAPPING = {
-    marshmallow.fields.Integer: ('integer', 'int32'),
-    marshmallow.fields.Number: ('number', None),
-    marshmallow.fields.Float: ('number', 'float'),
-    marshmallow.fields.Decimal: ('number', None),
-    marshmallow.fields.String: ('string', None),
-    marshmallow.fields.Boolean: ('boolean', None),
-    marshmallow.fields.UUID: ('string', 'uuid'),
-    marshmallow.fields.DateTime: ('string', 'date-time'),
-    marshmallow.fields.Date: ('string', 'date'),
-    marshmallow.fields.Time: ('string', None),
-    marshmallow.fields.Email: ('string', 'email'),
-    marshmallow.fields.URL: ('string', 'url'),
-    marshmallow.fields.Dict: ('object', None),
+    marshmallow.fields.Integer: ("integer", "int32"),
+    marshmallow.fields.Number: ("number", None),
+    marshmallow.fields.Float: ("number", "float"),
+    marshmallow.fields.Decimal: ("number", None),
+    marshmallow.fields.String: ("string", None),
+    marshmallow.fields.Boolean: ("boolean", None),
+    marshmallow.fields.UUID: ("string", "uuid"),
+    marshmallow.fields.DateTime: ("string", "date-time"),
+    marshmallow.fields.Date: ("string", "date"),
+    marshmallow.fields.Time: ("string", None),
+    marshmallow.fields.Email: ("string", "email"),
+    marshmallow.fields.URL: ("string", "url"),
+    marshmallow.fields.Dict: ("object", None),
     # Assume base Field and Raw are strings
-    marshmallow.fields.Field: ('string', None),
-    marshmallow.fields.Raw: ('string', None),
-    marshmallow.fields.List: ('array', None),
+    marshmallow.fields.Field: ("string", None),
+    marshmallow.fields.Raw: ("string", None),
+    marshmallow.fields.List: ("array", None),
 }
 
 
 __location_map__ = {
-    'query': 'query',
-    'querystring': 'query',
-    'json': 'body',
-    'headers': 'header',
-    'cookies': 'cookie',
-    'form': 'formData',
-    'files': 'formData',
+    "query": "query",
+    "querystring": "query",
+    "json": "body",
+    "headers": "header",
+    "cookies": "cookie",
+    "form": "formData",
+    "files": "formData",
 }
 
 
@@ -63,37 +66,37 @@ __location_map__ = {
 # of field2property
 # https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject
 _VALID_PROPERTIES = {
-    'format',
-    'title',
-    'description',
-    'default',
-    'multipleOf',
-    'maximum',
-    'exclusiveMaximum',
-    'minimum',
-    'exclusiveMinimum',
-    'maxLength',
-    'minLength',
-    'pattern',
-    'maxItems',
-    'minItems',
-    'uniqueItems',
-    'maxProperties',
-    'minProperties',
-    'required',
-    'enum',
-    'type',
-    'items',
-    'allOf',
-    'properties',
-    'additionalProperties',
-    'readOnly',
-    'xml',
-    'externalDocs',
-    'example',
+    "format",
+    "title",
+    "description",
+    "default",
+    "multipleOf",
+    "maximum",
+    "exclusiveMaximum",
+    "minimum",
+    "exclusiveMinimum",
+    "maxLength",
+    "minLength",
+    "pattern",
+    "maxItems",
+    "minItems",
+    "uniqueItems",
+    "maxProperties",
+    "minProperties",
+    "required",
+    "enum",
+    "type",
+    "items",
+    "allOf",
+    "properties",
+    "additionalProperties",
+    "readOnly",
+    "xml",
+    "externalDocs",
+    "example",
 }
 
-_VALID_PREFIX = 'x-'
+_VALID_PREFIX = "x-"
 
 
 class OpenAPIConverter(object):
@@ -102,13 +105,14 @@ class OpenAPIConverter(object):
     :param str|OpenAPIVersion openapi_version: The OpenAPI version to use.
         Should be in the form '2.x' or '3.x.x' to comply with the OpenAPI standard.
     """
+
     def __init__(self, openapi_version, schema_name_resolver, spec):
         self.openapi_version = OpenAPIVersion(openapi_version)
         self.schema_name_resolver = schema_name_resolver
         self.spec = spec
         # Schema references
         self.refs = {}
-        # Field mappings
+        #  Field mappings
         self.field_mapping = DEFAULT_FIELD_MAPPING
 
     @staticmethod
@@ -121,8 +125,8 @@ class OpenAPIConverter(object):
         """
         if MARSHMALLOW_VERSION_INFO[0] < 3:
             # use getattr in case we're running against older versions of marshmallow.
-            dump_to = getattr(field, 'dump_to', None)
-            load_from = getattr(field, 'load_from', None)
+            dump_to = getattr(field, "dump_to", None)
+            load_from = getattr(field, "load_from", None)
             return dump_to or load_from or name
         return field.data_key or name
 
@@ -139,7 +143,7 @@ class OpenAPIConverter(object):
         elif len(args) == 2:
             openapi_type_field = args
         else:
-            raise TypeError('Pass core marshmallow field type or (type, fmt) pair.')
+            raise TypeError("Pass core marshmallow field type or (type, fmt) pair.")
 
         def inner(field_type):
             self.field_mapping[field_type] = openapi_type_field
@@ -154,14 +158,12 @@ class OpenAPIConverter(object):
         :param Field field: A marshmallow field.
         :rtype: dict
         """
-        type_, fmt = self.field_mapping.get(type(field), ('string', None))
+        type_, fmt = self.field_mapping.get(type(field), ("string", None))
 
-        ret = {
-            'type': type_,
-        }
+        ret = {"type": type_}
 
         if fmt:
-            ret['format'] = fmt
+            ret["format"] = fmt
 
         return ret
 
@@ -176,12 +178,12 @@ class OpenAPIConverter(object):
         :rtype: dict
         """
         ret = {}
-        if 'doc_default' in field.metadata:
-            ret['default'] = field.metadata['doc_default']
+        if "doc_default" in field.metadata:
+            ret["default"] = field.metadata["doc_default"]
         else:
             default = field.missing
             if default is not marshmallow.missing and not callable(default):
-                ret['default'] = default
+                ret["default"] = default
 
         return ret
 
@@ -194,18 +196,20 @@ class OpenAPIConverter(object):
         attributes = {}
 
         comparable = [
-            validator.comparable for validator in field.validators
-            if hasattr(validator, 'comparable')
+            validator.comparable
+            for validator in field.validators
+            if hasattr(validator, "comparable")
         ]
         if comparable:
-            attributes['enum'] = comparable
+            attributes["enum"] = comparable
         else:
             choices = [
-                OrderedSet(validator.choices) for validator in field.validators
-                if hasattr(validator, 'choices')
+                OrderedSet(validator.choices)
+                for validator in field.validators
+                if hasattr(validator, "choices")
             ]
             if choices:
-                attributes['enum'] = list(functools.reduce(operator.and_, choices))
+                attributes["enum"] = list(functools.reduce(operator.and_, choices))
 
         return attributes
 
@@ -217,7 +221,7 @@ class OpenAPIConverter(object):
         """
         attributes = {}
         if field.dump_only:
-            attributes['readOnly'] = True
+            attributes["readOnly"] = True
         return attributes
 
     def field2write_only(self, field, **kwargs):
@@ -228,7 +232,7 @@ class OpenAPIConverter(object):
         """
         attributes = {}
         if field.load_only and self.openapi_version.major >= 3:
-            attributes['writeOnly'] = True
+            attributes["writeOnly"] = True
         return attributes
 
     def field2nullable(self, field, **kwargs):
@@ -239,7 +243,9 @@ class OpenAPIConverter(object):
         """
         attributes = {}
         if field.allow_none:
-            attributes['x-nullable' if self.openapi_version.major < 3 else 'nullable'] = True
+            attributes[
+                "x-nullable" if self.openapi_version.major < 3 else "nullable"
+            ] = True
         return attributes
 
     def field2range(self, field, **kwargs):
@@ -250,32 +256,27 @@ class OpenAPIConverter(object):
         :rtype: dict
         """
         validators = [
-            validator for validator in field.validators
+            validator
+            for validator in field.validators
             if (
-                hasattr(validator, 'min') and
-                hasattr(validator, 'max') and
-                not hasattr(validator, 'equal')
+                hasattr(validator, "min")
+                and hasattr(validator, "max")
+                and not hasattr(validator, "equal")
             )
         ]
 
         attributes = {}
         for validator in validators:
             if validator.min is not None:
-                if hasattr(attributes, 'minimum'):
-                    attributes['minimum'] = max(
-                        attributes['minimum'],
-                        validator.min,
-                    )
+                if hasattr(attributes, "minimum"):
+                    attributes["minimum"] = max(attributes["minimum"], validator.min)
                 else:
-                    attributes['minimum'] = validator.min
+                    attributes["minimum"] = validator.min
             if validator.max is not None:
-                if hasattr(attributes, 'maximum'):
-                    attributes['maximum'] = min(
-                        attributes['maximum'],
-                        validator.max,
-                    )
+                if hasattr(attributes, "maximum"):
+                    attributes["maximum"] = min(attributes["maximum"], validator.max)
                 else:
-                    attributes['maximum'] = validator.max
+                    attributes["maximum"] = validator.max
         return attributes
 
     def field2length(self, field, **kwargs):
@@ -288,38 +289,30 @@ class OpenAPIConverter(object):
         attributes = {}
 
         validators = [
-            validator for validator in field.validators
+            validator
+            for validator in field.validators
             if (
-                hasattr(validator, 'min') and
-                hasattr(validator, 'max') and
-                hasattr(validator, 'equal')
+                hasattr(validator, "min")
+                and hasattr(validator, "max")
+                and hasattr(validator, "equal")
             )
         ]
 
         is_array = isinstance(
-            field, (
-                marshmallow.fields.Nested,
-                marshmallow.fields.List,
-            ),
+            field, (marshmallow.fields.Nested, marshmallow.fields.List)
         )
-        min_attr = 'minItems' if is_array else 'minLength'
-        max_attr = 'maxItems' if is_array else 'maxLength'
+        min_attr = "minItems" if is_array else "minLength"
+        max_attr = "maxItems" if is_array else "maxLength"
 
         for validator in validators:
             if validator.min is not None:
                 if hasattr(attributes, min_attr):
-                    attributes[min_attr] = max(
-                        attributes[min_attr],
-                        validator.min,
-                    )
+                    attributes[min_attr] = max(attributes[min_attr], validator.min)
                 else:
                     attributes[min_attr] = validator.min
             if validator.max is not None:
                 if hasattr(attributes, max_attr):
-                    attributes[max_attr] = min(
-                        attributes[max_attr],
-                        validator.max,
-                    )
+                    attributes[max_attr] = min(attributes[max_attr], validator.max)
                 else:
                     attributes[max_attr] = validator.max
 
@@ -336,16 +329,19 @@ class OpenAPIConverter(object):
         :param Field field: A marshmallow field.
         :rtype: dict
         """
-        regex_validators = (v for v in field.validators
-                            if isinstance(getattr(v, 'regex', None), RegexType))
+        regex_validators = (
+            v
+            for v in field.validators
+            if isinstance(getattr(v, "regex", None), RegexType)
+        )
         v = next(regex_validators, None)
-        attributes = {} if v is None else {'pattern': v.regex.pattern}
+        attributes = {} if v is None else {"pattern": v.regex.pattern}
 
         if next(regex_validators, None) is not None:
             warnings.warn(
-                'More than one regex validator defined on {} field. Only the '
-                'first one will be used in the output spec.'
-                .format(type(field)), UserWarning,
+                "More than one regex validator defined on {} field. Only the "
+                "first one will be used in the output spec.".format(type(field)),
+                UserWarning,
             )
 
         return attributes
@@ -369,13 +365,14 @@ class OpenAPIConverter(object):
         """
         # Dasherize metadata that starts with x_
         metadata = {
-            key.replace('_', '-') if key.startswith('x_') else key: value
+            key.replace("_", "-") if key.startswith("x_") else key: value
             for key, value in iteritems(field.metadata)
         }
 
         # Avoid validation error with "Additional properties not allowed"
         ret = {
-            key: value for key, value in metadata.items()
+            key: value
+            for key, value in metadata.items()
             if key in _VALID_PROPERTIES or key.startswith(_VALID_PREFIX)
         }
         return ret
@@ -395,36 +392,36 @@ class OpenAPIConverter(object):
         ret = {}
 
         for attr_func in (
-                self.field2type_and_format,
-                self.field2default,
-                self.field2choices,
-                self.field2read_only,
-                self.field2write_only,
-                self.field2nullable,
-                self.field2range,
-                self.field2length,
-                self.field2pattern,
-                self.metadata2properties,
+            self.field2type_and_format,
+            self.field2default,
+            self.field2choices,
+            self.field2read_only,
+            self.field2write_only,
+            self.field2nullable,
+            self.field2range,
+            self.field2length,
+            self.field2pattern,
+            self.metadata2properties,
         ):
             ret.update(attr_func(field))
 
         if isinstance(field, marshmallow.fields.Nested):
-            del ret['type']
+            del ret["type"]
             # marshmallow>=2.7.0 compat
-            field.metadata.pop('many', None)
+            field.metadata.pop("many", None)
 
             schema_dict = self.resolve_nested_schema(field.schema)
-            if ret and '$ref' in schema_dict:
-                ret.update({'allOf': [schema_dict]})
+            if ret and "$ref" in schema_dict:
+                ret.update({"allOf": [schema_dict]})
             else:
                 ret.update(schema_dict)
         elif isinstance(field, marshmallow.fields.List):
-            ret['items'] = self.field2property(field.container)
+            ret["items"] = self.field2property(field.container)
         elif isinstance(field, marshmallow.fields.Dict):
             if MARSHMALLOW_VERSION_INFO[0] >= 3:
                 if field.value_container:
-                    ret['additionalProperties'] = self.field2property(
-                        field.value_container,
+                    ret["additionalProperties"] = self.field2property(
+                        field.value_container
                     )
 
         return ret
@@ -451,21 +448,18 @@ class OpenAPIConverter(object):
                     return self.schema2jsonschema(schema)
                 except RuntimeError:
                     raise APISpecError(
-                        'Name resolver returned None for schema {schema} which is '
-                        'part of a chain of circular referencing schemas. Please'
-                        ' ensure that the schema_name_resolver passed to'
-                        ' MarshmallowPlugin returns a string for all circular'
-                        ' referencing schemas.'.format(schema=schema),
+                        "Name resolver returned None for schema {schema} which is "
+                        "part of a chain of circular referencing schemas. Please"
+                        " ensure that the schema_name_resolver passed to"
+                        " MarshmallowPlugin returns a string for all circular"
+                        " referencing schemas.".format(schema=schema)
                     )
             name = get_unique_schema_name(self.spec.components, name)
-            self.spec.components.schema(
-                name,
-                schema=schema,
-            )
+            self.spec.components.schema(name, schema=schema)
         return self.get_ref_dict(schema_instance)
 
     def schema2parameters(
-        self, schema, default_in='body', name='body', required=False, description=None,
+        self, schema, default_in="body", name="body", required=False, description=None
     ):
         """Return an array of OpenAPI parameters given a given marshmallow
         :class:`Schema <marshmallow.Schema>`. If `default_in` is "body", then return an array
@@ -475,29 +469,30 @@ class OpenAPIConverter(object):
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject
         """
         openapi_default_in = __location_map__.get(default_in, default_in)
-        if self.openapi_version.major < 3 and openapi_default_in == 'body':
+        if self.openapi_version.major < 3 and openapi_default_in == "body":
             prop = self.resolve_schema_dict(schema)
 
             param = {
-                'in': openapi_default_in,
-                'required': required,
-                'name': name,
-                'schema': prop,
+                "in": openapi_default_in,
+                "required": required,
+                "name": name,
+                "schema": prop,
             }
 
             if description:
-                param['description'] = description
+                param["description"] = description
 
             return [param]
 
-        assert not getattr(schema, 'many', False), \
-            "Schemas with many=True are only supported for 'json' location (aka 'in: body')"
+        assert not getattr(
+            schema, "many", False
+        ), "Schemas with many=True are only supported for 'json' location (aka 'in: body')"
 
         fields = get_fields(schema, exclude_dump_only=True)
 
         return self.fields2parameters(fields, default_in=default_in)
 
-    def fields2parameters(self, fields, default_in='body'):
+    def fields2parameters(self, fields, default_in="body"):
         """Return an array of OpenAPI parameters given a mapping between field names and
         :class:`Field <marshmallow.Field>` objects. If `default_in` is "body", then return an array
         of a single parameter; else return an array of a parameter for each included field in
@@ -521,24 +516,30 @@ class OpenAPIConverter(object):
                 name=self._observed_name(field_obj, field_name),
                 default_in=default_in,
             )
-            if self.openapi_version.major < 3 and param['in'] == 'body' and body_param is not None:
-                body_param['schema']['properties'].update(param['schema']['properties'])
-                required_fields = param['schema'].get('required', [])
+            if (
+                self.openapi_version.major < 3
+                and param["in"] == "body"
+                and body_param is not None
+            ):
+                body_param["schema"]["properties"].update(param["schema"]["properties"])
+                required_fields = param["schema"].get("required", [])
                 if required_fields:
-                    body_param['schema'].setdefault('required', []).extend(required_fields)
+                    body_param["schema"].setdefault("required", []).extend(
+                        required_fields
+                    )
             else:
-                if self.openapi_version.major < 3 and param['in'] == 'body':
+                if self.openapi_version.major < 3 and param["in"] == "body":
                     body_param = param
                 parameters.append(param)
         return parameters
 
-    def field2parameter(self, field, name='body', default_in='body'):
+    def field2parameter(self, field, name="body", default_in="body"):
         """Return an OpenAPI parameter as a `dict`, given a marshmallow
         :class:`Field <marshmallow.Field>`.
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject
         """
-        location = field.metadata.get('location', None)
+        location = field.metadata.get("location", None)
         prop = self.field2property(field)
         return self.property2parameter(
             prop,
@@ -550,8 +551,13 @@ class OpenAPIConverter(object):
         )
 
     def property2parameter(
-        self, prop, name='body', required=False, multiple=False,
-        location=None, default_in='body',
+        self,
+        prop,
+        name="body",
+        required=False,
+        multiple=False,
+        location=None,
+        default_in="body",
     ):
         """Return the Parameter Object definition for a JSON Schema property.
 
@@ -568,33 +574,30 @@ class OpenAPIConverter(object):
         """
         openapi_default_in = __location_map__.get(default_in, default_in)
         openapi_location = __location_map__.get(location, openapi_default_in)
-        ret = {
-            'in': openapi_location,
-            'name': name,
-        }
+        ret = {"in": openapi_location, "name": name}
 
-        if openapi_location == 'body':
-            ret['required'] = False
-            ret['name'] = 'body'
-            ret['schema'] = {
-                'type': 'object',
-                'properties': {name: prop} if name else {},
+        if openapi_location == "body":
+            ret["required"] = False
+            ret["name"] = "body"
+            ret["schema"] = {
+                "type": "object",
+                "properties": {name: prop} if name else {},
             }
             if name and required:
-                ret['schema']['required'] = [name]
+                ret["schema"]["required"] = [name]
         else:
-            ret['required'] = required
+            ret["required"] = required
             if self.openapi_version.major < 3:
                 if multiple:
-                    ret['collectionFormat'] = 'multi'
+                    ret["collectionFormat"] = "multi"
                 ret.update(prop)
             else:
                 if multiple:
-                    ret['explode'] = True
-                    ret['style'] = 'form'
-                if prop.get('description', None):
-                    ret['description'] = prop.pop('description')
-                ret['schema'] = prop
+                    ret["explode"] = True
+                    ret["style"] = "form"
+                if prop.get("description", None):
+                    ret["description"] = prop.pop("description")
+                ret["schema"] = prop
         return ret
 
     def schema2jsonschema(self, schema):
@@ -630,22 +633,19 @@ class OpenAPIConverter(object):
         :rtype: dict, a JSON Schema Object
         """
         fields = get_fields(schema)
-        Meta = getattr(schema, 'Meta', None)
-        partial = getattr(schema, 'partial', None)
-        ordered = getattr(schema, 'ordered', False)
+        Meta = getattr(schema, "Meta", None)
+        partial = getattr(schema, "partial", None)
+        ordered = getattr(schema, "ordered", False)
 
         jsonschema = self.fields2jsonschema(fields, partial=partial, ordered=ordered)
 
-        if hasattr(Meta, 'title'):
-            jsonschema['title'] = Meta.title
-        if hasattr(Meta, 'description'):
-            jsonschema['description'] = Meta.description
+        if hasattr(Meta, "title"):
+            jsonschema["title"] = Meta.title
+        if hasattr(Meta, "description"):
+            jsonschema["description"] = Meta.description
 
-        if getattr(schema, 'many', False):
-            jsonschema = {
-                'type': 'array',
-                'items': jsonschema,
-            }
+        if getattr(schema, "many", False):
+            jsonschema = {"type": "array", "items": jsonschema}
 
         return jsonschema
 
@@ -660,22 +660,21 @@ class OpenAPIConverter(object):
             in the iterable will not be marked as required.
         :rtype: dict, a JSON Schema Object
         """
-        jsonschema = {
-            'type': 'object',
-            'properties': OrderedDict() if ordered else {},
-        }
+        jsonschema = {"type": "object", "properties": OrderedDict() if ordered else {}}
 
         for field_name, field_obj in iteritems(fields):
             observed_field_name = self._observed_name(field_obj, field_name)
             property = self.field2property(field_obj)
-            jsonschema['properties'][observed_field_name] = property
+            jsonschema["properties"][observed_field_name] = property
 
             if field_obj.required:
-                if not partial or (is_collection(partial) and field_name not in partial):
-                    jsonschema.setdefault('required', []).append(observed_field_name)
+                if not partial or (
+                    is_collection(partial) and field_name not in partial
+                ):
+                    jsonschema.setdefault("required", []).append(observed_field_name)
 
-        if 'required' in jsonschema:
-            jsonschema['required'].sort()
+        if "required" in jsonschema:
+            jsonschema["required"].sort()
 
         return jsonschema
 
@@ -685,12 +684,9 @@ class OpenAPIConverter(object):
         """
         ref_path = self.get_ref_path()
         schema_key = make_schema_key(schema)
-        ref_schema = {'$ref': '#/{0}/{1}'.format(ref_path, self.refs[schema_key])}
-        if getattr(schema, 'many', False):
-            return {
-                'type': 'array',
-                'items': ref_schema,
-            }
+        ref_schema = {"$ref": "#/{}/{}".format(ref_path, self.refs[schema_key])}
+        if getattr(schema, "many", False):
+            return {"type": "array", "items": ref_schema}
         return ref_schema
 
     def get_ref_path(self):
@@ -699,20 +695,17 @@ class OpenAPIConverter(object):
         :param int openapi_version.major: The major version of the OpenAPI standard
             to use. Supported values are 2 and 3.
         """
-        ref_paths = {
-            2: 'definitions',
-            3: 'components/schemas',
-        }
+        ref_paths = {2: "definitions", 3: "components/schemas"}
         return ref_paths[self.openapi_version.major]
 
     def resolve_schema_dict(self, schema):
         if isinstance(schema, dict):
-            if schema.get('type') == 'array' and 'items' in schema:
-                schema['items'] = self.resolve_schema_dict(schema['items'])
-            if schema.get('type') == 'object' and 'properties' in schema:
-                schema['properties'] = {
+            if schema.get("type") == "array" and "items" in schema:
+                schema["items"] = self.resolve_schema_dict(schema["items"])
+            if schema.get("type") == "object" and "properties" in schema:
+                schema["properties"] = {
                     k: self.resolve_schema_dict(v)
-                    for k, v in schema['properties'].items()
+                    for k, v in schema["properties"].items()
                 }
             return schema
 

--- a/apispec/plugin.py
+++ b/apispec/plugin.py
@@ -4,8 +4,10 @@
 
 from .exceptions import PluginMethodNotImplementedError
 
+
 class BasePlugin(object):
     """Base class for APISpec plugin classes."""
+
     def init_spec(self, spec):
         """Initialize plugin with APISpec object
 

--- a/apispec/utils.py
+++ b/apispec/utils.py
@@ -9,6 +9,7 @@ from distutils import version
 
 from apispec import exceptions
 
+
 def validate_spec(spec):
     """Validate the output of an :class:`APISpec` object against the
     OpenAPI specification.
@@ -25,13 +26,13 @@ def validate_spec(spec):
     except ImportError as error:  # re-raise with a more verbose message
         exc_class = type(error)
         raise exc_class(
-            'validate_spec requires prance to be installed. '
-            'You can install all validation requirements using:\n'
-            "    pip install 'apispec[validation]'",
+            "validate_spec requires prance to be installed. "
+            "You can install all validation requirements using:\n"
+            "    pip install 'apispec[validation]'"
         )
     parser_kwargs = {}
     if spec.openapi_version.version[0] == 3:
-        parser_kwargs['backend'] = 'openapi-spec-validator'
+        parser_kwargs["backend"] = "openapi-spec-validator"
     try:
         prance.BaseParser(spec_string=json.dumps(spec.to_dict()), **parser_kwargs)
     except prance.ValidationError as err:
@@ -57,15 +58,20 @@ class OpenAPIVersion(version.LooseVersion, object):
             assert ver.vstring == '3.0.2'
             assert str(ver) == '3.0.2'
     """
-    MIN_INCLUSIVE_VERSION = version.LooseVersion('2.0')
-    MAX_EXCLUSIVE_VERSION = version.LooseVersion('4.0')
+
+    MIN_INCLUSIVE_VERSION = version.LooseVersion("2.0")
+    MAX_EXCLUSIVE_VERSION = version.LooseVersion("4.0")
 
     def __init__(self, openapi_version):
         if isinstance(openapi_version, version.LooseVersion):
             openapi_version = openapi_version.vstring
-        if not self.MIN_INCLUSIVE_VERSION <= openapi_version < self.MAX_EXCLUSIVE_VERSION:
+        if (
+            not self.MIN_INCLUSIVE_VERSION
+            <= openapi_version
+            < self.MAX_EXCLUSIVE_VERSION
+        ):
             raise exceptions.APISpecError(
-                'Not a valid OpenAPI version number: {}'.format(openapi_version),
+                "Not a valid OpenAPI version number: {}".format(openapi_version)
             )
         super(OpenAPIVersion, self).__init__(openapi_version)
 
@@ -81,6 +87,7 @@ class OpenAPIVersion(version.LooseVersion, object):
     def patch(self):
         return self.version[2]
 
+
 # from django.contrib.admindocs.utils
 def trim_docstring(docstring):
     """Uniformly trims leading/trailing whitespace from docstrings.
@@ -88,12 +95,13 @@ def trim_docstring(docstring):
     Based on http://www.python.org/peps/pep-0257.html#handling-docstring-indentation
     """
     if not docstring or not docstring.strip():
-        return ''
+        return ""
     # Convert tabs to spaces and split into lines
     lines = docstring.expandtabs().splitlines()
     indent = min(len(line) - len(line.lstrip()) for line in lines if line.lstrip())
     trimmed = [lines[0].lstrip()] + [line[indent:].rstrip() for line in lines[1:]]
-    return '\n'.join(trimmed).strip()
+    return "\n".join(trimmed).strip()
+
 
 # from rest_framework.utils.formatting
 def dedent(content):
@@ -104,13 +112,16 @@ def dedent(content):
     as it fails to dedent multiline docstrings that include
     unindented text on the initial line.
     """
-    whitespace_counts = [len(line) - len(line.lstrip(' '))
-                         for line in content.splitlines()[1:] if line.lstrip()]
+    whitespace_counts = [
+        len(line) - len(line.lstrip(" "))
+        for line in content.splitlines()[1:]
+        if line.lstrip()
+    ]
 
     # unindent the content if needed
     if whitespace_counts:
-        whitespace_pattern = '^' + (' ' * min(whitespace_counts))
-        content = re.sub(re.compile(whitespace_pattern, re.MULTILINE), '', content)
+        whitespace_pattern = "^" + (" " * min(whitespace_counts))
+        content = re.sub(re.compile(whitespace_pattern, re.MULTILINE), "", content)
 
     return content.strip()
 

--- a/apispec/yaml_utils.py
+++ b/apispec/yaml_utils.py
@@ -9,15 +9,15 @@ from apispec.utils import trim_docstring, dedent
 
 
 class YAMLDumper(yaml.Dumper):
-
     @staticmethod
     def _represent_dict(dumper, instance):
-        return dumper.represent_mapping('tag:yaml.org,2002:map', instance.items())
+        return dumper.represent_mapping("tag:yaml.org,2002:map", instance.items())
 
     if PY2:
+
         @staticmethod
         def _represent_unicode(_, uni):
-            return yaml.ScalarNode(tag=u'tag:yaml.org,2002:str', value=uni)
+            return yaml.ScalarNode(tag=u"tag:yaml.org,2002:str", value=uni)
 
 
 if PY2:
@@ -31,31 +31,24 @@ def dict_to_yaml(dic):
 
 def load_yaml_from_docstring(docstring):
     """Loads YAML from docstring."""
-    split_lines = trim_docstring(docstring).split('\n')
+    split_lines = trim_docstring(docstring).split("\n")
 
     # Cut YAML from rest of docstring
     for index, line in enumerate(split_lines):
         line = line.strip()
-        if line.startswith('---'):
+        if line.startswith("---"):
             cut_from = index
             break
     else:
         return {}
 
-    yaml_string = '\n'.join(split_lines[cut_from:])
+    yaml_string = "\n".join(split_lines[cut_from:])
     yaml_string = dedent(yaml_string)
     return yaml.safe_load(yaml_string) or {}
 
 
-PATH_KEYS = set([
-    'get',
-    'put',
-    'post',
-    'delete',
-    'options',
-    'head',
-    'patch',
-])
+PATH_KEYS = {"get", "put", "post", "delete", "options", "head", "patch"}
+
 
 def load_operations_from_docstring(docstring):
     """Return a dictionary of OpenAPI operations parsed from a
@@ -63,6 +56,7 @@ def load_operations_from_docstring(docstring):
     """
     doc_data = load_yaml_from_docstring(docstring)
     return {
-        key: val for key, val in iteritems(doc_data)
-        if key in PATH_KEYS or key.startswith('x-')
+        key: val
+        for key, val in iteritems(doc_data)
+        if key in PATH_KEYS or key.startswith("x-")
     }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,42 +5,43 @@ import datetime as dt
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 import apispec  # noqa: E402
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.todo',
-    'sphinx_issues',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.todo",
+    "sphinx_issues",
 ]
 
-primary_domain = 'py'
-default_role = 'py:obj'
+primary_domain = "py"
+default_role = "py:obj"
 
 intersphinx_mapping = {
-    'python': ('http://python.readthedocs.io/en/latest/', None),
-    'marshmallow': ('http://marshmallow.readthedocs.io/en/latest/', None),
+    "python": ("http://python.readthedocs.io/en/latest/", None),
+    "marshmallow": ("http://marshmallow.readthedocs.io/en/latest/", None),
 }
 
-issues_github_path = 'marshmallow-code/apispec'
+issues_github_path = "marshmallow-code/apispec"
 
-source_suffix = '.rst'
-master_doc = 'index'
-project = 'apispec'
-copyright = 'Steven Loria {0:%Y}'.format(dt.datetime.utcnow())
+source_suffix = ".rst"
+master_doc = "index"
+project = "apispec"
+copyright = "Steven Loria {:%Y}".format(dt.datetime.utcnow())
 
 version = release = apispec.__version__
 
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # THEME
 
 # on_rtd is whether we are on readthedocs.org
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
+
+    html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,7 +57,7 @@ Example Application
           description: Get a random pet
           responses:
             200:
-            content:
+              content:
                 application/json:
                   schema: PetSchema
         """

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,13 +28,10 @@ Example Application
 
     # Create an APISpec
     spec = APISpec(
-        title='Swagger Petstore',
-        version='1.0.0',
-        openapi_version='3.0.2',
-        plugins=[
-            FlaskPlugin(),
-            MarshmallowPlugin(),
-        ],
+        title="Swagger Petstore",
+        version="1.0.0",
+        openapi_version="3.0.2",
+        plugins=[FlaskPlugin(), MarshmallowPlugin()],
     )
 
     # Optional marshmallow support
@@ -42,14 +39,17 @@ Example Application
         id = fields.Int()
         name = fields.Str(required=True)
 
+
     class PetSchema(Schema):
         category = fields.Nested(CategorySchema, many=True)
         name = fields.Str()
 
+
     # Optional Flask support
     app = Flask(__name__)
 
-    @app.route('/random')
+
+    @app.route("/random")
     def random_pet():
         """A cute furry animal endpoint.
         ---
@@ -64,9 +64,10 @@ Example Application
         pet = get_random_pet()
         return jsonify(PetSchema().dump(pet).data)
 
+
     # Register entities and paths
-    spec.components.schema('Category', schema=CategorySchema)
-    spec.components.schema('Pet', schema=PetSchema)
+    spec.components.schema("Category", schema=CategorySchema)
+    spec.components.schema("Pet", schema=PetSchema)
     with app.test_request_context():
         spec.path(view=random_pet)
 
@@ -77,6 +78,7 @@ Generated OpenAPI Spec
 .. code-block:: python
 
     import json
+
     print(json.dumps(spec.to_dict(), indent=2))
     # {
     #   "paths": {

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,22 +11,23 @@ First, create an `APISpec <apispec.APISpec>` object, passing basic information a
     from apispec import APISpec
 
     spec = APISpec(
-        title='Gisty',
-        version='1.0.0',
-        openapi_version='3.0.2',
-        info=dict(
-            description='A minimal gist API'
-        )
+        title="Gisty",
+        version="1.0.0",
+        openapi_version="3.0.2",
+        info=dict(description="A minimal gist API"),
     )
 
 Add schemas to your spec using `spec.components.schema <apispec.core.Components.schema>`.
 
 .. code-block:: python
 
-    spec.components.schema('Gist', properties={
-        'id': {'type': 'integer', 'format': 'int64'},
-        'name': {'type': 'string'}
-    })
+    spec.components.schema(
+        "Gist",
+        properties={
+            "id": {"type": "integer", "format": "int64"},
+            "name": {"type": "string"},
+        },
+    )
 
 
 Add paths to your spec using `path <apispec.APISpec.path>`.
@@ -35,20 +36,18 @@ Add paths to your spec using `path <apispec.APISpec.path>`.
 
 
     spec.path(
-        path='/gist/{gist_id}',
+        path="/gist/{gist_id}",
         operations=dict(
             get=dict(
                 responses={
-                    '200': {
-                        'content': {
-                            'application/json': {
-                                'schema': {'$ref': '#/definitions/Gist'}
-                            }
+                    "200": {
+                        "content": {
+                            "application/json": {"schema": {"$ref": "#/definitions/Gist"}}
                         }
                     }
                 }
             )
-        )
+        ),
     )
 
 
@@ -57,12 +56,9 @@ one statement:
 
 .. code-block:: python
 
-    spec.path(...)\
-        .path(...)\
-        .tag(...)
+    spec.path(...).path(...).tag(...)
 
-    spec.components.schema(...)\
-                   .parameter(...)
+    spec.components.schema(...).parameter(...)
 
 To output your OpenAPI spec, invoke the `to_dict <apispec.APISpec.to_dict>` method.
 

--- a/docs/special_topics.rst
+++ b/docs/special_topics.rst
@@ -12,11 +12,13 @@ To add additional fields (e.g. ``"discriminator"``) to Schema objects generated 
 .. code-block:: python
 
     properties = {
-        'id': {'type': 'integer', 'format': 'int64'},
-        'name': {'type': 'string', 'example': 'doggie'},
+        "id": {"type": "integer", "format": "int64"},
+        "name": {"type": "string", "example": "doggie"},
     }
 
-    spec.components.schema('Pet', properties=properties, extra_fields={'discriminator': 'petType'})
+    spec.components.schema(
+        "Pet", properties=properties, extra_fields={"discriminator": "petType"}
+    )
 
 
 .. note::
@@ -91,17 +93,15 @@ Here is an example that includes a `Server Object <https://github.com/OAI/OpenAP
 
     settings = yaml.safe_load(OPENAPI_SPEC)
     # retrieve  title, version, and openapi version
-    title = settings['info'].pop('title')
-    spec_version = settings['info'].pop('version')
-    openapi_version = settings.pop('openapi')
+    title = settings["info"].pop("title")
+    spec_version = settings["info"].pop("version")
+    openapi_version = settings.pop("openapi")
 
     spec = APISpec(
         title=title,
         version=spec_version,
         openapi_version=openapi_version,
-        plugins=(
-            MarshmallowPlugin(),
-        ),
+        plugins=(MarshmallowPlugin(),),
         **settings
     )
 
@@ -124,18 +124,14 @@ to document `Security Scheme Objects <https://github.com/OAI/OpenAPI-Specificati
     from pprint import pprint
     from apispec import APISpec
 
-    spec = APISpec(
-        title='Swagger Petstore',
-        version='1.0.0',
-        openapi_version='3.0.2',
-    )
+    spec = APISpec(title="Swagger Petstore", version="1.0.0", openapi_version="3.0.2")
 
-    api_key_scheme = {'type': 'apiKey', 'in': 'header', 'name': 'X-API-Key'}
-    jwt_scheme = {'type': 'http', 'scheme': 'bearer', 'bearerFormat': 'JWT'}
+    api_key_scheme = {"type": "apiKey", "in": "header", "name": "X-API-Key"}
+    jwt_scheme = {"type": "http", "scheme": "bearer", "bearerFormat": "JWT"}
 
     spec.components.security_scheme("api_key", **api_key_scheme)
     spec.components.security_scheme("jwt", **jwt_scheme)
 
-    pprint(spec.to_dict()['components']['securitySchemes'], indent=2)
+    pprint(spec.to_dict()["components"]["securitySchemes"], indent=2)
     # { 'api_key': {'in': 'header', 'name': 'X-API-Key', 'type': 'apiKey'},
     #   'jwt': {'bearerFormat': 'JWT', 'scheme': 'bearer', 'type': 'http'}}

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -20,13 +20,11 @@ To enable a plugin, pass an instance to the constructor of `APISpec <apispec.API
     from apispec.ext.marshmallow import MarshmallowPlugin
 
     spec = APISpec(
-        title='Gisty',
-        version='1.0.0',
-        openapi_version='3.0.2',
-        info=dict(
-            description='A minimal gist API'
-        ),
-        plugins=[MarshmallowPlugin()]
+        title="Gisty",
+        version="1.0.0",
+        openapi_version="3.0.2",
+        info=dict(description="A minimal gist API"),
+        plugins=[MarshmallowPlugin()],
     )
 
 
@@ -54,16 +52,11 @@ We can now use the marshmallow and Flask plugins.
     from apispec_webframeworks.flask import FlaskPlugin
 
     spec = APISpec(
-        title='Gisty',
-        version='1.0.0',
-        openapi_version='3.0.2',
-        info=dict(
-            description='A minimal gist API'
-        ),
-        plugins=[
-            FlaskPlugin(),
-            MarshmallowPlugin(),
-        ]
+        title="Gisty",
+        version="1.0.0",
+        openapi_version="3.0.2",
+        info=dict(description="A minimal gist API"),
+        plugins=[FlaskPlugin(), MarshmallowPlugin()],
     )
 
 
@@ -73,8 +66,10 @@ Our application will have a marshmallow `Schema <marshmallow.Schema>` for gists.
 
     from marshmallow import Schema, fields
 
+
     class GistParameter(Schema):
         gist_id = fields.Int()
+
 
     class GistSchema(Schema):
         id = fields.Int()
@@ -87,7 +82,7 @@ The marshmallow plugin allows us to pass this `Schema` to
 
 .. code-block:: python
 
-    spec.components.schema('Gist', schema=GistSchema)
+    spec.components.schema("Gist", schema=GistSchema)
 
 The schema is now added to the spec.
 
@@ -115,7 +110,7 @@ We'll add some YAML in the docstring to add response information.
     app = Flask(__name__)
 
     # NOTE: Plugins may inspect docstrings to gather more information for the spec
-    @app.route('/gists/<gist_id>')
+    @app.route("/gists/<gist_id>")
     def gist_detail(gist_id):
         """Gist detail view.
         ---
@@ -127,7 +122,7 @@ We'll add some YAML in the docstring to add response information.
                 200:
                     schema: GistSchema
         """
-        return 'details about gist {}'.format(gist_id)
+        return "details about gist {}".format(gist_id)
 
 The Flask plugin allows us to pass this view to `spec.path <apispec.APISpec.path>`.
 
@@ -171,9 +166,10 @@ If your API uses `method-based dispatching <http://flask.pocoo.org/docs/0.12/vie
 
     from flask.views import MethodView
 
+
     class GistApi(MethodView):
         def get(self):
-            '''Gist view
+            """Gist view
             ---
             description: get a gist
             responses:
@@ -181,17 +177,18 @@ If your API uses `method-based dispatching <http://flask.pocoo.org/docs/0.12/vie
                 content:
                 application/json:
                     schema: GistSchema
-            '''
+            """
             pass
 
         def post(self):
             pass
 
-    method_view = GistApi.as_view('gist')
+
+    method_view = GistApi.as_view("gist")
     app.add_url_rule("/gist", view_func=method_view)
     with app.test_request_context():
         spec.path(view=method_view)
-    pprint(dict(spec.to_dict()['paths']['/gist']))
+    pprint(dict(spec.to_dict()["paths"]["/gist"]))
     # {'get': {'description': 'get a gist',
     #          'responses': {200: {'content': {'application/json': {'schema': {'$ref': '#/components/schemas/Gist'}}}}}},
     #  'post': {}}
@@ -249,23 +246,22 @@ schemas with custom fields, use the
     ma_plugin = MarshmallowPlugin()
 
     spec = APISpec(
-        title='Gisty',
-        version='1.0.0',
-        openapi_version='3.0.2',
-        info=dict(
-            description='A minimal gist API'
-        ),
-        plugins=[ma_plugin]
+        title="Gisty",
+        version="1.0.0",
+        openapi_version="3.0.2",
+        info=dict(description="A minimal gist API"),
+        plugins=[ma_plugin],
     )
 
 
-    @ma_plugin.map_to_openapi_type('string', 'uuid')
+    @ma_plugin.map_to_openapi_type("string", "uuid")
     class MyCustomField(Integer):
-        # ...
+        pass
+
 
     @ma_plugin.map_to_openapi_type(Integer)  # will map to ('integer', 'int32')
     class MyCustomFieldThatsKindaLikeAnInteger(Integer):
-        # ...
+        pass
 
 
 

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -14,7 +14,7 @@ Enabling Plugins
 To enable a plugin, pass an instance to the constructor of `APISpec <apispec.APISpec>`.
 
 .. code-block:: python
-    :emphasize-lines: 11
+    :emphasize-lines: 9
 
     from apispec import APISpec
     from apispec.ext.marshmallow import MarshmallowPlugin
@@ -115,12 +115,14 @@ We'll add some YAML in the docstring to add response information.
         """Gist detail view.
         ---
         get:
-            parameters:
-                - in: path
-                  schema: GistParameter
-            responses:
-                200:
-                    schema: GistSchema
+          parameters:
+          - in: path
+            schema: GistParameter
+          responses:
+            200:
+              content:
+                application/json:
+                  schema: GistSchema
         """
         return "details about gist {}".format(gist_id)
 
@@ -174,9 +176,9 @@ If your API uses `method-based dispatching <http://flask.pocoo.org/docs/0.12/vie
             description: get a gist
             responses:
             200:
-                content:
+              content:
                 application/json:
-                    schema: GistSchema
+                  schema: GistSchema
             """
             pass
 

--- a/docs/writing_plugins.rst
+++ b/docs/writing_plugins.rst
@@ -27,8 +27,8 @@ A plugin with a path helper function may look something like this:
     from apispec import Path, BasePlugin
     from apispec.utils import load_operations_from_docstring
 
-    class MyPlugin(BasePlugin):
 
+    class MyPlugin(BasePlugin):
         def path_helper(self, path, func, **kwargs):
             """Path helper that parses docstrings for operations. Adds a
             ``func`` parameter to `apispec.APISpec.path`.
@@ -59,8 +59,8 @@ Here's a plugin example involving conditional processing depending on the OpenAP
     from apispec import BasePlugin
     from apispec.yaml_utils import load_operations_from_docstring
 
-    class DocPlugin(BasePlugin):
 
+    class DocPlugin(BasePlugin):
         def init_spec(self, spec):
             super(DocPlugin, self).init_spec(spec)
             self.openapi_major_version = spec.openapi_version.major
@@ -75,7 +75,7 @@ Here's a plugin example involving conditional processing depending on the OpenAP
                 "...Mutating doc_operations for OpenAPI v2..."
             else:
                 "...Mutating doc_operations for OpenAPI v3+..."
-            operations.update(doc_operations
+            operations.update(doc_operations)
 
 
 To use the plugin:
@@ -86,11 +86,9 @@ To use the plugin:
     from docplugin import DocPlugin
 
     spec = APISpec(
-        title='Gisty',
-        version='1.0.0',
-        openapi_version='3.0.2',
-        plugins=[DocPlugin()]
+        title="Gisty", version="1.0.0", openapi_version="3.0.2", plugins=[DocPlugin()]
     )
+
 
     def gist_detail(gist_id):
         """Gist detail view.
@@ -104,8 +102,9 @@ To use the plugin:
         """
         pass
 
-    spec.path(path='/gists/{gist_id}', func=gist_detail)
-    print(dict(spec.to_dict()['paths']))
+
+    spec.path(path="/gists/{gist_id}", func=gist_detail)
+    print(dict(spec.to_dict()["paths"]))
     # {'/gists/{gist_id}': OrderedDict([('get', {'responses': {200: {'content': {'application/json': {'schema': '#/definitions/Gist'}}}}})])}
 
 

--- a/docs/writing_plugins.rst
+++ b/docs/writing_plugins.rst
@@ -94,9 +94,9 @@ To use the plugin:
         """Gist detail view.
         ---
         get:
-        responses:
+          responses:
             200:
-            content:
+              content:
                 application/json:
                 schema: '#/definitions/Gist'
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,10 +7,8 @@ license_files = LICENSE
 # will need to generate wheels for each Python version that you support.
 universal=1
 
-# E265: block comment should start with #
-# E302: expected 2 blank lines, found 0
-# E266: too many leading ‘#’ for block comment
-# W504: line break after binary operator
 [flake8]
-ignore = E265,E302,E266,W504
-max-line-length = 110
+ignore = E203, E266, E501, W503
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9

--- a/setup.py
+++ b/setup.py
@@ -3,41 +3,29 @@ import re
 from setuptools import setup, find_packages
 
 EXTRAS_REQUIRE = {
-    'yaml': [
-        'PyYAML>=3.10',
-    ],
-    'validation': [
-        'prance[osv]>=0.11',
-    ],
-    'webframeworks-tests': [
-        'apispec-webframeworks[tests]>=0.3.0',
-    ],
-    'lint': [
-        'flake8==3.7.4',
-        'pre-commit==1.14.2',
+    "yaml": ["PyYAML>=3.10"],
+    "validation": ["prance[osv]>=0.11"],
+    "webframeworks-tests": ["apispec-webframeworks[tests]>=0.3.0"],
+    "lint": [
+        "flake8==3.7.4",
+        'flake8-bugbear==18.8.0; python_version >= "3.5"',
+        "pre-commit==1.14.2",
     ],
 }
-EXTRAS_REQUIRE['tests'] = (
-    EXTRAS_REQUIRE['yaml'] +
-    EXTRAS_REQUIRE['validation'] +
-    [
-        'marshmallow==2.18.0',
-        'pytest',
-        'mock',
-    ]
+EXTRAS_REQUIRE["tests"] = (
+    EXTRAS_REQUIRE["yaml"]
+    + EXTRAS_REQUIRE["validation"]
+    + ["marshmallow==2.18.0", "pytest", "mock"]
 )
-EXTRAS_REQUIRE['dev'] = (
-    EXTRAS_REQUIRE['tests'] +
-    EXTRAS_REQUIRE['lint'] +
-    ['tox']
-)
+EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
+
 
 def find_version(fname):
     """Attempts to find the version number in the file names fname.
     Raises RuntimeError if not found.
     """
-    version = ''
-    with open(fname, 'r') as fp:
+    version = ""
+    with open(fname, "r") as fp:
         reg = re.compile(r'__version__ = [\'"]([^\'"]*)[\'"]')
         for line in fp:
             m = reg.match(line)
@@ -45,7 +33,7 @@ def find_version(fname):
                 version = m.group(1)
                 break
     if not version:
-        raise RuntimeError('Cannot find version information.')
+        raise RuntimeError("Cannot find version information.")
     return version
 
 
@@ -56,37 +44,37 @@ def read(fname):
 
 
 setup(
-    name='apispec',
-    version=find_version('apispec/__init__.py'),
-    description='A pluggable API specification generator. Currently supports the '
-                'OpenAPI Specification (f.k.a. the Swagger specification).',
-    long_description=read('README.rst'),
-    author='Steven Loria',
-    author_email='sloria1@gmail.com',
-    url='https://github.com/marshmallow-code/apispec',
-    packages=find_packages(exclude=('test*', )),
-    package_dir={'apispec': 'apispec'},
+    name="apispec",
+    version=find_version("apispec/__init__.py"),
+    description="A pluggable API specification generator. Currently supports the "
+    "OpenAPI Specification (f.k.a. the Swagger specification).",
+    long_description=read("README.rst"),
+    author="Steven Loria",
+    author_email="sloria1@gmail.com",
+    url="https://github.com/marshmallow-code/apispec",
+    packages=find_packages(exclude=("test*",)),
+    package_dir={"apispec": "apispec"},
     include_package_data=True,
     extras_require=EXTRAS_REQUIRE,
-    license='MIT',
+    license="MIT",
     zip_safe=False,
-    keywords='apispec swagger openapi specification oas documentation spec rest api',
+    keywords="apispec swagger openapi specification oas documentation spec rest api",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
-    test_suite='tests',
+    test_suite="tests",
     project_urls={
-        'Funding': 'https://opencollective.com/marshmallow',
-        'Issues': 'https://github.com/marshmallow-code/apispec/issues',
-        'Tidelift': 'https://tidelift.com/subscription/pkg/pypi-apispec?utm_source=pypi-apispec&utm_medium=pypi',  # noqa: E501
+        "Funding": "https://opencollective.com/marshmallow",
+        "Issues": "https://github.com/marshmallow-code/apispec/issues",
+        "Tidelift": "https://tidelift.com/subscription/pkg/pypi-apispec?utm_source=pypi-apispec&utm_medium=pypi",  # noqa: E501
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,29 +10,27 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 def make_spec(openapi_version):
     ma_plugin = MarshmallowPlugin()
     spec = APISpec(
-        title='Validation',
-        version='0.1',
+        title="Validation",
+        version="0.1",
         openapi_version=openapi_version,
-        plugins=(ma_plugin, ),
+        plugins=(ma_plugin,),
     )
-    return namedtuple(
-        'Spec', ('spec', 'marshmallow_plugin', 'openapi'),
-    )(
-        spec, ma_plugin, ma_plugin.openapi,
+    return namedtuple("Spec", ("spec", "marshmallow_plugin", "openapi"))(
+        spec, ma_plugin, ma_plugin.openapi
     )
 
 
-@pytest.fixture(params=('2.0', '3.0.0'))
+@pytest.fixture(params=("2.0", "3.0.0"))
 def spec_fixture(request):
     return make_spec(request.param)
 
 
-@pytest.fixture(params=('2.0', '3.0.0'))
+@pytest.fixture(params=("2.0", "3.0.0"))
 def spec(request):
     return make_spec(request.param).spec
 
 
-@pytest.fixture(params=('2.0', '3.0.0'))
+@pytest.fixture(params=("2.0", "3.0.0"))
 def openapi(request):
     spec = make_spec(request.param)
     return spec.openapi

--- a/tests/plugins/dummy_plugin.py
+++ b/tests/plugins/dummy_plugin.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
+
 def setup(spec):
-    spec.old_plugins['tests.plugins.dummy_plugin']['foo'] = 42
+    spec.old_plugins["tests.plugins.dummy_plugin"]["foo"] = 42

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -2,14 +2,19 @@ from marshmallow import Schema, fields
 
 
 class PetSchema(Schema):
-    description = dict(id='Pet id', name='Pet name', password='Password')
-    id = fields.Int(dump_only=True, description=description['id'])
-    name = fields.Str(required=True, deprecated=False, allowEmptyValue=False, description=description['name'])
-    password = fields.Str(load_only=True, description=description['password'])
+    description = dict(id="Pet id", name="Pet name", password="Password")
+    id = fields.Int(dump_only=True, description=description["id"])
+    name = fields.Str(
+        required=True,
+        deprecated=False,
+        allowEmptyValue=False,
+        description=description["name"],
+    )
+    password = fields.Str(load_only=True, description=description["password"])
 
 
 class SampleSchema(Schema):
-    runs = fields.Nested('RunSchema', many=True)
+    runs = fields.Nested("RunSchema", many=True)
 
     count = fields.Int()
 
@@ -27,14 +32,14 @@ class AnalysisWithListSchema(Schema):
 
 
 class PatternedObjectSchema(Schema):
-    count = fields.Int(dump_only=True, **{'x-count': 1})
+    count = fields.Int(dump_only=True, **{"x-count": 1})
     count2 = fields.Int(dump_only=True, x_count2=2)
 
 
 class SelfReferencingSchema(Schema):
     id = fields.Int()
-    single = fields.Nested('self')
-    many = fields.Nested('self', many=True)
+    single = fields.Nested("self")
+    many = fields.Nested("self", many=True)
 
 
 class OrderedSchema(Schema):
@@ -51,6 +56,6 @@ class OrderedSchema(Schema):
 class DefaultValuesSchema(Schema):
     number_auto_default = fields.Int(missing=12)
     number_manual_default = fields.Int(missing=12, doc_default=42)
-    string_callable_default = fields.Str(missing=lambda: 'Callable')
-    string_manual_default = fields.Str(missing=lambda: 'Callable', doc_default='Manual')
+    string_callable_default = fields.Str(missing=lambda: "Callable")
+    string_manual_default = fields.Str(missing=lambda: "Callable", doc_default="Manual")
     numbers = fields.List(fields.Int, missing=list)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,527 +7,538 @@ import yaml
 from apispec import APISpec, BasePlugin
 from apispec.exceptions import APISpecError, DuplicateComponentNameError
 
-from .utils import get_definitions, get_paths, get_parameters, get_responses, get_security_schemes
+from .utils import (
+    get_definitions,
+    get_paths,
+    get_parameters,
+    get_responses,
+    get_security_schemes,
+)
 
 
-description = 'This is a sample Petstore server.  You can find out more '
-'about Swagger at <a href=\"http://swagger.wordnik.com\">http://swagger.wordnik.com</a> '
-'or on irc.freenode.net, #swagger.  For this sample, you can use the api '
-'key \"special-key\" to test the authorization filters'
+description = "This is a sample Petstore server.  You can find out more "
+'about Swagger at <a href="http://swagger.wordnik.com">http://swagger.wordnik.com</a> '
+"or on irc.freenode.net, #swagger.  For this sample, you can use the api "
+'key "special-key" to test the authorization filters'
 
 
-@pytest.fixture(params=('2.0', '3.0.0'))
+@pytest.fixture(params=("2.0", "3.0.0"))
 def spec(request):
     openapi_version = request.param
-    if openapi_version == '2.0':
-        security_kwargs = {
-            'security': [{'apiKey': []}],
-        }
+    if openapi_version == "2.0":
+        security_kwargs = {"security": [{"apiKey": []}]}
     else:
         security_kwargs = {
-            'components': {
-                'securitySchemes': {
-                    'bearerAuth':
-                        dict(type='http', scheme='bearer', bearerFormat='JWT'),
+            "components": {
+                "securitySchemes": {
+                    "bearerAuth": dict(type="http", scheme="bearer", bearerFormat="JWT")
                 },
-                'schemas': {
-                    'ErrorResponse': {
-                        'type': 'object',
-                        'properties': {
-                            'ok': {
-                                'type': 'boolean', 'description': 'status indicator', 'example': False,
-                            },
+                "schemas": {
+                    "ErrorResponse": {
+                        "type": "object",
+                        "properties": {
+                            "ok": {
+                                "type": "boolean",
+                                "description": "status indicator",
+                                "example": False,
+                            }
                         },
-                        'required': ['ok'],
-                    },
+                        "required": ["ok"],
+                    }
                 },
-            },
+            }
         }
     return APISpec(
-        title='Swagger Petstore',
-        version='1.0.0',
+        title="Swagger Petstore",
+        version="1.0.0",
         openapi_version=openapi_version,
-        info={'description': description},
+        info={"description": description},
         **security_kwargs
     )
 
 
 class TestAPISpecInit:
-
     def test_raises_wrong_apispec_version(self):
         with pytest.raises(APISpecError) as excinfo:
             APISpec(
-                'Swagger Petstore',
-                version='1.0.0',
-                openapi_version='4.0',  # 4.0 is not supported
-                info={'description': description},
-                security=[{'apiKey': []}],
+                "Swagger Petstore",
+                version="1.0.0",
+                openapi_version="4.0",  # 4.0 is not supported
+                info={"description": description},
+                security=[{"apiKey": []}],
             )
-        assert 'Not a valid OpenAPI version number:' in str(excinfo)
+        assert "Not a valid OpenAPI version number:" in str(excinfo)
 
 
 class TestMetadata:
-
     def test_openapi_metadata(self, spec):
         metadata = spec.to_dict()
-        assert metadata['info']['title'] == 'Swagger Petstore'
-        assert metadata['info']['version'] == '1.0.0'
-        assert metadata['info']['description'] == description
+        assert metadata["info"]["title"] == "Swagger Petstore"
+        assert metadata["info"]["version"] == "1.0.0"
+        assert metadata["info"]["description"] == description
         if spec.openapi_version.major < 3:
-            assert metadata['swagger'] == spec.openapi_version.vstring
-            assert metadata['security'] == [{'apiKey': []}]
+            assert metadata["swagger"] == spec.openapi_version.vstring
+            assert metadata["security"] == [{"apiKey": []}]
         else:
-            assert metadata['openapi'] == spec.openapi_version.vstring
-            security_schemes = {'bearerAuth': dict(type='http', scheme='bearer', bearerFormat='JWT')}
-            assert metadata['components']['securitySchemes'] == security_schemes
-            assert metadata['components']['schemas'].get('ErrorResponse', False)
-            assert metadata['info']['title'] == 'Swagger Petstore'
-            assert metadata['info']['version'] == '1.0.0'
-            assert metadata['info']['description'] == description
+            assert metadata["openapi"] == spec.openapi_version.vstring
+            security_schemes = {
+                "bearerAuth": dict(type="http", scheme="bearer", bearerFormat="JWT")
+            }
+            assert metadata["components"]["securitySchemes"] == security_schemes
+            assert metadata["components"]["schemas"].get("ErrorResponse", False)
+            assert metadata["info"]["title"] == "Swagger Petstore"
+            assert metadata["info"]["version"] == "1.0.0"
+            assert metadata["info"]["description"] == description
 
-    @pytest.mark.parametrize('spec', ('3.0.0', ), indirect=True)
+    @pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
     def test_openapi_metadata_merge_v3(self, spec):
         properties = {
-            'ok': {
-                'type': 'boolean', 'description': 'property description', 'example': True,
-            },
+            "ok": {
+                "type": "boolean",
+                "description": "property description",
+                "example": True,
+            }
         }
-        spec.components.schema('definition', properties=properties, description='definiton description')
+        spec.components.schema(
+            "definition", properties=properties, description="definiton description"
+        )
         metadata = spec.to_dict()
-        assert metadata['components']['schemas'].get('ErrorResponse', False)
-        assert metadata['components']['schemas'].get('definition', False)
+        assert metadata["components"]["schemas"].get("ErrorResponse", False)
+        assert metadata["components"]["schemas"].get("definition", False)
 
 
 class TestTags:
 
     tag = {
-        'name': 'MyTag',
-        'description': 'This tag gathers all API endpoints which are mine.',
+        "name": "MyTag",
+        "description": "This tag gathers all API endpoints which are mine.",
     }
 
     def test_tag(self, spec):
         spec.tag(self.tag)
-        tags_json = spec.to_dict()['tags']
+        tags_json = spec.to_dict()["tags"]
         assert self.tag in tags_json
 
     def test_tag_is_chainable(self, spec):
-        spec.tag({'name': 'tag1'}).tag({'name': 'tag2'})
-        assert spec.to_dict()['tags'] == [{'name': 'tag1'}, {'name': 'tag2'}]
+        spec.tag({"name": "tag1"}).tag({"name": "tag2"})
+        assert spec.to_dict()["tags"] == [{"name": "tag1"}, {"name": "tag2"}]
 
 
 class TestDefinitions:
 
     properties = {
-        'id': {'type': 'integer', 'format': 'int64'},
-        'name': {'type': 'string', 'example': 'doggie'},
+        "id": {"type": "integer", "format": "int64"},
+        "name": {"type": "string", "example": "doggie"},
     }
 
     def test_definition(self, spec):
-        spec.components.schema('Pet', properties=self.properties)
+        spec.components.schema("Pet", properties=self.properties)
         defs = get_definitions(spec)
-        assert 'Pet' in defs
-        assert defs['Pet']['properties'] == self.properties
+        assert "Pet" in defs
+        assert defs["Pet"]["properties"] == self.properties
 
     def test_definition_is_chainable(self, spec):
-        spec.components.schema('Pet', properties={}).schema('Plant', properties={})
+        spec.components.schema("Pet", properties={}).schema("Plant", properties={})
         defs = get_definitions(spec)
-        assert 'Pet' in defs
-        assert 'Plant' in defs
+        assert "Pet" in defs
+        assert "Plant" in defs
 
     def test_definition_description(self, spec):
-        model_description = 'An animal which lives with humans.'
-        spec.components.schema('Pet', properties=self.properties, description=model_description)
-        defs = get_definitions(spec)
-        assert defs['Pet']['description'] == model_description
-
-    def test_definition_stores_enum(self, spec):
-        enum = ['name', 'photoUrls']
+        model_description = "An animal which lives with humans."
         spec.components.schema(
-            'Pet',
-            properties=self.properties,
-            enum=enum,
+            "Pet", properties=self.properties, description=model_description
         )
         defs = get_definitions(spec)
-        assert defs['Pet']['enum'] == enum
+        assert defs["Pet"]["description"] == model_description
+
+    def test_definition_stores_enum(self, spec):
+        enum = ["name", "photoUrls"]
+        spec.components.schema("Pet", properties=self.properties, enum=enum)
+        defs = get_definitions(spec)
+        assert defs["Pet"]["enum"] == enum
 
     def test_definition_extra_fields(self, spec):
-        extra_fields = {'discriminator': 'name'}
-        spec.components.schema('Pet', properties=self.properties, extra_fields=extra_fields)
+        extra_fields = {"discriminator": "name"}
+        spec.components.schema(
+            "Pet", properties=self.properties, extra_fields=extra_fields
+        )
         defs = get_definitions(spec)
-        assert defs['Pet']['discriminator'] == 'name'
+        assert defs["Pet"]["discriminator"] == "name"
 
     def test_definition_duplicate_name(self, spec):
-        spec.components.schema('Pet', properties=self.properties)
+        spec.components.schema("Pet", properties=self.properties)
         with pytest.raises(
             DuplicateComponentNameError,
             match='Another schema with name "Pet" is already registered.',
         ):
-            spec.components.schema('Pet', properties=self.properties)
+            spec.components.schema("Pet", properties=self.properties)
 
     def test_to_yaml(self, spec):
-        enum = ['name', 'photoUrls']
-        spec.components.schema(
-            'Pet',
-            properties=self.properties,
-            enum=enum,
-        )
+        enum = ["name", "photoUrls"]
+        spec.components.schema("Pet", properties=self.properties, enum=enum)
         assert spec.to_dict() == yaml.safe_load(spec.to_yaml())
+
 
 class TestPath:
     paths = {
-        '/pet/{petId}': {
-            'get': {
-                'parameters': [
+        "/pet/{petId}": {
+            "get": {
+                "parameters": [
                     {
-                        'required': True,
-                        'format': 'int64',
-                        'name': 'petId',
-                        'in': 'path',
-                        'type': 'integer',
-                        'description': 'ID of pet that needs to be fetched',
-                    },
+                        "required": True,
+                        "format": "int64",
+                        "name": "petId",
+                        "in": "path",
+                        "type": "integer",
+                        "description": "ID of pet that needs to be fetched",
+                    }
                 ],
-                'responses': {
-                    '200': {
-                        'schema': {'$ref': '#/definitions/Pet'},
-                        'description': 'successful operation',
+                "responses": {
+                    "200": {
+                        "schema": {"$ref": "#/definitions/Pet"},
+                        "description": "successful operation",
                     },
-                    '400': {
-                        'description': 'Invalid ID supplied',
-                    },
-                    '404': {
-                        'description': 'Pet not found',
-                    },
+                    "400": {"description": "Invalid ID supplied"},
+                    "404": {"description": "Pet not found"},
                 },
-                'produces': [
-                    'application/json',
-                    'application/xml',
-                ],
-                'operationId': 'getPetById',
-                'summary': 'Find pet by ID',
-                'description': (
-                    'Returns a pet when ID < 10.  '
-                    'ID > 10 or nonintegers will simulate API error conditions'
+                "produces": ["application/json", "application/xml"],
+                "operationId": "getPetById",
+                "summary": "Find pet by ID",
+                "description": (
+                    "Returns a pet when ID < 10.  "
+                    "ID > 10 or nonintegers will simulate API error conditions"
                 ),
-                'tags': ['pet'],
-            },
-        },
+                "tags": ["pet"],
+            }
+        }
     }
 
     def test_path(self, spec):
-        route_spec = self.paths['/pet/{petId}']['get']
+        route_spec = self.paths["/pet/{petId}"]["get"]
         spec.path(
-            path='/pet/{petId}',
+            path="/pet/{petId}",
             operations=dict(
                 get=dict(
-                    parameters=route_spec['parameters'],
-                    responses=route_spec['responses'],
-                    produces=route_spec['produces'],
-                    operationId=route_spec['operationId'],
-                    summary=route_spec['summary'],
-                    description=route_spec['description'],
-                    tags=route_spec['tags'],
-                ),
+                    parameters=route_spec["parameters"],
+                    responses=route_spec["responses"],
+                    produces=route_spec["produces"],
+                    operationId=route_spec["operationId"],
+                    summary=route_spec["summary"],
+                    description=route_spec["description"],
+                    tags=route_spec["tags"],
+                )
             ),
         )
 
-        p = get_paths(spec)['/pet/{petId}']['get']
-        assert p['parameters'] == route_spec['parameters']
-        assert p['responses'] == route_spec['responses']
-        assert p['operationId'] == route_spec['operationId']
-        assert p['summary'] == route_spec['summary']
-        assert p['description'] == route_spec['description']
-        assert p['tags'] == route_spec['tags']
+        p = get_paths(spec)["/pet/{petId}"]["get"]
+        assert p["parameters"] == route_spec["parameters"]
+        assert p["responses"] == route_spec["responses"]
+        assert p["operationId"] == route_spec["operationId"]
+        assert p["summary"] == route_spec["summary"]
+        assert p["description"] == route_spec["description"]
+        assert p["tags"] == route_spec["tags"]
 
     def test_paths_maintain_order(self, spec):
-        spec.path(path='/path1')
-        spec.path(path='/path2')
-        spec.path(path='/path3')
-        spec.path(path='/path4')
-        assert list(spec.to_dict()['paths'].keys()) == ['/path1', '/path2', '/path3', '/path4']
+        spec.path(path="/path1")
+        spec.path(path="/path2")
+        spec.path(path="/path3")
+        spec.path(path="/path4")
+        assert list(spec.to_dict()["paths"].keys()) == [
+            "/path1",
+            "/path2",
+            "/path3",
+            "/path4",
+        ]
 
     def test_paths_is_chainable(self, spec):
-        spec.path(path='/path1').path('/path2')
-        assert list(spec.to_dict()['paths'].keys()) == ['/path1', '/path2']
+        spec.path(path="/path1").path("/path2")
+        assert list(spec.to_dict()["paths"].keys()) == ["/path1", "/path2"]
 
     def test_methods_maintain_order(self, spec):
-        methods = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options']
+        methods = ["get", "post", "put", "patch", "delete", "head", "options"]
         for method in methods:
-            spec.path(path='/path', operations=OrderedDict({method: {}}))
-        assert list(spec.to_dict()['paths']['/path']) == methods
+            spec.path(path="/path", operations=OrderedDict({method: {}}))
+        assert list(spec.to_dict()["paths"]["/path"]) == methods
 
     def test_path_merges_paths(self, spec):
         """Test that adding a second HTTP method to an existing path performs
         a merge operation instead of an overwrite"""
-        path = '/pet/{petId}'
-        route_spec = self.paths[path]['get']
-        spec.path(
-            path=path,
-            operations=dict(
-                get=route_spec,
-            ),
-        )
+        path = "/pet/{petId}"
+        route_spec = self.paths[path]["get"]
+        spec.path(path=path, operations=dict(get=route_spec))
         spec.path(
             path=path,
             operations=dict(
                 put=dict(
-                    parameters=route_spec['parameters'],
-                    responses=route_spec['responses'],
-                    produces=route_spec['produces'],
-                    operationId='updatePet',
-                    summary='Updates an existing Pet',
-                    description='Use this method to make changes to Pet `petId`',
-                    tags=route_spec['tags'],
-                ),
+                    parameters=route_spec["parameters"],
+                    responses=route_spec["responses"],
+                    produces=route_spec["produces"],
+                    operationId="updatePet",
+                    summary="Updates an existing Pet",
+                    description="Use this method to make changes to Pet `petId`",
+                    tags=route_spec["tags"],
+                )
             ),
         )
 
         p = get_paths(spec)[path]
-        assert 'get' in p
-        assert 'put' in p
+        assert "get" in p
+        assert "put" in p
 
     def test_path_ensures_path_parameters_required(self, spec):
-        path = '/pet/{petId}'
+        path = "/pet/{petId}"
         spec.path(
             path=path,
-            operations=dict(
-                put=dict(
-                    parameters=[{
-                        'name': 'petId',
-                        'in': 'path',
-                    }],
-                ),
-            ),
+            operations=dict(put=dict(parameters=[{"name": "petId", "in": "path"}])),
         )
-        assert get_paths(spec)[path]['put']['parameters'][0]['required'] is True
+        assert get_paths(spec)[path]["put"]["parameters"][0]["required"] is True
 
     def test_path_with_no_path_raises_error(self, spec):
         with pytest.raises(APISpecError) as excinfo:
             spec.path()
-        assert 'Path template is not specified' in str(excinfo)
+        assert "Path template is not specified" in str(excinfo)
 
     def test_parameter(self, spec):
-        route_spec = self.paths['/pet/{petId}']['get']
+        route_spec = self.paths["/pet/{petId}"]["get"]
 
-        spec.components.parameter('test_parameter', 'path', **route_spec['parameters'][0])
+        spec.components.parameter(
+            "test_parameter", "path", **route_spec["parameters"][0]
+        )
 
         spec.path(
-            path='/pet/{petId}',
-            operations={'get': {'parameters': ['test_parameter']}},
+            path="/pet/{petId}", operations={"get": {"parameters": ["test_parameter"]}}
         )
 
         metadata = spec.to_dict()
-        p = get_paths(spec)['/pet/{petId}']['get']
+        p = get_paths(spec)["/pet/{petId}"]["get"]
 
         if spec.openapi_version.major < 3:
-            assert p['parameters'][0] == {'$ref': '#/parameters/test_parameter'}
-            assert route_spec['parameters'][0] == metadata['parameters']['test_parameter']
+            assert p["parameters"][0] == {"$ref": "#/parameters/test_parameter"}
+            assert (
+                route_spec["parameters"][0] == metadata["parameters"]["test_parameter"]
+            )
         else:
-            assert p['parameters'][0] == {'$ref': '#/components/parameters/test_parameter'}
-            assert route_spec['parameters'][0] == metadata['components']['parameters']['test_parameter']
+            assert p["parameters"][0] == {
+                "$ref": "#/components/parameters/test_parameter"
+            }
+            assert (
+                route_spec["parameters"][0]
+                == metadata["components"]["parameters"]["test_parameter"]
+            )
 
     def test_parameter_is_chainable(self, spec):
-        spec.components.parameter('param1', 'path').parameter('param2', 'path')
+        spec.components.parameter("param1", "path").parameter("param2", "path")
         params = get_parameters(spec)
-        assert 'param1' in params
-        assert 'param2' in params
+        assert "param1" in params
+        assert "param2" in params
 
     def test_parameter_duplicate_name(self, spec):
-        route_spec = self.paths['/pet/{petId}']['get']
-        spec.components.parameter('test_parameter', 'path', **route_spec['parameters'][0])
+        route_spec = self.paths["/pet/{petId}"]["get"]
+        spec.components.parameter(
+            "test_parameter", "path", **route_spec["parameters"][0]
+        )
         with pytest.raises(
             DuplicateComponentNameError,
             match='Another parameter with name "test_parameter" is already registered.',
         ):
-            spec.components.parameter('test_parameter', 'path', **route_spec['parameters'][0])
+            spec.components.parameter(
+                "test_parameter", "path", **route_spec["parameters"][0]
+            )
 
     def test_response(self, spec):
-        route_spec = self.paths['/pet/{petId}']['get']
+        route_spec = self.paths["/pet/{petId}"]["get"]
 
-        spec.components.response('test_response', **route_spec['responses']['200'])
+        spec.components.response("test_response", **route_spec["responses"]["200"])
 
         spec.path(
-            path='/pet/{petId}',
-            operations={'get': {'responses': {'200': 'test_response'}}},
+            path="/pet/{petId}",
+            operations={"get": {"responses": {"200": "test_response"}}},
         )
 
         metadata = spec.to_dict()
-        p = get_paths(spec)['/pet/{petId}']['get']
+        p = get_paths(spec)["/pet/{petId}"]["get"]
 
         if spec.openapi_version.major < 3:
-            assert p['responses']['200'] == {'$ref': '#/responses/test_response'}
-            assert route_spec['responses']['200'] == metadata['responses']['test_response']
+            assert p["responses"]["200"] == {"$ref": "#/responses/test_response"}
+            assert (
+                route_spec["responses"]["200"] == metadata["responses"]["test_response"]
+            )
         else:
-            assert p['responses']['200'] == {'$ref': '#/components/responses/test_response'}
-            assert route_spec['responses']['200'] == metadata['components']['responses']['test_response']
+            assert p["responses"]["200"] == {
+                "$ref": "#/components/responses/test_response"
+            }
+            assert (
+                route_spec["responses"]["200"]
+                == metadata["components"]["responses"]["test_response"]
+            )
 
     def test_response_is_chainable(self, spec):
-        spec.components.response('resp1').response('resp2')
+        spec.components.response("resp1").response("resp2")
         responses = get_responses(spec)
-        assert 'resp1' in responses
-        assert 'resp2' in responses
+        assert "resp1" in responses
+        assert "resp2" in responses
 
     def test_response_duplicate_name(self, spec):
-        route_spec = self.paths['/pet/{petId}']['get']
-        spec.components.response('test_response', **route_spec['responses']['200'])
+        route_spec = self.paths["/pet/{petId}"]["get"]
+        spec.components.response("test_response", **route_spec["responses"]["200"])
         with pytest.raises(
             DuplicateComponentNameError,
             match='Another response with name "test_response" is already registered.',
         ):
-            spec.components.response('test_response', **route_spec['responses']['200'])
+            spec.components.response("test_response", **route_spec["responses"]["200"])
 
     def test_security_scheme(self, spec):
-        sec_scheme = {'type': 'apiKey', 'in': 'header', 'name': 'X-API-Key'}
-        spec.components.security_scheme('ApiKeyAuth', **sec_scheme)
-        assert get_security_schemes(spec)['ApiKeyAuth'] == sec_scheme
+        sec_scheme = {"type": "apiKey", "in": "header", "name": "X-API-Key"}
+        spec.components.security_scheme("ApiKeyAuth", **sec_scheme)
+        assert get_security_schemes(spec)["ApiKeyAuth"] == sec_scheme
 
     def test_security_scheme_is_chainable(self, spec):
-        spec.components.security_scheme('sec_1').security_scheme('sec_2')
+        spec.components.security_scheme("sec_1").security_scheme("sec_2")
         security_schemes = get_security_schemes(spec)
-        assert 'sec_1' in security_schemes
-        assert 'sec_2' in security_schemes
+        assert "sec_1" in security_schemes
+        assert "sec_2" in security_schemes
 
     def test_security_scheme_duplicate_name(self, spec):
-        sec_scheme_1 = {'type': 'apiKey', 'in': 'header', 'name': 'X-API-Key'}
-        sec_scheme_2 = {'type': 'apiKey', 'in': 'header', 'name': 'X-API-Key-2'}
-        spec.components.security_scheme('ApiKeyAuth', **sec_scheme_1)
+        sec_scheme_1 = {"type": "apiKey", "in": "header", "name": "X-API-Key"}
+        sec_scheme_2 = {"type": "apiKey", "in": "header", "name": "X-API-Key-2"}
+        spec.components.security_scheme("ApiKeyAuth", **sec_scheme_1)
         with pytest.raises(
             DuplicateComponentNameError,
             match='Another security scheme with name "ApiKeyAuth" is already registered.',
         ):
-            spec.components.security_scheme('ApiKeyAuth', **sec_scheme_2)
+            spec.components.security_scheme("ApiKeyAuth", **sec_scheme_2)
 
     def test_path_check_invalid_http_method(self, spec):
-        spec.path('/pet/{petId}', operations={'get': {}})
-        spec.path('/pet/{petId}', operations={'x-dummy': {}})
+        spec.path("/pet/{petId}", operations={"get": {}})
+        spec.path("/pet/{petId}", operations={"x-dummy": {}})
         with pytest.raises(APISpecError) as excinfo:
-            spec.path('/pet/{petId}', operations={'dummy': {}})
-        assert 'One or more HTTP methods are invalid' in str(excinfo)
+            spec.path("/pet/{petId}", operations={"dummy": {}})
+        assert "One or more HTTP methods are invalid" in str(excinfo)
 
 
 class TestPlugins:
-
     @staticmethod
     def test_plugin_factory(return_none=False):
-
         class TestPlugin(BasePlugin):
             def schema_helper(self, name, definition, **kwargs):
                 if not return_none:
-                    return {'properties': {'name': {'type': 'string'}}}
+                    return {"properties": {"name": {"type": "string"}}}
 
             def parameter_helper(self, **kwargs):
                 if not return_none:
-                    return {'description': 'some parameter'}
+                    return {"description": "some parameter"}
 
             def response_helper(self, **kwargs):
                 if not return_none:
-                    return {'description': '42'}
+                    return {"description": "42"}
 
             def path_helper(self, path, operations, **kwargs):
                 if not return_none:
-                    if path == '/path_1':
-                        operations.update({'get': {'responses': {'200': {}}}})
-                        return '/path_1_modified'
+                    if path == "/path_1":
+                        operations.update({"get": {"responses": {"200": {}}}})
+                        return "/path_1_modified"
 
             def operation_helper(self, path, operations, **kwargs):
-                if path == '/path_2':
-                    operations['post'] = {'responses': {'201': {}}}
+                if path == "/path_2":
+                    operations["post"] = {"responses": {"201": {}}}
 
         return TestPlugin()
 
-    @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.0'))
-    @pytest.mark.parametrize('return_none', (True, False))
+    @pytest.mark.parametrize("openapi_version", ("2.0", "3.0.0"))
+    @pytest.mark.parametrize("return_none", (True, False))
     def test_plugin_schema_helper_is_used(self, openapi_version, return_none):
         spec = APISpec(
-            title='Swagger Petstore',
-            version='1.0.0',
+            title="Swagger Petstore",
+            version="1.0.0",
             openapi_version=openapi_version,
-            plugins=(self.test_plugin_factory(return_none), ),
+            plugins=(self.test_plugin_factory(return_none),),
         )
-        spec.components.schema('Pet', {})
+        spec.components.schema("Pet", {})
         definitions = get_definitions(spec)
         if return_none:
-            assert definitions['Pet'] == {}
+            assert definitions["Pet"] == {}
         else:
-            assert definitions['Pet'] == {'properties': {'name': {'type': 'string'}}}
+            assert definitions["Pet"] == {"properties": {"name": {"type": "string"}}}
 
-    @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.0'))
-    @pytest.mark.parametrize('return_none', (True, False))
+    @pytest.mark.parametrize("openapi_version", ("2.0", "3.0.0"))
+    @pytest.mark.parametrize("return_none", (True, False))
     def test_plugin_parameter_helper_is_used(self, openapi_version, return_none):
         spec = APISpec(
-            title='Swagger Petstore',
-            version='1.0.0',
+            title="Swagger Petstore",
+            version="1.0.0",
             openapi_version=openapi_version,
-            plugins=(self.test_plugin_factory(return_none), ),
+            plugins=(self.test_plugin_factory(return_none),),
         )
-        spec.components.parameter('Pet', 'body', **{})
+        spec.components.parameter("Pet", "body", **{})
         parameters = get_parameters(spec)
         if return_none:
-            assert parameters['Pet'] == {'in': 'body', 'name': 'Pet'}
+            assert parameters["Pet"] == {"in": "body", "name": "Pet"}
         else:
-            assert parameters['Pet'] == {'in': 'body', 'name': 'Pet', 'description': 'some parameter'}
+            assert parameters["Pet"] == {
+                "in": "body",
+                "name": "Pet",
+                "description": "some parameter",
+            }
 
-    @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.0'))
-    @pytest.mark.parametrize('return_none', (True, False))
+    @pytest.mark.parametrize("openapi_version", ("2.0", "3.0.0"))
+    @pytest.mark.parametrize("return_none", (True, False))
     def test_plugin_response_helper_is_used(self, openapi_version, return_none):
         spec = APISpec(
-            title='Swagger Petstore',
-            version='1.0.0',
+            title="Swagger Petstore",
+            version="1.0.0",
             openapi_version=openapi_version,
-            plugins=(self.test_plugin_factory(return_none), ),
+            plugins=(self.test_plugin_factory(return_none),),
         )
-        spec.components.response('Pet', **{})
+        spec.components.response("Pet", **{})
         responses = get_responses(spec)
         if return_none:
-            assert responses['Pet'] == {}
+            assert responses["Pet"] == {}
         else:
-            assert responses['Pet'] == {'description': '42'}
+            assert responses["Pet"] == {"description": "42"}
 
-    @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.0'))
-    @pytest.mark.parametrize('return_none', (True, False))
+    @pytest.mark.parametrize("openapi_version", ("2.0", "3.0.0"))
+    @pytest.mark.parametrize("return_none", (True, False))
     def test_plugin_path_helper_is_used(self, openapi_version, return_none):
         spec = APISpec(
-            title='Swagger Petstore',
-            version='1.0.0',
+            title="Swagger Petstore",
+            version="1.0.0",
             openapi_version=openapi_version,
-            plugins=(self.test_plugin_factory(return_none), ),
+            plugins=(self.test_plugin_factory(return_none),),
         )
-        spec.path('/path_1')
+        spec.path("/path_1")
         paths = get_paths(spec)
         assert len(paths) == 1
         if return_none:
-            assert paths['/path_1'] == {}
+            assert paths["/path_1"] == {}
         else:
-            assert paths['/path_1_modified'] == {'get': {'responses': {'200': {}}}}
+            assert paths["/path_1_modified"] == {"get": {"responses": {"200": {}}}}
 
-    @pytest.mark.parametrize('openapi_version', ('2.0', '3.0.0'))
+    @pytest.mark.parametrize("openapi_version", ("2.0", "3.0.0"))
     def test_plugin_operation_helper_is_used(self, openapi_version):
         spec = APISpec(
-            title='Swagger Petstore',
-            version='1.0.0',
+            title="Swagger Petstore",
+            version="1.0.0",
             openapi_version=openapi_version,
-            plugins=(self.test_plugin_factory(), ),
+            plugins=(self.test_plugin_factory(),),
         )
-        spec.path('/path_2', operations={'post': {'responses': {'200': {}}}})
+        spec.path("/path_2", operations={"post": {"responses": {"200": {}}}})
         paths = get_paths(spec)
         assert len(paths) == 1
-        assert paths['/path_2'] == {'post': {'responses': {'201': {}}}}
+        assert paths["/path_2"] == {"post": {"responses": {"201": {}}}}
 
 
 class TestPluginsOrder:
-
     class OrderedPlugin(BasePlugin):
-
         def __init__(self, index, output):
             super(TestPluginsOrder.OrderedPlugin, self).__init__()
             self.index = index
             self.output = output
 
         def path_helper(self, path, operations, **kwargs):
-            self.output.append('plugin_{}_path'.format(self.index))
+            self.output.append("plugin_{}_path".format(self.index))
 
         def operation_helper(self, path, operations, **kwargs):
-            self.output.append('plugin_{}_operations'.format(self.index))
+            self.output.append("plugin_{}_operations".format(self.index))
 
     def test_plugins_order(self):
         """Test plugins execution order in APISpec.path
@@ -537,13 +548,15 @@ class TestPluginsOrder:
         """
         output = []
         spec = APISpec(
-            title='Swagger Petstore',
-            version='1.0.0',
-            openapi_version='3.0.0',
+            title="Swagger Petstore",
+            version="1.0.0",
+            openapi_version="3.0.0",
             plugins=(self.OrderedPlugin(1, output), self.OrderedPlugin(2, output)),
         )
-        spec.path('/path', operations={'get': {'responses': {200: {}}}})
+        spec.path("/path", operations={"get": {"responses": {200: {}}}})
         assert output == [
-            'plugin_1_path', 'plugin_2_path',
-            'plugin_1_operations', 'plugin_2_operations',
+            "plugin_1_path",
+            "plugin_2_path",
+            "plugin_1_operations",
+            "plugin_2_operations",
         ]

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -12,140 +12,137 @@ from apispec.ext.marshmallow import MarshmallowPlugin
 from apispec.ext.marshmallow.openapi import MARSHMALLOW_VERSION_INFO
 from apispec.exceptions import APISpecError
 from .schemas import (
-    PetSchema, AnalysisSchema, RunSchema,
-    SelfReferencingSchema, OrderedSchema, PatternedObjectSchema,
-    DefaultValuesSchema, AnalysisWithListSchema,
+    PetSchema,
+    AnalysisSchema,
+    RunSchema,
+    SelfReferencingSchema,
+    OrderedSchema,
+    PatternedObjectSchema,
+    DefaultValuesSchema,
+    AnalysisWithListSchema,
 )
 
 from .utils import get_definitions, get_parameters, get_responses, get_paths, ref_path
 
 
 class TestDefinitionHelper:
-
-    @pytest.mark.parametrize('schema', [PetSchema, PetSchema()])
+    @pytest.mark.parametrize("schema", [PetSchema, PetSchema()])
     def test_can_use_schema_as_definition(self, spec, schema):
-        spec.components.schema('Pet', schema=schema)
+        spec.components.schema("Pet", schema=schema)
         definitions = get_definitions(spec)
-        props = definitions['Pet']['properties']
+        props = definitions["Pet"]["properties"]
 
-        assert props['id']['type'] == 'integer'
-        assert props['name']['type'] == 'string'
+        assert props["id"]["type"] == "integer"
+        assert props["name"]["type"] == "string"
 
     def test_schema_helper_without_schema(self, spec):
-        spec.components.schema('Pet', properties={'key': {'type': 'integer'}})
+        spec.components.schema("Pet", properties={"key": {"type": "integer"}})
         definitions = get_definitions(spec)
-        assert definitions['Pet']['properties'] == {'key': {'type': 'integer'}}
+        assert definitions["Pet"]["properties"] == {"key": {"type": "integer"}}
 
-    @pytest.mark.parametrize('schema', [AnalysisSchema, AnalysisSchema()])
+    @pytest.mark.parametrize("schema", [AnalysisSchema, AnalysisSchema()])
     def test_resolve_schema_dict_auto_reference(self, schema):
         def resolver(schema):
             return schema.__name__
+
         spec = APISpec(
-            title='Test auto-reference',
-            version='0.1',
-            openapi_version='2.0',
-            plugins=(
-                MarshmallowPlugin(schema_name_resolver=resolver),
-            ),
+            title="Test auto-reference",
+            version="0.1",
+            openapi_version="2.0",
+            plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
         assert {} == get_definitions(spec)
 
-        spec.components.schema('analysis', schema=schema)
+        spec.components.schema("analysis", schema=schema)
         spec.path(
-            '/test', operations={
-                'get': {
-                    'responses': {
-                        '200': {
-                            'schema': {
-                                '$ref': '#/definitions/analysis',
-                            },
-                        },
-                    },
-                },
+            "/test",
+            operations={
+                "get": {
+                    "responses": {"200": {"schema": {"$ref": "#/definitions/analysis"}}}
+                }
             },
         )
         definitions = get_definitions(spec)
         assert 3 == len(definitions)
 
-        assert 'analysis' in definitions
-        assert 'SampleSchema' in definitions
-        assert 'RunSchema' in definitions
+        assert "analysis" in definitions
+        assert "SampleSchema" in definitions
+        assert "RunSchema" in definitions
 
-    @pytest.mark.parametrize('schema', [AnalysisWithListSchema, AnalysisWithListSchema()])
+    @pytest.mark.parametrize(
+        "schema", [AnalysisWithListSchema, AnalysisWithListSchema()]
+    )
     def test_resolve_schema_dict_auto_reference_in_list(self, schema):
         def resolver(schema):
             return schema.__name__
+
         spec = APISpec(
-            title='Test auto-reference',
-            version='0.1',
-            openapi_version='2.0',
-            plugins=(
-                MarshmallowPlugin(schema_name_resolver=resolver,),
-            ),
+            title="Test auto-reference",
+            version="0.1",
+            openapi_version="2.0",
+            plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
         assert {} == get_definitions(spec)
 
-        spec.components.schema('analysis', schema=schema)
+        spec.components.schema("analysis", schema=schema)
         spec.path(
-            '/test', operations={
-                'get': {
-                    'responses': {
-                        '200': {
-                            'schema': {
-                                '$ref': '#/definitions/analysis',
-                            },
-                        },
-                    },
-                },
+            "/test",
+            operations={
+                "get": {
+                    "responses": {"200": {"schema": {"$ref": "#/definitions/analysis"}}}
+                }
             },
         )
         definitions = get_definitions(spec)
         assert 3 == len(definitions)
 
-        assert 'analysis' in definitions
-        assert 'SampleSchema' in definitions
-        assert 'RunSchema' in definitions
+        assert "analysis" in definitions
+        assert "SampleSchema" in definitions
+        assert "RunSchema" in definitions
 
-    @pytest.mark.parametrize('schema', [AnalysisSchema, AnalysisSchema()])
+    @pytest.mark.parametrize("schema", [AnalysisSchema, AnalysisSchema()])
     def test_resolve_schema_dict_auto_reference_return_none(self, schema):
         # this resolver return None
         def resolver(schema):
             return None
+
         spec = APISpec(
-            title='Test auto-reference',
-            version='0.1',
-            openapi_version='2.0',
-            plugins=(
-                MarshmallowPlugin(schema_name_resolver=resolver,),
-            ),
+            title="Test auto-reference",
+            version="0.1",
+            openapi_version="2.0",
+            plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
         assert {} == get_definitions(spec)
 
-        with pytest.raises(APISpecError, match='Name resolver returned None for schema'):
-            spec.components.schema('analysis', schema=schema)
+        with pytest.raises(
+            APISpecError, match="Name resolver returned None for schema"
+        ):
+            spec.components.schema("analysis", schema=schema)
 
-    @pytest.mark.parametrize('schema', [AnalysisSchema, AnalysisSchema()])
+    @pytest.mark.parametrize("schema", [AnalysisSchema, AnalysisSchema()])
     def test_warning_when_schema_added_twice(self, spec, schema):
-        spec.components.schema('Analysis', schema=schema)
-        with pytest.warns(UserWarning, match='has already been added to the spec'):
-            spec.components.schema('DuplicateAnalysis', schema=schema)
+        spec.components.schema("Analysis", schema=schema)
+        with pytest.warns(UserWarning, match="has already been added to the spec"):
+            spec.components.schema("DuplicateAnalysis", schema=schema)
 
     def test_schema_instances_with_different_modifiers_added(self, spec):
         class MultiModifierSchema(Schema):
             pet_unmodified = Nested(PetSchema)
-            pet_exclude = Nested(PetSchema, exclude=('name',))
+            pet_exclude = Nested(PetSchema, exclude=("name",))
 
-        spec.components.schema('Pet', schema=PetSchema())
-        spec.components.schema('Pet_Exclude', schema=PetSchema(exclude=('name',)))
+        spec.components.schema("Pet", schema=PetSchema())
+        spec.components.schema("Pet_Exclude", schema=PetSchema(exclude=("name",)))
 
-        spec.components.schema('MultiModifierSchema', schema=MultiModifierSchema)
+        spec.components.schema("MultiModifierSchema", schema=MultiModifierSchema)
 
         definitions = get_definitions(spec)
-        pet_unmodified_ref = definitions['MultiModifierSchema']['properties']['pet_unmodified']
-        assert pet_unmodified_ref == {'$ref': ref_path(spec) + 'Pet'}
+        pet_unmodified_ref = definitions["MultiModifierSchema"]["properties"][
+            "pet_unmodified"
+        ]
+        assert pet_unmodified_ref == {"$ref": ref_path(spec) + "Pet"}
 
-        pet_exclude = definitions['MultiModifierSchema']['properties']['pet_exclude']
-        assert pet_exclude == {'$ref': ref_path(spec) + 'Pet_Exclude'}
+        pet_exclude = definitions["MultiModifierSchema"]["properties"]["pet_exclude"]
+        assert pet_exclude == {"$ref": ref_path(spec) + "Pet_Exclude"}
 
     def test_schema_with_clashing_names(self, spec):
         class Pet(PetSchema):
@@ -155,75 +152,75 @@ class TestDefinitionHelper:
             pet_1 = Nested(PetSchema)
             pet_2 = Nested(Pet)
 
-        with pytest.warns(UserWarning, match='Multiple schemas resolved to the name Pet'):
-            spec.components.schema('NameClashSchema', schema=NameClashSchema)
+        with pytest.warns(
+            UserWarning, match="Multiple schemas resolved to the name Pet"
+        ):
+            spec.components.schema("NameClashSchema", schema=NameClashSchema)
 
         definitions = get_definitions(spec)
 
-        assert 'Pet' in definitions
-        assert 'Pet1' in definitions
+        assert "Pet" in definitions
+        assert "Pet1" in definitions
+
 
 class TestComponentParameterHelper:
-
-    @pytest.mark.parametrize('schema', [PetSchema, PetSchema()])
+    @pytest.mark.parametrize("schema", [PetSchema, PetSchema()])
     def test_can_use_schema_in_parameter(self, spec, schema):
         if spec.openapi_version.major < 3:
-            kwargs = {'schema': schema}
+            kwargs = {"schema": schema}
         else:
-            kwargs = {'content': {'application/json': {'schema': schema}}}
-        spec.components.parameter('Pet', 'body', **kwargs)
-        parameter = get_parameters(spec)['Pet']
-        assert parameter['in'] == 'body'
+            kwargs = {"content": {"application/json": {"schema": schema}}}
+        spec.components.parameter("Pet", "body", **kwargs)
+        parameter = get_parameters(spec)["Pet"]
+        assert parameter["in"] == "body"
         if spec.openapi_version.major < 3:
-            reference = parameter['schema']
+            reference = parameter["schema"]
         else:
-            reference = parameter['content']['application/json']['schema']
+            reference = parameter["content"]["application/json"]["schema"]
 
-        assert reference == {'$ref': ref_path(spec) + 'Pet'}
+        assert reference == {"$ref": ref_path(spec) + "Pet"}
 
-        resolved_schema = spec.components._schemas['Pet']
-        assert resolved_schema['properties']['name']['type'] == 'string'
-        assert resolved_schema['properties']['password']['type'] == 'string'
-        assert resolved_schema['properties']['id']['type'] == 'integer'
+        resolved_schema = spec.components._schemas["Pet"]
+        assert resolved_schema["properties"]["name"]["type"] == "string"
+        assert resolved_schema["properties"]["password"]["type"] == "string"
+        assert resolved_schema["properties"]["id"]["type"] == "integer"
 
 
 class TestComponentResponseHelper:
-
-    @pytest.mark.parametrize('schema', [PetSchema, PetSchema()])
+    @pytest.mark.parametrize("schema", [PetSchema, PetSchema()])
     def test_can_use_schema_in_response(self, spec, schema):
         if spec.openapi_version.major < 3:
-            kwargs = {'schema': schema}
+            kwargs = {"schema": schema}
         else:
-            kwargs = {'content': {'application/json': {'schema': schema}}}
-        spec.components.response('GetPetOk', **kwargs)
-        response = get_responses(spec)['GetPetOk']
+            kwargs = {"content": {"application/json": {"schema": schema}}}
+        spec.components.response("GetPetOk", **kwargs)
+        response = get_responses(spec)["GetPetOk"]
         if spec.openapi_version.major < 3:
-            reference = response['schema']
+            reference = response["schema"]
         else:
-            reference = response['content']['application/json']['schema']
+            reference = response["content"]["application/json"]["schema"]
 
-        assert reference == {'$ref': ref_path(spec) + 'Pet'}
+        assert reference == {"$ref": ref_path(spec) + "Pet"}
 
-        resolved_schema = spec.components._schemas['Pet']
-        assert resolved_schema['properties']['id']['type'] == 'integer'
-        assert resolved_schema['properties']['name']['type'] == 'string'
-        assert resolved_schema['properties']['password']['type'] == 'string'
+        resolved_schema = spec.components._schemas["Pet"]
+        assert resolved_schema["properties"]["id"]["type"] == "integer"
+        assert resolved_schema["properties"]["name"]["type"] == "string"
+        assert resolved_schema["properties"]["password"]["type"] == "string"
 
 
 class TestCustomField:
-
     def test_can_use_custom_field_decorator(self, spec_fixture):
-
         @spec_fixture.marshmallow_plugin.map_to_openapi_type(DateTime)
         class CustomNameA(Field):
             pass
 
-        @spec_fixture.marshmallow_plugin.map_to_openapi_type('integer', 'int32')
+        @spec_fixture.marshmallow_plugin.map_to_openapi_type("integer", "int32")
         class CustomNameB(Field):
             pass
 
         with pytest.raises(TypeError):
-            @spec_fixture.marshmallow_plugin.map_to_openapi_type('integer')
+
+            @spec_fixture.marshmallow_plugin.map_to_openapi_type("integer")
             class BadCustomField(Field):
                 pass
 
@@ -233,580 +230,507 @@ class TestCustomField:
         class CustomPetBSchema(PetSchema):
             name = CustomNameB()
 
-        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
-        spec_fixture.spec.components.schema('CustomPetA', schema=CustomPetASchema)
-        spec_fixture.spec.components.schema('CustomPetB', schema=CustomPetBSchema)
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
+        spec_fixture.spec.components.schema("CustomPetA", schema=CustomPetASchema)
+        spec_fixture.spec.components.schema("CustomPetB", schema=CustomPetBSchema)
 
-        props_0 = get_definitions(spec_fixture.spec)['Pet']['properties']
-        props_a = get_definitions(spec_fixture.spec)['CustomPetA']['properties']
-        props_b = get_definitions(spec_fixture.spec)['CustomPetB']['properties']
+        props_0 = get_definitions(spec_fixture.spec)["Pet"]["properties"]
+        props_a = get_definitions(spec_fixture.spec)["CustomPetA"]["properties"]
+        props_b = get_definitions(spec_fixture.spec)["CustomPetB"]["properties"]
 
-        assert props_0['name']['type'] == 'string'
-        assert 'format' not in props_0['name']
+        assert props_0["name"]["type"] == "string"
+        assert "format" not in props_0["name"]
 
-        assert props_a['name']['type'] == 'string'
-        assert props_a['name']['format'] == 'date-time'
+        assert props_a["name"]["type"] == "string"
+        assert props_a["name"]["format"] == "date-time"
 
-        assert props_b['name']['type'] == 'integer'
-        assert props_b['name']['format'] == 'int32'
+        assert props_b["name"]["type"] == "integer"
+        assert props_b["name"]["format"] == "int32"
 
 
 class TestOperationHelper:
-
-    @pytest.mark.parametrize('pet_schema', (PetSchema, PetSchema(), 'tests.schemas.PetSchema'))
-    @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize(
+        "pet_schema", (PetSchema, PetSchema(), "tests.schemas.PetSchema")
+    )
+    @pytest.mark.parametrize("spec_fixture", ("2.0",), indirect=True)
     def test_schema_v2(self, spec_fixture, pet_schema):
         spec_fixture.spec.path(
-            path='/pet',
+            path="/pet",
             operations={
-                'get': {
-                    'responses': {
+                "get": {
+                    "responses": {
                         200: {
-                            'schema': pet_schema,
-                            'description': 'successful operation',
-                        },
-                    },
-                },
+                            "schema": pet_schema,
+                            "description": "successful operation",
+                        }
+                    }
+                }
             },
         )
-        get = get_paths(spec_fixture.spec)['/pet']['get']
-        reference = get['responses'][200]['schema']
-        assert reference == {'$ref': ref_path(spec_fixture.spec) + 'Pet'}
+        get = get_paths(spec_fixture.spec)["/pet"]["get"]
+        reference = get["responses"][200]["schema"]
+        assert reference == {"$ref": ref_path(spec_fixture.spec) + "Pet"}
         assert len(spec_fixture.spec.components._schemas) == 1
-        resolved_schema = spec_fixture.spec.components._schemas['Pet']
-        assert resolved_schema == spec_fixture.openapi.schema2jsonschema(
-            PetSchema,
-        )
-        assert get['responses'][200]['description'] == 'successful operation'
+        resolved_schema = spec_fixture.spec.components._schemas["Pet"]
+        assert resolved_schema == spec_fixture.openapi.schema2jsonschema(PetSchema)
+        assert get["responses"][200]["description"] == "successful operation"
 
-    @pytest.mark.parametrize('pet_schema', (PetSchema, PetSchema(), 'tests.schemas.PetSchema'))
-    @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
+    @pytest.mark.parametrize(
+        "pet_schema", (PetSchema, PetSchema(), "tests.schemas.PetSchema")
+    )
+    @pytest.mark.parametrize("spec_fixture", ("3.0.0",), indirect=True)
     def test_schema_v3(self, spec_fixture, pet_schema):
         spec_fixture.spec.path(
-            path='/pet',
+            path="/pet",
             operations={
-                'get': {
-                    'responses': {
+                "get": {
+                    "responses": {
                         200: {
-                            'content': {
-                                'application/json': {
-                                    'schema': pet_schema,
-                                },
-                            },
-                            'description': 'successful operation',
-                        },
-                    },
-                },
+                            "content": {"application/json": {"schema": pet_schema}},
+                            "description": "successful operation",
+                        }
+                    }
+                }
             },
         )
-        get = get_paths(spec_fixture.spec)['/pet']['get']
-        reference = get['responses'][200]['content']['application/json']['schema']
+        get = get_paths(spec_fixture.spec)["/pet"]["get"]
+        reference = get["responses"][200]["content"]["application/json"]["schema"]
 
-        assert reference == {'$ref': ref_path(spec_fixture.spec) + 'Pet'}
+        assert reference == {"$ref": ref_path(spec_fixture.spec) + "Pet"}
         assert len(spec_fixture.spec.components._schemas) == 1
-        resolved_schema = spec_fixture.spec.components._schemas['Pet']
-        assert resolved_schema == spec_fixture.openapi.schema2jsonschema(
-            PetSchema,
-        )
-        assert get['responses'][200]['description'] == 'successful operation'
+        resolved_schema = spec_fixture.spec.components._schemas["Pet"]
+        assert resolved_schema == spec_fixture.openapi.schema2jsonschema(PetSchema)
+        assert get["responses"][200]["description"] == "successful operation"
 
-    @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize("spec_fixture", ("2.0",), indirect=True)
     def test_schema_expand_parameters_v2(self, spec_fixture):
         spec_fixture.spec.path(
-            path='/pet',
+            path="/pet",
             operations={
-                'get': {
-                    'parameters': [{
-                        'in': 'query',
-                        'schema': PetSchema,
-                    }],
-                },
-                'post': {
-                    'parameters': [{
-                        'in': 'body',
-                        'description': 'a pet schema',
-                        'required': True,
-                        'name': 'pet',
-                        'schema': PetSchema,
-                    }],
+                "get": {"parameters": [{"in": "query", "schema": PetSchema}]},
+                "post": {
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "description": "a pet schema",
+                            "required": True,
+                            "name": "pet",
+                            "schema": PetSchema,
+                        }
+                    ]
                 },
             },
         )
-        p = get_paths(spec_fixture.spec)['/pet']
-        get = p['get']
-        assert get['parameters'] == spec_fixture.openapi.schema2parameters(
-            PetSchema(), default_in='query',
+        p = get_paths(spec_fixture.spec)["/pet"]
+        get = p["get"]
+        assert get["parameters"] == spec_fixture.openapi.schema2parameters(
+            PetSchema(), default_in="query"
         )
-        post = p['post']
-        assert post['parameters'] == spec_fixture.openapi.schema2parameters(
-            PetSchema, default_in='body', required=True,
-            name='pet', description='a pet schema',
+        post = p["post"]
+        assert post["parameters"] == spec_fixture.openapi.schema2parameters(
+            PetSchema,
+            default_in="body",
+            required=True,
+            name="pet",
+            description="a pet schema",
         )
 
-    @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
+    @pytest.mark.parametrize("spec_fixture", ("3.0.0",), indirect=True)
     def test_schema_expand_parameters_v3(self, spec_fixture):
         spec_fixture.spec.path(
-            path='/pet',
+            path="/pet",
             operations={
-                'get': {
-                    'parameters': [{
-                        'in': 'query',
-                        'schema': PetSchema,
-                    }],
-                },
-                'post': {
-                    'requestBody': {
-                        'description': 'a pet schema',
-                        'required': True,
-                        'content': {
-                            'application/json': {
-                                'schema': PetSchema,
-                            },
-                        },
-                    },
+                "get": {"parameters": [{"in": "query", "schema": PetSchema}]},
+                "post": {
+                    "requestBody": {
+                        "description": "a pet schema",
+                        "required": True,
+                        "content": {"application/json": {"schema": PetSchema}},
+                    }
                 },
             },
         )
-        p = get_paths(spec_fixture.spec)['/pet']
-        get = p['get']
-        assert get['parameters'] == spec_fixture.openapi.schema2parameters(
-            PetSchema(), default_in='query',
+        p = get_paths(spec_fixture.spec)["/pet"]
+        get = p["get"]
+        assert get["parameters"] == spec_fixture.openapi.schema2parameters(
+            PetSchema(), default_in="query"
         )
-        for parameter in get['parameters']:
-            description = parameter.get('description', False)
+        for parameter in get["parameters"]:
+            description = parameter.get("description", False)
             assert description
-            name = parameter['name']
+            name = parameter["name"]
             assert description == PetSchema.description[name]
-        post = p['post']
+        post = p["post"]
         post_schema = spec_fixture.openapi.resolve_schema_dict(PetSchema)
-        assert post['requestBody']['content']['application/json']['schema'] == post_schema
-        assert post['requestBody']['description'] == 'a pet schema'
-        assert post['requestBody']['required']
+        assert (
+            post["requestBody"]["content"]["application/json"]["schema"] == post_schema
+        )
+        assert post["requestBody"]["description"] == "a pet schema"
+        assert post["requestBody"]["required"]
 
-    @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize("spec_fixture", ("2.0",), indirect=True)
     def test_schema_uses_ref_if_available_v2(self, spec_fixture):
-        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
         spec_fixture.spec.path(
-            path='/pet',
-            operations={
-                'get': {
-                    'responses': {
-                        200: {
-                            'schema': PetSchema,
-                        },
-                    },
-                },
-            },
+            path="/pet", operations={"get": {"responses": {200: {"schema": PetSchema}}}}
         )
-        get = get_paths(spec_fixture.spec)['/pet']['get']
-        assert get['responses'][200]['schema']['$ref'] == ref_path(spec_fixture.spec) + 'Pet'
+        get = get_paths(spec_fixture.spec)["/pet"]["get"]
+        assert (
+            get["responses"][200]["schema"]["$ref"]
+            == ref_path(spec_fixture.spec) + "Pet"
+        )
 
-    @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
+    @pytest.mark.parametrize("spec_fixture", ("3.0.0",), indirect=True)
     def test_schema_uses_ref_if_available_v3(self, spec_fixture):
-        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
         spec_fixture.spec.path(
-            path='/pet',
+            path="/pet",
             operations={
-                'get': {
-                    'responses': {
-                        200: {
-                            'content': {
-                                'application/json': {
-                                    'schema': PetSchema,
-                                },
-                            },
-                        },
-                    },
-                },
+                "get": {
+                    "responses": {
+                        200: {"content": {"application/json": {"schema": PetSchema}}}
+                    }
+                }
             },
         )
-        get = get_paths(spec_fixture.spec)['/pet']['get']
-        assert get['responses'][200]['content']['application/json']['schema']['$ref'] == ref_path(
-            spec_fixture.spec,
-        ) + 'Pet'
+        get = get_paths(spec_fixture.spec)["/pet"]["get"]
+        assert (
+            get["responses"][200]["content"]["application/json"]["schema"]["$ref"]
+            == ref_path(spec_fixture.spec) + "Pet"
+        )
 
     def test_schema_uses_ref_if_available_name_resolver_returns_none_v2(self):
         def resolver(schema):
             return None
+
         spec = APISpec(
-            title='Test auto-reference',
-            version='0.1',
-            openapi_version='2.0',
-            plugins=(
-                MarshmallowPlugin(schema_name_resolver=resolver,),
-            ),
+            title="Test auto-reference",
+            version="0.1",
+            openapi_version="2.0",
+            plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        spec.components.schema('Pet', schema=PetSchema)
+        spec.components.schema("Pet", schema=PetSchema)
         spec.path(
-            path='/pet',
-            operations={
-                'get': {
-                    'responses': {
-                        200: {
-                            'schema': PetSchema,
-                        },
-                    },
-                },
-            },
+            path="/pet", operations={"get": {"responses": {200: {"schema": PetSchema}}}}
         )
-        get = get_paths(spec)['/pet']['get']
-        assert get['responses'][200]['schema']['$ref'] == ref_path(spec) + 'Pet'
+        get = get_paths(spec)["/pet"]["get"]
+        assert get["responses"][200]["schema"]["$ref"] == ref_path(spec) + "Pet"
 
     def test_schema_uses_ref_if_available_name_resolver_returns_none_v3(self):
         def resolver(schema):
             return None
+
         spec = APISpec(
-            title='Test auto-reference',
-            version='0.1',
-            openapi_version='3.0.0',
-            plugins=(
-                MarshmallowPlugin(schema_name_resolver=resolver,),
-            ),
+            title="Test auto-reference",
+            version="0.1",
+            openapi_version="3.0.0",
+            plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        spec.components.schema('Pet', schema=PetSchema)
+        spec.components.schema("Pet", schema=PetSchema)
         spec.path(
-            path='/pet',
+            path="/pet",
             operations={
-                'get': {
-                    'responses': {
-                        200: {
-                            'content': {
-                                'application/json': {
-                                    'schema': PetSchema,
-                                },
-                            },
-                        },
-                    },
-                },
+                "get": {
+                    "responses": {
+                        200: {"content": {"application/json": {"schema": PetSchema}}}
+                    }
+                }
             },
         )
-        get = get_paths(spec)['/pet']['get']
-        assert get['responses'][200]['content']['application/json']['schema']['$ref'] == ref_path(
-            spec,
-        ) + 'Pet'
+        get = get_paths(spec)["/pet"]["get"]
+        assert (
+            get["responses"][200]["content"]["application/json"]["schema"]["$ref"]
+            == ref_path(spec) + "Pet"
+        )
 
-    @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
-    def test_schema_uses_ref_in_parameters_and_request_body_if_available_v2(self, spec_fixture):
-        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+    @pytest.mark.parametrize("spec_fixture", ("2.0",), indirect=True)
+    def test_schema_uses_ref_in_parameters_and_request_body_if_available_v2(
+        self, spec_fixture
+    ):
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
         spec_fixture.spec.path(
-            path='/pet',
+            path="/pet",
             operations={
-                'get': {
-                    'parameters': [{
-                        'in': 'query',
-                        'schema': PetSchema,
-                    }],
-                },
-                'post': {
-                    'parameters': [{
-                        'in': 'body',
-                        'schema': PetSchema,
-                    }],
-                },
+                "get": {"parameters": [{"in": "query", "schema": PetSchema}]},
+                "post": {"parameters": [{"in": "body", "schema": PetSchema}]},
             },
         )
-        p = get_paths(spec_fixture.spec)['/pet']
-        assert 'schema' not in p['get']['parameters'][0]
-        post = p['post']
-        assert len(post['parameters']) == 1
-        assert post['parameters'][0]['schema']['$ref'] == ref_path(spec_fixture.spec) + 'Pet'
+        p = get_paths(spec_fixture.spec)["/pet"]
+        assert "schema" not in p["get"]["parameters"][0]
+        post = p["post"]
+        assert len(post["parameters"]) == 1
+        assert (
+            post["parameters"][0]["schema"]["$ref"]
+            == ref_path(spec_fixture.spec) + "Pet"
+        )
 
-    @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
-    def test_schema_uses_ref_in_parameters_and_request_body_if_available_v3(self, spec_fixture):
-        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+    @pytest.mark.parametrize("spec_fixture", ("3.0.0",), indirect=True)
+    def test_schema_uses_ref_in_parameters_and_request_body_if_available_v3(
+        self, spec_fixture
+    ):
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
         spec_fixture.spec.path(
-            path='/pet',
+            path="/pet",
             operations={
-                'get': {
-                    'parameters': [{
-                        'in': 'query',
-                        'schema': PetSchema,
-                    }],
-                },
-                'post': {
-                    'requestBody': {
-                        'content': {
-                            'application/json': {
-                                'schema': PetSchema,
-                            },
-                        },
-                    },
+                "get": {"parameters": [{"in": "query", "schema": PetSchema}]},
+                "post": {
+                    "requestBody": {
+                        "content": {"application/json": {"schema": PetSchema}}
+                    }
                 },
             },
         )
-        p = get_paths(spec_fixture.spec)['/pet']
-        assert 'schema' in p['get']['parameters'][0]
-        post = p['post']
-        schema_ref = post['requestBody']['content']['application/json']['schema']
-        assert schema_ref == {'$ref': ref_path(spec_fixture.spec) + 'Pet'}
+        p = get_paths(spec_fixture.spec)["/pet"]
+        assert "schema" in p["get"]["parameters"][0]
+        post = p["post"]
+        schema_ref = post["requestBody"]["content"]["application/json"]["schema"]
+        assert schema_ref == {"$ref": ref_path(spec_fixture.spec) + "Pet"}
 
-    @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize("spec_fixture", ("2.0",), indirect=True)
     def test_schema_array_uses_ref_if_available_v2(self, spec_fixture):
-        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
         spec_fixture.spec.path(
-            path='/pet',
+            path="/pet",
             operations={
-                'get': {
-                    'parameters': [{
-                        'in': 'body',
-                        'schema': {
-                            'type': 'array',
-                            'items': PetSchema,
-                        },
-                    }],
-                    'responses': {
-                        200: {
-                            'schema': {
-                                'type': 'array',
-                                'items': PetSchema,
-                            },
-                        },
+                "get": {
+                    "parameters": [
+                        {"in": "body", "schema": {"type": "array", "items": PetSchema}}
+                    ],
+                    "responses": {
+                        200: {"schema": {"type": "array", "items": PetSchema}}
                     },
-                },
+                }
             },
         )
-        get = get_paths(spec_fixture.spec)['/pet']['get']
-        len(get['parameters']) == 1
+        get = get_paths(spec_fixture.spec)["/pet"]["get"]
+        len(get["parameters"]) == 1
         resolved_schema = {
-            'type': 'array',
-            'items': {'$ref': ref_path(spec_fixture.spec) + 'Pet'},
+            "type": "array",
+            "items": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
         }
-        assert get['parameters'][0]['schema'] == resolved_schema
-        assert get['responses'][200]['schema'] == resolved_schema
+        assert get["parameters"][0]["schema"] == resolved_schema
+        assert get["responses"][200]["schema"] == resolved_schema
 
-    @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
+    @pytest.mark.parametrize("spec_fixture", ("3.0.0",), indirect=True)
     def test_schema_array_uses_ref_if_available_v3(self, spec_fixture):
-        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
         spec_fixture.spec.path(
-            path='/pet',
+            path="/pet",
             operations={
-                'get': {
-                    'parameters': [{
-                        'in': 'body',
-                        'content': {
-                            'application/json': {
-                                'schema': {
-                                    'type': 'array',
-                                    'items': PetSchema,
-                                },
+                "get": {
+                    "parameters": [
+                        {
+                            "in": "body",
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "array", "items": PetSchema}
+                                }
                             },
-                        },
-                    }],
-                    'responses': {
+                        }
+                    ],
+                    "responses": {
                         200: {
-                            'content': {
-                                'application/json': {
-                                    'schema': {
-                                        'type': 'array',
-                                        'items': PetSchema,
-                                    },
-                                },
-                            },
-                        },
+                            "content": {
+                                "application/json": {
+                                    "schema": {"type": "array", "items": PetSchema}
+                                }
+                            }
+                        }
                     },
-                },
+                }
             },
         )
-        p = get_paths(spec_fixture.spec)['/pet']
-        assert 'get' in p
-        op = p['get']
+        p = get_paths(spec_fixture.spec)["/pet"]
+        assert "get" in p
+        op = p["get"]
         resolved_schema = {
-            'type': 'array',
-            'items': {'$ref': ref_path(spec_fixture.spec) + 'Pet'},
+            "type": "array",
+            "items": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
         }
-        request_schema = op['parameters'][0]['content']['application/json']['schema']
+        request_schema = op["parameters"][0]["content"]["application/json"]["schema"]
         assert request_schema == resolved_schema
-        response_schema = op['responses'][200]['content']['application/json']['schema']
+        response_schema = op["responses"][200]["content"]["application/json"]["schema"]
         assert response_schema == resolved_schema
 
-    @pytest.mark.parametrize('spec_fixture', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize("spec_fixture", ("2.0",), indirect=True)
     def test_schema_partially_v2(self, spec_fixture):
-        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
         spec_fixture.spec.path(
-            path='/parents',
+            path="/parents",
             operations={
-                'get': {
-                    'responses': {
+                "get": {
+                    "responses": {
                         200: {
-                            'schema': {
-                                'type': 'object',
-                                'properties': {
-                                    'mother': PetSchema,
-                                    'father': PetSchema,
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "mother": PetSchema,
+                                    "father": PetSchema,
                                 },
-                            },
-                        },
-                    },
-                },
+                            }
+                        }
+                    }
+                }
             },
         )
-        get = get_paths(spec_fixture.spec)['/parents']['get']
-        assert get['responses'][200]['schema'] == {
-            'type': 'object',
-            'properties': {
-                'mother': {'$ref': ref_path(spec_fixture.spec) + 'Pet'},
-                'father': {'$ref': ref_path(spec_fixture.spec) + 'Pet'},
+        get = get_paths(spec_fixture.spec)["/parents"]["get"]
+        assert get["responses"][200]["schema"] == {
+            "type": "object",
+            "properties": {
+                "mother": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
+                "father": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
             },
         }
 
-    @pytest.mark.parametrize('spec_fixture', ('3.0.0', ), indirect=True)
+    @pytest.mark.parametrize("spec_fixture", ("3.0.0",), indirect=True)
     def test_schema_partially_v3(self, spec_fixture):
-        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
         spec_fixture.spec.path(
-            path='/parents',
+            path="/parents",
             operations={
-                'get': {
-                    'responses': {
+                "get": {
+                    "responses": {
                         200: {
-                            'content': {
-                                'application/json': {
-                                    'schema': {
-                                        'type': 'object',
-                                        'properties': {
-                                            'mother': PetSchema,
-                                            'father': PetSchema,
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "mother": PetSchema,
+                                            "father": PetSchema,
                                         },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             },
         )
-        get = get_paths(spec_fixture.spec)['/parents']['get']
-        assert get['responses'][200]['content']['application/json']['schema'] == {
-            'type': 'object',
-            'properties': {
-                'mother': {'$ref': ref_path(spec_fixture.spec) + 'Pet'},
-                'father': {'$ref': ref_path(spec_fixture.spec) + 'Pet'},
+        get = get_paths(spec_fixture.spec)["/parents"]["get"]
+        assert get["responses"][200]["content"]["application/json"]["schema"] == {
+            "type": "object",
+            "properties": {
+                "mother": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
+                "father": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
             },
         }
 
     def test_schema_global_state_untouched_2json(self, spec_fixture):
-        assert RunSchema._declared_fields['sample']._Nested__schema is None
+        assert RunSchema._declared_fields["sample"]._Nested__schema is None
         data = spec_fixture.openapi.schema2jsonschema(RunSchema)
         json.dumps(data)
-        assert RunSchema._declared_fields['sample']._Nested__schema is None
+        assert RunSchema._declared_fields["sample"]._Nested__schema is None
 
     def test_schema_global_state_untouched_2parameters(self, spec_fixture):
-        assert RunSchema._declared_fields['sample']._Nested__schema is None
+        assert RunSchema._declared_fields["sample"]._Nested__schema is None
         data = spec_fixture.openapi.schema2parameters(RunSchema)
         json.dumps(data)
-        assert RunSchema._declared_fields['sample']._Nested__schema is None
+        assert RunSchema._declared_fields["sample"]._Nested__schema is None
+
 
 class TestCircularReference:
-
     def test_circular_referencing_schemas(self, spec):
-        spec.components.schema('Analysis', schema=AnalysisSchema)
+        spec.components.schema("Analysis", schema=AnalysisSchema)
         definitions = get_definitions(spec)
-        ref = definitions['Analysis']['properties']['sample']['$ref']
-        assert ref == ref_path(spec) + 'Sample'
+        ref = definitions["Analysis"]["properties"]["sample"]["$ref"]
+        assert ref == ref_path(spec) + "Sample"
+
 
 # Regression tests for issue #55
 class TestSelfReference:
-
     def test_self_referencing_field_single(self, spec):
-        spec.components.schema('SelfReference', schema=SelfReferencingSchema)
+        spec.components.schema("SelfReference", schema=SelfReferencingSchema)
         definitions = get_definitions(spec)
-        ref = definitions['SelfReference']['properties']['single']['$ref']
-        assert ref == ref_path(spec) + 'SelfReference'
+        ref = definitions["SelfReference"]["properties"]["single"]["$ref"]
+        assert ref == ref_path(spec) + "SelfReference"
 
     def test_self_referencing_field_many(self, spec):
-        spec.components.schema('SelfReference', schema=SelfReferencingSchema)
+        spec.components.schema("SelfReference", schema=SelfReferencingSchema)
         definitions = get_definitions(spec)
-        result = definitions['SelfReference']['properties']['many']
+        result = definitions["SelfReference"]["properties"]["many"]
         assert result == {
-            'type': 'array',
-            'items': {'$ref': ref_path(spec) + 'SelfReference'},
+            "type": "array",
+            "items": {"$ref": ref_path(spec) + "SelfReference"},
         }
 
 
 class TestOrderedSchema:
-
     def test_ordered_schema(self, spec):
-        spec.components.schema('Ordered', schema=OrderedSchema)
-        result = get_definitions(spec)['Ordered']['properties']
-        assert list(result.keys()) == ['field1', 'field2', 'field3', 'field4', 'field5']
+        spec.components.schema("Ordered", schema=OrderedSchema)
+        result = get_definitions(spec)["Ordered"]["properties"]
+        assert list(result.keys()) == ["field1", "field2", "field3", "field4", "field5"]
 
 
 class TestFieldWithCustomProps:
     def test_field_with_custom_props(self, spec):
-        spec.components.schema('PatternedObject', schema=PatternedObjectSchema)
-        result = get_definitions(spec)['PatternedObject']['properties']['count']
-        assert 'x-count' in result
-        assert result['x-count'] == 1
+        spec.components.schema("PatternedObject", schema=PatternedObjectSchema)
+        result = get_definitions(spec)["PatternedObject"]["properties"]["count"]
+        assert "x-count" in result
+        assert result["x-count"] == 1
 
     def test_field_with_custom_props_passed_as_snake_case(self, spec):
-        spec.components.schema('PatternedObject', schema=PatternedObjectSchema)
-        result = get_definitions(spec)['PatternedObject']['properties']['count2']
-        assert 'x-count2' in result
-        assert result['x-count2'] == 2
+        spec.components.schema("PatternedObject", schema=PatternedObjectSchema)
+        result = get_definitions(spec)["PatternedObject"]["properties"]["count2"]
+        assert "x-count2" in result
+        assert result["x-count2"] == 2
 
 
 class TestSchemaWithDefaultValues:
     def test_schema_with_default_values(self, spec):
-        spec.components.schema('DefaultValuesSchema', schema=DefaultValuesSchema)
+        spec.components.schema("DefaultValuesSchema", schema=DefaultValuesSchema)
         definitions = get_definitions(spec)
-        props = definitions['DefaultValuesSchema']['properties']
-        assert props['number_auto_default']['default'] == 12
-        assert props['number_manual_default']['default'] == 42
-        assert 'default' not in props['string_callable_default']
-        assert props['string_manual_default']['default'] == 'Manual'
-        assert 'default' not in props['numbers']
+        props = definitions["DefaultValuesSchema"]["properties"]
+        assert props["number_auto_default"]["default"] == 12
+        assert props["number_manual_default"]["default"] == 42
+        assert "default" not in props["string_callable_default"]
+        assert props["string_manual_default"]["default"] == "Manual"
+        assert "default" not in props["numbers"]
 
 
 @pytest.mark.skipif(
-    MARSHMALLOW_VERSION_INFO[0] < 3,
-    reason='Values ignored in marshmallow 2',
+    MARSHMALLOW_VERSION_INFO[0] < 3, reason="Values ignored in marshmallow 2"
 )
 class TestDictValues:
     def test_dict_values_resolve_to_additional_properties(self, spec):
-
         class SchemaWithDict(Schema):
             dict_field = Dict(values=String())
 
-        spec.components.schema('SchemaWithDict', schema=SchemaWithDict)
-        result = get_definitions(spec)['SchemaWithDict']['properties']['dict_field']
-        assert result == {'type': 'object', 'additionalProperties': {'type': 'string'}}
+        spec.components.schema("SchemaWithDict", schema=SchemaWithDict)
+        result = get_definitions(spec)["SchemaWithDict"]["properties"]["dict_field"]
+        assert result == {"type": "object", "additionalProperties": {"type": "string"}}
 
     def test_dict_with_empty_values_field(self, spec):
-
         class SchemaWithDict(Schema):
             dict_field = Dict()
 
-        spec.components.schema('SchemaWithDict', schema=SchemaWithDict)
-        result = get_definitions(spec)['SchemaWithDict']['properties']['dict_field']
-        assert result == {'type': 'object'}
+        spec.components.schema("SchemaWithDict", schema=SchemaWithDict)
+        result = get_definitions(spec)["SchemaWithDict"]["properties"]["dict_field"]
+        assert result == {"type": "object"}
 
     def test_dict_with_nested(self, spec):
-
         class SchemaWithDict(Schema):
             dict_field = Dict(values=Nested(PetSchema))
 
-        spec.components.schema('SchemaWithDict', schema=SchemaWithDict)
+        spec.components.schema("SchemaWithDict", schema=SchemaWithDict)
 
         assert len(get_definitions(spec)) == 2
 
-        result = get_definitions(spec)['SchemaWithDict']['properties']['dict_field']
+        result = get_definitions(spec)["SchemaWithDict"]["properties"]["dict_field"]
         assert result == {
-            'additionalProperties': {'$ref': ref_path(spec) + 'Pet'},
-            'type': 'object',
+            "additionalProperties": {"$ref": ref_path(spec) + "Pet"},
+            "type": "object",
         }
 
 
 class TestList:
     def test_list_with_nested(self, spec):
-
         class SchemaWithList(Schema):
             list_field = List(Nested(PetSchema))
 
-        spec.components.schema('SchemaWithList', schema=SchemaWithList)
+        spec.components.schema("SchemaWithList", schema=SchemaWithList)
 
         assert len(get_definitions(spec)) == 2
 
-        result = get_definitions(spec)['SchemaWithList']['properties']['list_field']
-        assert result == {
-            'items': {'$ref': ref_path(spec) + 'Pet'},
-            'type': 'array',
-        }
+        result = get_definitions(spec)["SchemaWithList"]["properties"]["list_field"]
+        assert result == {"items": {"$ref": ref_path(spec) + "Pet"}, "type": "array"}

--- a/tests/test_ext_marshmallow_common.py
+++ b/tests/test_ext_marshmallow_common.py
@@ -7,7 +7,7 @@ from .schemas import PetSchema, SampleSchema
 
 class TestMakeSchemaKey:
     def test_raise_if_schema_class_passed(self):
-        with pytest.raises(TypeError, match='based on a Schema instance'):
+        with pytest.raises(TypeError, match="based on a Schema instance"):
             make_schema_key(PetSchema)
 
     def test_same_schemas_instances_equal(self):
@@ -23,19 +23,23 @@ class TestMakeSchemaKey:
 class TestUniqueName:
     def test_unique_name(self, spec):
         properties = {
-            'id': {'type': 'integer', 'format': 'int64'},
-            'name': {'type': 'string', 'example': 'doggie'},
+            "id": {"type": "integer", "format": "int64"},
+            "name": {"type": "string", "example": "doggie"},
         }
 
-        name = get_unique_schema_name(spec.components, 'Pet')
-        assert name == 'Pet'
+        name = get_unique_schema_name(spec.components, "Pet")
+        assert name == "Pet"
 
-        spec.components.schema('Pet', properties=properties)
-        with pytest.warns(UserWarning, match='Multiple schemas resolved to the name Pet'):
-            name_1 = get_unique_schema_name(spec.components, 'Pet')
-        assert name_1 == 'Pet1'
+        spec.components.schema("Pet", properties=properties)
+        with pytest.warns(
+            UserWarning, match="Multiple schemas resolved to the name Pet"
+        ):
+            name_1 = get_unique_schema_name(spec.components, "Pet")
+        assert name_1 == "Pet1"
 
-        spec.components.schema('Pet1', properties=properties)
-        with pytest.warns(UserWarning, match='Multiple schemas resolved to the name Pet'):
-            name_2 = get_unique_schema_name(spec.components, 'Pet')
-        assert name_2 == 'Pet2'
+        spec.components.schema("Pet1", properties=properties)
+        with pytest.warns(
+            UserWarning, match="Multiple schemas resolved to the name Pet"
+        ):
+            name_2 = get_unique_schema_name(spec.components, "Pet")
+        assert name_2 == "Pet2"

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -16,255 +16,254 @@ from .utils import get_definitions, ref_path
 
 
 class TestMarshmallowFieldToOpenAPI:
-
     def test_field2choices_preserving_order(self, openapi):
-        choices = ['a', 'b', 'c', 'aa', '0', 'cc']
+        choices = ["a", "b", "c", "aa", "0", "cc"]
         field = fields.String(validate=validate.OneOf(choices))
-        assert openapi.field2choices(field) == {'enum': choices}
+        assert openapi.field2choices(field) == {"enum": choices}
 
     @mark.parametrize(
-        ('FieldClass', 'jsontype'), [
-            (fields.Integer, 'integer'),
-            (fields.Number, 'number'),
-            (fields.Float, 'number'),
-            (fields.String, 'string'),
-            (fields.Str, 'string'),
-            (fields.Boolean, 'boolean'),
-            (fields.Bool, 'boolean'),
-            (fields.UUID, 'string'),
-            (fields.DateTime, 'string'),
-            (fields.Date, 'string'),
-            (fields.Time, 'string'),
-            (fields.Email, 'string'),
-            (fields.URL, 'string'),
+        ("FieldClass", "jsontype"),
+        [
+            (fields.Integer, "integer"),
+            (fields.Number, "number"),
+            (fields.Float, "number"),
+            (fields.String, "string"),
+            (fields.Str, "string"),
+            (fields.Boolean, "boolean"),
+            (fields.Bool, "boolean"),
+            (fields.UUID, "string"),
+            (fields.DateTime, "string"),
+            (fields.Date, "string"),
+            (fields.Time, "string"),
+            (fields.Email, "string"),
+            (fields.URL, "string"),
             # Assume base Field and Raw are strings
-            (fields.Field, 'string'),
-            (fields.Raw, 'string'),
+            (fields.Field, "string"),
+            (fields.Raw, "string"),
         ],
     )
     def test_field2property_type(self, FieldClass, jsontype, openapi):
         field = FieldClass()
         res = openapi.field2property(field)
-        assert res['type'] == jsontype
+        assert res["type"] == jsontype
 
     def test_formatted_field_translates_to_array(self, openapi):
         field = fields.List(fields.String)
         res = openapi.field2property(field)
-        assert res['type'] == 'array'
-        assert res['items'] == openapi.field2property(fields.String())
+        assert res["type"] == "array"
+        assert res["items"] == openapi.field2property(fields.String())
 
     @mark.parametrize(
-        ('FieldClass', 'expected_format'), [
-            (fields.Integer, 'int32'),
-            (fields.Float, 'float'),
-            (fields.UUID, 'uuid'),
-            (fields.DateTime, 'date-time'),
-            (fields.Date, 'date'),
-            (fields.Email, 'email'),
-            (fields.URL, 'url'),
+        ("FieldClass", "expected_format"),
+        [
+            (fields.Integer, "int32"),
+            (fields.Float, "float"),
+            (fields.UUID, "uuid"),
+            (fields.DateTime, "date-time"),
+            (fields.Date, "date"),
+            (fields.Email, "email"),
+            (fields.URL, "url"),
         ],
     )
     def test_field2property_formats(self, FieldClass, expected_format, openapi):
         field = FieldClass()
         res = openapi.field2property(field)
-        assert res['format'] == expected_format
+        assert res["format"] == expected_format
 
     def test_field_with_description(self, openapi):
-        field = fields.Str(description='a username')
+        field = fields.Str(description="a username")
         res = openapi.field2property(field)
-        assert res['description'] == 'a username'
+        assert res["description"] == "a username"
 
     def test_field_with_missing(self, openapi):
-        field = fields.Str(default='foo', missing='bar')
+        field = fields.Str(default="foo", missing="bar")
         res = openapi.field2property(field)
-        assert res['default'] == 'bar'
+        assert res["default"] == "bar"
 
     def test_field_with_boolean_false_missing(self, openapi):
         field = fields.Boolean(default=None, missing=False)
         res = openapi.field2property(field)
-        assert res['default'] is False
+        assert res["default"] is False
 
     def test_field_with_missing_load(self, openapi):
-        field = fields.Str(default='foo', missing='bar')
+        field = fields.Str(default="foo", missing="bar")
         res = openapi.field2property(field)
-        assert res['default'] == 'bar'
+        assert res["default"] == "bar"
 
     def test_field_with_boolean_false_missing_load(self, openapi):
         field = fields.Boolean(default=None, missing=False)
         res = openapi.field2property(field)
-        assert res['default'] is False
+        assert res["default"] is False
 
     def test_field_with_missing_callable(self, openapi):
-        field = fields.Str(missing=lambda: 'dummy')
+        field = fields.Str(missing=lambda: "dummy")
         res = openapi.field2property(field)
-        assert 'default' not in res
+        assert "default" not in res
 
     def test_field_with_doc_default(self, openapi):
-        field = fields.Str(doc_default='Manual default')
+        field = fields.Str(doc_default="Manual default")
         res = openapi.field2property(field)
-        assert res['default'] == 'Manual default'
+        assert res["default"] == "Manual default"
 
     def test_field_with_doc_default_and_missing(self, openapi):
         field = fields.Int(doc_default=42, missing=12)
         res = openapi.field2property(field)
-        assert res['default'] == 42
+        assert res["default"] == 42
 
     def test_fields_with_missing_load(self, openapi):
-        field_dict = {'field': fields.Str(default='foo', missing='bar')}
-        res = openapi.fields2parameters(field_dict, default_in='query')
+        field_dict = {"field": fields.Str(default="foo", missing="bar")}
+        res = openapi.fields2parameters(field_dict, default_in="query")
         if openapi.openapi_version.major < 3:
-            assert res[0]['default'] == 'bar'
+            assert res[0]["default"] == "bar"
         else:
-            assert res[0]['schema']['default'] == 'bar'
+            assert res[0]["schema"]["default"] == "bar"
 
     def test_fields_with_location(self, openapi):
-        field_dict = {'field': fields.Str(location='querystring')}
-        res = openapi.fields2parameters(field_dict, default_in='headers')
-        assert res[0]['in'] == 'query'
+        field_dict = {"field": fields.Str(location="querystring")}
+        res = openapi.fields2parameters(field_dict, default_in="headers")
+        assert res[0]["in"] == "query"
 
     # json/body is invalid for OpenAPI 3
-    @pytest.mark.parametrize('openapi', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize("openapi", ("2.0",), indirect=True)
     def test_fields_with_multiple_json_locations(self, openapi):
         field_dict = {
-            'field1': fields.Str(location='json', required=True),
-            'field2': fields.Str(location='json', required=True),
-            'field3': fields.Str(location='json'),
+            "field1": fields.Str(location="json", required=True),
+            "field2": fields.Str(location="json", required=True),
+            "field3": fields.Str(location="json"),
         }
         res = openapi.fields2parameters(field_dict, default_in=None)
         assert len(res) == 1
-        assert res[0]['in'] == 'body'
-        assert res[0]['required'] is False
-        assert 'field1' in res[0]['schema']['properties']
-        assert 'field2' in res[0]['schema']['properties']
-        assert 'field3' in res[0]['schema']['properties']
-        assert 'required' in res[0]['schema']
-        assert len(res[0]['schema']['required']) == 2
-        assert 'field1' in res[0]['schema']['required']
-        assert 'field2' in res[0]['schema']['required']
+        assert res[0]["in"] == "body"
+        assert res[0]["required"] is False
+        assert "field1" in res[0]["schema"]["properties"]
+        assert "field2" in res[0]["schema"]["properties"]
+        assert "field3" in res[0]["schema"]["properties"]
+        assert "required" in res[0]["schema"]
+        assert len(res[0]["schema"]["required"]) == 2
+        assert "field1" in res[0]["schema"]["required"]
+        assert "field2" in res[0]["schema"]["required"]
 
     def test_fields2parameters_does_not_modify_metadata(self, openapi):
-        field_dict = {'field': fields.Str(location='querystring')}
-        res = openapi.fields2parameters(field_dict, default_in='headers')
-        assert res[0]['in'] == 'query'
+        field_dict = {"field": fields.Str(location="querystring")}
+        res = openapi.fields2parameters(field_dict, default_in="headers")
+        assert res[0]["in"] == "query"
 
-        res = openapi.fields2parameters(field_dict, default_in='headers')
-        assert res[0]['in'] == 'query'
+        res = openapi.fields2parameters(field_dict, default_in="headers")
+        assert res[0]["in"] == "query"
 
     def test_fields_location_mapping(self, openapi):
-        field_dict = {'field': fields.Str(location='cookies')}
-        res = openapi.fields2parameters(field_dict, default_in='headers')
-        assert res[0]['in'] == 'cookie'
+        field_dict = {"field": fields.Str(location="cookies")}
+        res = openapi.fields2parameters(field_dict, default_in="headers")
+        assert res[0]["in"] == "cookie"
 
     def test_fields_default_location_mapping(self, openapi):
-        field_dict = {'field': fields.Str()}
-        res = openapi.fields2parameters(field_dict, default_in='headers')
-        assert res[0]['in'] == 'header'
+        field_dict = {"field": fields.Str()}
+        res = openapi.fields2parameters(field_dict, default_in="headers")
+        assert res[0]["in"] == "header"
 
     # json/body is invalid for OpenAPI 3
-    @pytest.mark.parametrize('openapi', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize("openapi", ("2.0",), indirect=True)
     def test_fields_default_location_mapping_if_schema_many(self, openapi):
-
         class ExampleSchema(Schema):
             id = fields.Int()
 
         schema = ExampleSchema(many=True)
-        res = openapi.schema2parameters(schema=schema, default_in='json')
-        assert res[0]['in'] == 'body'
+        res = openapi.schema2parameters(schema=schema, default_in="json")
+        assert res[0]["in"] == "body"
 
     def test_fields_with_dump_only(self, openapi):
         class UserSchema(Schema):
             name = fields.Str(dump_only=True)
-        res = openapi.fields2parameters(UserSchema._declared_fields, default_in='query')
+
+        res = openapi.fields2parameters(UserSchema._declared_fields, default_in="query")
         assert len(res) == 0
-        res = openapi.fields2parameters(UserSchema().fields, default_in='query')
+        res = openapi.fields2parameters(UserSchema().fields, default_in="query")
         assert len(res) == 0
 
         class UserSchema(Schema):
             name = fields.Str()
 
             class Meta:
-                dump_only = ('name',)
-        res = openapi.schema2parameters(
-            schema=UserSchema, default_in='query',
-        )
+                dump_only = ("name",)
+
+        res = openapi.schema2parameters(schema=UserSchema, default_in="query")
         assert len(res) == 0
 
     def test_field_with_choices(self, openapi):
-        field = fields.Str(validate=validate.OneOf(['freddie', 'brian', 'john']))
+        field = fields.Str(validate=validate.OneOf(["freddie", "brian", "john"]))
         res = openapi.field2property(field)
-        assert set(res['enum']) == {'freddie', 'brian', 'john'}
+        assert set(res["enum"]) == {"freddie", "brian", "john"}
 
     def test_field_with_equal(self, openapi):
-        field = fields.Str(validate=validate.Equal('only choice'))
+        field = fields.Str(validate=validate.Equal("only choice"))
         res = openapi.field2property(field)
-        assert res['enum'] == ['only choice']
+        assert res["enum"] == ["only choice"]
 
     def test_only_allows_valid_properties_in_metadata(self, openapi):
         field = fields.Str(
-            missing='foo',
-            description='foo',
-            enum=['red', 'blue'],
-            allOf=['bar'],
-            not_valid='lol',
+            missing="foo",
+            description="foo",
+            enum=["red", "blue"],
+            allOf=["bar"],
+            not_valid="lol",
         )
         res = openapi.field2property(field)
-        assert res['default'] == field.missing
-        assert 'description' in res
-        assert 'enum' in res
-        assert 'allOf' in res
-        assert 'not_valid' not in res
+        assert res["default"] == field.missing
+        assert "description" in res
+        assert "enum" in res
+        assert "allOf" in res
+        assert "not_valid" not in res
 
     def test_field_with_choices_multiple(self, openapi):
-        field = fields.Str(validate=[
-            validate.OneOf(['freddie', 'brian', 'john']),
-            validate.OneOf(['brian', 'john', 'roger']),
-        ])
+        field = fields.Str(
+            validate=[
+                validate.OneOf(["freddie", "brian", "john"]),
+                validate.OneOf(["brian", "john", "roger"]),
+            ]
+        )
         res = openapi.field2property(field)
-        assert set(res['enum']) == {'brian', 'john'}
+        assert set(res["enum"]) == {"brian", "john"}
 
     def test_field_with_additional_metadata(self, openapi):
         field = fields.Str(minLength=6, maxLength=100)
         res = openapi.field2property(field)
-        assert res['maxLength'] == 100
-        assert res['minLength'] == 6
+        assert res["maxLength"] == 100
+        assert res["minLength"] == 6
 
     def test_field_with_allow_none(self, openapi):
         field = fields.Str(allow_none=True)
         res = openapi.field2property(field)
         if openapi.openapi_version.major < 3:
-            assert res['x-nullable'] is True
+            assert res["x-nullable"] is True
         else:
-            assert res['nullable'] is True
+            assert res["nullable"] is True
 
     def test_field_with_str_regex(self, openapi):
-        regex_str = '^[a-zA-Z0-9]$'
+        regex_str = "^[a-zA-Z0-9]$"
         field = fields.Str(validate=validate.Regexp(regex_str))
         ret = openapi.field2property(field)
-        assert ret['pattern'] == regex_str
+        assert ret["pattern"] == regex_str
 
     def test_field_with_pattern_obj_regex(self, openapi):
-        regex_str = '^[a-zA-Z0-9]$'
+        regex_str = "^[a-zA-Z0-9]$"
         field = fields.Str(validate=validate.Regexp(re.compile(regex_str)))
         ret = openapi.field2property(field)
-        assert ret['pattern'] == regex_str
+        assert ret["pattern"] == regex_str
 
     def test_field_with_no_pattern(self, openapi):
         field = fields.Str()
         ret = openapi.field2property(field)
-        assert 'pattern' not in ret
+        assert "pattern" not in ret
 
     def test_field_with_multiple_patterns(self, recwarn, openapi):
-        regex_validators = [
-            validate.Regexp('winner'),
-            validate.Regexp('loser'),
-        ]
+        regex_validators = [validate.Regexp("winner"), validate.Regexp("loser")]
         field = fields.Str(validate=regex_validators)
-        with pytest.warns(UserWarning, match='More than one regex validator'):
+        with pytest.warns(UserWarning, match="More than one regex validator"):
             ret = openapi.field2property(field)
-        assert ret['pattern'] == 'winner'
+        assert ret["pattern"] == "winner"
+
 
 class TestMarshmallowSchemaToModelDefinition:
-
     def test_invalid_schema(self, openapi):
         with pytest.raises(ValueError):
             openapi.schema2jsonschema(None)
@@ -272,74 +271,73 @@ class TestMarshmallowSchemaToModelDefinition:
     def test_schema2jsonschema_with_explicit_fields(self, openapi):
         class UserSchema(Schema):
             _id = fields.Int()
-            email = fields.Email(description='email address of the user')
+            email = fields.Email(description="email address of the user")
             name = fields.Str()
 
             class Meta:
-                title = 'User'
+                title = "User"
 
         res = openapi.schema2jsonschema(UserSchema)
-        assert res['title'] == 'User'
-        assert res['type'] == 'object'
-        props = res['properties']
-        assert props['_id']['type'] == 'integer'
-        assert props['email']['type'] == 'string'
-        assert props['email']['format'] == 'email'
-        assert props['email']['description'] == 'email address of the user'
+        assert res["title"] == "User"
+        assert res["type"] == "object"
+        props = res["properties"]
+        assert props["_id"]["type"] == "integer"
+        assert props["email"]["type"] == "string"
+        assert props["email"]["format"] == "email"
+        assert props["email"]["description"] == "email address of the user"
 
     @pytest.mark.skipif(
-        MARSHMALLOW_VERSION_INFO[0] >= 3,
-        reason='Behaviour changed in marshmallow 3',
+        MARSHMALLOW_VERSION_INFO[0] >= 3, reason="Behaviour changed in marshmallow 3"
     )
     def test_schema2jsonschema_override_name_ma2(self, openapi):
         class ExampleSchema(Schema):
-            _id = fields.Int(load_from='id', dump_to='id')
-            _dt = fields.Int(load_from='lf_no_match', dump_to='dt')
-            _lf = fields.Int(load_from='lf')
-            _global = fields.Int(load_from='global', dump_to='global')
+            _id = fields.Int(load_from="id", dump_to="id")
+            _dt = fields.Int(load_from="lf_no_match", dump_to="dt")
+            _lf = fields.Int(load_from="lf")
+            _global = fields.Int(load_from="global", dump_to="global")
 
             class Meta:
-                exclude = ('_global', )
+                exclude = ("_global",)
 
         res = openapi.schema2jsonschema(ExampleSchema)
-        assert res['type'] == 'object'
-        props = res['properties']
+        assert res["type"] == "object"
+        props = res["properties"]
         # `_id` renamed to `id`
-        assert '_id' not in props and props['id']['type'] == 'integer'
+        assert "_id" not in props and props["id"]["type"] == "integer"
         # `load_from` and `dump_to` do not match, `dump_to` is used
-        assert 'lf_no_match' not in props
-        assert props['dt']['type'] == 'integer'
+        assert "lf_no_match" not in props
+        assert props["dt"]["type"] == "integer"
         # `load_from` and no `dump_to`, `load_from` is used
-        assert props['lf']['type'] == 'integer'
+        assert props["lf"]["type"] == "integer"
         # `_global` excluded correctly
-        assert '_global' not in props and 'global' not in props
+        assert "_global" not in props and "global" not in props
 
     @pytest.mark.skipif(
-        MARSHMALLOW_VERSION_INFO[0] < 3,
-        reason='Behaviour changed in marshmallow 3',
+        MARSHMALLOW_VERSION_INFO[0] < 3, reason="Behaviour changed in marshmallow 3"
     )
     def test_schema2jsonschema_override_name_ma3(self, openapi):
         class ExampleSchema(Schema):
-            _id = fields.Int(data_key='id')
-            _global = fields.Int(data_key='global')
+            _id = fields.Int(data_key="id")
+            _global = fields.Int(data_key="global")
 
             class Meta:
-                exclude = ('_global', )
+                exclude = ("_global",)
 
         res = openapi.schema2jsonschema(ExampleSchema)
-        assert res['type'] == 'object'
-        props = res['properties']
+        assert res["type"] == "object"
+        props = res["properties"]
         # `_id` renamed to `id`
-        assert '_id' not in props and props['id']['type'] == 'integer'
+        assert "_id" not in props and props["id"]["type"] == "integer"
         # `_global` excluded correctly
-        assert '_global' not in props and 'global' not in props
+        assert "_global" not in props and "global" not in props
 
     def test_required_fields(self, openapi):
         class BandSchema(Schema):
             drummer = fields.Str(required=True)
             bassist = fields.Str()
+
         res = openapi.schema2jsonschema(BandSchema)
-        assert res['required'] == ['drummer']
+        assert res["required"] == ["drummer"]
 
     def test_partial(self, openapi):
         class BandSchema(Schema):
@@ -347,190 +345,193 @@ class TestMarshmallowSchemaToModelDefinition:
             bassist = fields.Str(required=True)
 
         res = openapi.schema2jsonschema(BandSchema(partial=True))
-        assert 'required' not in res
+        assert "required" not in res
 
-        res = openapi.schema2jsonschema(BandSchema(partial=('drummer', )))
-        assert res['required'] == ['bassist']
+        res = openapi.schema2jsonschema(BandSchema(partial=("drummer",)))
+        assert res["required"] == ["bassist"]
 
     def test_no_required_fields(self, openapi):
         class BandSchema(Schema):
             drummer = fields.Str()
             bassist = fields.Str()
+
         res = openapi.schema2jsonschema(BandSchema)
-        assert 'required' not in res
+        assert "required" not in res
 
     def test_title_and_description_may_be_added(self, openapi):
         class UserSchema(Schema):
             class Meta:
-                title = 'User'
-                description = 'A registered user'
+                title = "User"
+                description = "A registered user"
 
         res = openapi.schema2jsonschema(UserSchema)
-        assert res['description'] == 'A registered user'
-        assert res['title'] == 'User'
+        assert res["description"] == "A registered user"
+        assert res["title"] == "User"
 
     def test_excluded_fields(self, openapi):
         class WhiteStripesSchema(Schema):
             class Meta:
-                exclude = ('bassist', )
+                exclude = ("bassist",)
+
             guitarist = fields.Str()
             drummer = fields.Str()
             bassist = fields.Str()
 
         res = openapi.schema2jsonschema(WhiteStripesSchema)
-        assert set(res['properties'].keys()) == set(['guitarist', 'drummer'])
+        assert set(res["properties"].keys()) == {"guitarist", "drummer"}
 
     def test_only_explicitly_declared_fields_are_translated(self, recwarn, openapi):
         class UserSchema(Schema):
             _id = fields.Int()
 
             class Meta:
-                title = 'User'
-                fields = ('_id', 'email', )
+                title = "User"
+                fields = ("_id", "email")
 
         with warnings.catch_warnings():
-            warnings.simplefilter('always')
+            warnings.simplefilter("always")
             res = openapi.schema2jsonschema(UserSchema)
-            assert res['type'] == 'object'
-            props = res['properties']
-            assert '_id' in props
-            assert 'email' not in props
+            assert res["type"] == "object"
+            props = res["properties"]
+            assert "_id" in props
+            assert "email" not in props
             warning = recwarn.pop()
-            expected_msg = 'Only explicitly-declared fields will be included in the Schema Object.'
+            expected_msg = (
+                "Only explicitly-declared fields will be included in the Schema Object."
+            )
             assert expected_msg in str(warning.message)
             assert issubclass(warning.category, UserWarning)
 
     def test_observed_field_name_for_required_field(self, openapi):
         if MARSHMALLOW_VERSION_INFO[0] < 3:
             fields_dict = {
-                'user_id': fields.Int(load_from='id', dump_to='id', required=True),
+                "user_id": fields.Int(load_from="id", dump_to="id", required=True)
             }
         else:
-            fields_dict = {
-                'user_id': fields.Int(data_key='id', required=True),
-            }
+            fields_dict = {"user_id": fields.Int(data_key="id", required=True)}
 
         res = openapi.fields2jsonschema(fields_dict)
-        assert res['required'] == ['id']
+        assert res["required"] == ["id"]
 
     def test_schema_instance_inspection(self, openapi):
         class UserSchema(Schema):
             _id = fields.Int()
 
         res = openapi.schema2jsonschema(UserSchema())
-        assert res['type'] == 'object'
-        props = res['properties']
-        assert '_id' in props
+        assert res["type"] == "object"
+        props = res["properties"]
+        assert "_id" in props
 
     def test_schema_instance_inspection_with_many(self, openapi):
         class UserSchema(Schema):
             _id = fields.Int()
 
         res = openapi.schema2jsonschema(UserSchema(many=True))
-        assert res['type'] == 'array'
-        assert 'items' in res
-        props = res['items']['properties']
-        assert '_id' in props
+        assert res["type"] == "array"
+        assert "items" in res
+        props = res["items"]["properties"]
+        assert "_id" in props
 
     def test_raises_error_if_no_declared_fields(self, openapi):
         class NotASchema(object):
             pass
 
-        expected_error = "{0!r} doesn't have either `fields` or `_declared_fields`.".format(NotASchema)
+        expected_error = "{!r} doesn't have either `fields` or `_declared_fields`.".format(
+            NotASchema
+        )
         with pytest.raises(ValueError, match=expected_error):
             openapi.schema2jsonschema(NotASchema)
 
 
 class TestMarshmallowSchemaToParameters:
-
     def test_field_multiple(self, openapi):
-        field = fields.List(fields.Str, location='querystring')
-        res = openapi.field2parameter(field, name='field')
-        assert res['in'] == 'query'
+        field = fields.List(fields.Str, location="querystring")
+        res = openapi.field2parameter(field, name="field")
+        assert res["in"] == "query"
         if openapi.openapi_version.major < 3:
-            assert res['type'] == 'array'
-            assert res['items']['type'] == 'string'
-            assert res['collectionFormat'] == 'multi'
+            assert res["type"] == "array"
+            assert res["items"]["type"] == "string"
+            assert res["collectionFormat"] == "multi"
         else:
-            assert res['schema']['type'] == 'array'
-            assert res['schema']['items']['type'] == 'string'
-            assert res['style'] == 'form'
-            assert res['explode'] is True
+            assert res["schema"]["type"] == "array"
+            assert res["schema"]["items"]["type"] == "string"
+            assert res["style"] == "form"
+            assert res["explode"] is True
 
     def test_field_required(self, openapi):
-        field = fields.Str(required=True, location='query')
-        res = openapi.field2parameter(field, name='field')
-        assert res['required'] is True
+        field = fields.Str(required=True, location="query")
+        res = openapi.field2parameter(field, name="field")
+        assert res["required"] is True
 
     def test_invalid_schema(self, openapi):
         with pytest.raises(ValueError):
             openapi.schema2parameters(None)
 
     # json/body is invalid for OpenAPI 3
-    @pytest.mark.parametrize('openapi', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize("openapi", ("2.0",), indirect=True)
     def test_schema_body(self, openapi):
         class UserSchema(Schema):
             name = fields.Str()
             email = fields.Email()
 
-        res = openapi.schema2parameters(UserSchema, default_in='body')
+        res = openapi.schema2parameters(UserSchema, default_in="body")
         assert len(res) == 1
         param = res[0]
-        assert param['in'] == 'body'
-        assert param['schema'] == {'$ref': '#/definitions/User'}
+        assert param["in"] == "body"
+        assert param["schema"] == {"$ref": "#/definitions/User"}
 
     # json/body is invalid for OpenAPI 3
-    @pytest.mark.parametrize('openapi', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize("openapi", ("2.0",), indirect=True)
     def test_schema_body_with_dump_only(self, openapi):
         class UserSchema(Schema):
             name = fields.Str()
             email = fields.Email(dump_only=True)
 
-        res_nodump = openapi.schema2parameters(UserSchema, default_in='body')
+        res_nodump = openapi.schema2parameters(UserSchema, default_in="body")
         assert len(res_nodump) == 1
         param = res_nodump[0]
-        assert param['in'] == 'body'
-        assert param['schema'] == {'$ref': ref_path(openapi.spec) + 'User'}
+        assert param["in"] == "body"
+        assert param["schema"] == {"$ref": ref_path(openapi.spec) + "User"}
 
     # json/body is invalid for OpenAPI 3
-    @pytest.mark.parametrize('openapi', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize("openapi", ("2.0",), indirect=True)
     def test_schema_body_many(self, openapi):
         class UserSchema(Schema):
             name = fields.Str()
             email = fields.Email()
 
-        res = openapi.schema2parameters(UserSchema(many=True), default_in='body')
+        res = openapi.schema2parameters(UserSchema(many=True), default_in="body")
         assert len(res) == 1
         param = res[0]
-        assert param['in'] == 'body'
-        assert param['schema']['type'] == 'array'
-        assert param['schema']['items'] == {'$ref': '#/definitions/User'}
+        assert param["in"] == "body"
+        assert param["schema"]["type"] == "array"
+        assert param["schema"]["items"] == {"$ref": "#/definitions/User"}
 
     def test_schema_query(self, openapi):
         class UserSchema(Schema):
             name = fields.Str()
             email = fields.Email()
 
-        res = openapi.schema2parameters(UserSchema, default_in='query')
+        res = openapi.schema2parameters(UserSchema, default_in="query")
         assert len(res) == 2
-        res.sort(key=lambda param: param['name'])
-        assert res[0]['name'] == 'email'
-        assert res[0]['in'] == 'query'
-        assert res[1]['name'] == 'name'
-        assert res[1]['in'] == 'query'
+        res.sort(key=lambda param: param["name"])
+        assert res[0]["name"] == "email"
+        assert res[0]["in"] == "query"
+        assert res[1]["name"] == "name"
+        assert res[1]["in"] == "query"
 
     def test_schema_query_instance(self, openapi):
         class UserSchema(Schema):
             name = fields.Str()
             email = fields.Email()
 
-        res = openapi.schema2parameters(UserSchema(), default_in='query')
+        res = openapi.schema2parameters(UserSchema(), default_in="query")
         assert len(res) == 2
-        res.sort(key=lambda param: param['name'])
-        assert res[0]['name'] == 'email'
-        assert res[0]['in'] == 'query'
-        assert res[1]['name'] == 'name'
-        assert res[1]['in'] == 'query'
+        res.sort(key=lambda param: param["name"])
+        assert res[0]["name"] == "email"
+        assert res[0]["in"] == "query"
+        assert res[1]["name"] == "name"
+        assert res[1]["in"] == "query"
 
     def test_schema_query_instance_many_should_raise_exception(self, openapi):
         class UserSchema(Schema):
@@ -538,37 +539,33 @@ class TestMarshmallowSchemaToParameters:
             email = fields.Email()
 
         with pytest.raises(AssertionError):
-            openapi.schema2parameters(UserSchema(many=True), default_in='query')
+            openapi.schema2parameters(UserSchema(many=True), default_in="query")
 
     # json/body is invalid for OpenAPI 3
-    @pytest.mark.parametrize('openapi', ('2.0', ), indirect=True)
+    @pytest.mark.parametrize("openapi", ("2.0",), indirect=True)
     def test_fields_default_in_body(self, openapi):
-        field_dict = {
-            'name': fields.Str(),
-            'email': fields.Email(),
-        }
+        field_dict = {"name": fields.Str(), "email": fields.Email()}
         res = openapi.fields2parameters(field_dict)
         assert len(res) == 1
-        assert set(res[0]['schema']['properties'].keys()) == {'name', 'email'}
+        assert set(res[0]["schema"]["properties"].keys()) == {"name", "email"}
 
     def test_fields_query(self, openapi):
-        field_dict = {
-            'name': fields.Str(),
-            'email': fields.Email(),
-        }
-        res = openapi.fields2parameters(field_dict, default_in='query')
+        field_dict = {"name": fields.Str(), "email": fields.Email()}
+        res = openapi.fields2parameters(field_dict, default_in="query")
         assert len(res) == 2
-        res.sort(key=lambda param: param['name'])
-        assert res[0]['name'] == 'email'
-        assert res[0]['in'] == 'query'
-        assert res[1]['name'] == 'name'
-        assert res[1]['in'] == 'query'
+        res.sort(key=lambda param: param["name"])
+        assert res[0]["name"] == "email"
+        assert res[0]["in"] == "query"
+        assert res[1]["name"] == "name"
+        assert res[1]["in"] == "query"
 
     def test_raises_error_if_not_a_schema(self, openapi):
         class NotASchema(object):
             pass
 
-        expected_error = "{0!r} doesn't have either `fields` or `_declared_fields`".format(NotASchema)
+        expected_error = "{!r} doesn't have either `fields` or `_declared_fields`".format(
+            NotASchema
+        )
         with pytest.raises(ValueError, match=expected_error):
             openapi.schema2jsonschema(NotASchema)
 
@@ -578,103 +575,115 @@ class CategorySchema(Schema):
     name = fields.Str(required=True)
     breed = fields.Str(dump_only=True)
 
+
 class PageSchema(Schema):
     offset = fields.Int()
     limit = fields.Int()
+
 
 class PetSchema(Schema):
     category = fields.Nested(CategorySchema, many=True)
     name = fields.Str()
 
-class TestNesting:
 
+class TestNesting:
     def test_field2property_nested_spec_metadatas(self, spec_fixture):
-        spec_fixture.spec.components.schema('Category', schema=CategorySchema)
+        spec_fixture.spec.components.schema("Category", schema=CategorySchema)
         category = fields.Nested(
             CategorySchema,
-            description='A category',
-            invalid_property='not in the result',
-            x_extension='A great extension',
+            description="A category",
+            invalid_property="not in the result",
+            x_extension="A great extension",
         )
         result = spec_fixture.openapi.field2property(category)
         assert result == {
-            'allOf': [{'$ref': ref_path(spec_fixture.spec) + 'Category'}],
-            'description': 'A category',
-            'x-extension': 'A great extension',
+            "allOf": [{"$ref": ref_path(spec_fixture.spec) + "Category"}],
+            "description": "A category",
+            "x-extension": "A great extension",
         }
 
     def test_field2property_nested_spec(self, spec_fixture):
-        spec_fixture.spec.components.schema('Category', schema=CategorySchema)
+        spec_fixture.spec.components.schema("Category", schema=CategorySchema)
         category = fields.Nested(CategorySchema)
         assert spec_fixture.openapi.field2property(category) == {
-            '$ref': ref_path(spec_fixture.spec) + 'Category',
+            "$ref": ref_path(spec_fixture.spec) + "Category"
         }
 
     def test_field2property_nested_many_spec(self, spec_fixture):
-        spec_fixture.spec.components.schema('Category', schema=CategorySchema)
+        spec_fixture.spec.components.schema("Category", schema=CategorySchema)
         category = fields.Nested(CategorySchema, many=True)
         ret = spec_fixture.openapi.field2property(category)
-        assert ret['type'] == 'array'
-        assert ret['items'] == {'$ref': ref_path(spec_fixture.spec) + 'Category'}
+        assert ret["type"] == "array"
+        assert ret["items"] == {"$ref": ref_path(spec_fixture.spec) + "Category"}
 
     def test_field2property_nested_ref(self, spec_fixture):
         category = fields.Nested(CategorySchema)
         ref = spec_fixture.openapi.field2property(category)
-        assert ref == {'$ref': ref_path(spec_fixture.spec) + 'Category'}
+        assert ref == {"$ref": ref_path(spec_fixture.spec) + "Category"}
 
     def test_field2property_nested_many(self, spec_fixture):
         categories = fields.Nested(CategorySchema, many=True)
         res = spec_fixture.openapi.field2property(categories)
-        assert res['type'] == 'array'
-        assert res['items'] == {'$ref': ref_path(spec_fixture.spec) + 'Category'}
+        assert res["type"] == "array"
+        assert res["items"] == {"$ref": ref_path(spec_fixture.spec) + "Category"}
 
     def test_schema2jsonschema_with_nested_fields(self, spec_fixture):
         res = spec_fixture.openapi.schema2jsonschema(PetSchema)
-        props = res['properties']
+        props = res["properties"]
 
-        assert props['category']['items'] == {'$ref': ref_path(spec_fixture.spec) + 'Category'}
+        assert props["category"]["items"] == {
+            "$ref": ref_path(spec_fixture.spec) + "Category"
+        }
 
-    @pytest.mark.parametrize('modifier', ('only', 'exclude'))
-    def test_schema2jsonschema_with_nested_fields_only_exclude(self, spec_fixture, modifier):
+    @pytest.mark.parametrize("modifier", ("only", "exclude"))
+    def test_schema2jsonschema_with_nested_fields_only_exclude(
+        self, spec_fixture, modifier
+    ):
         class Child(Schema):
             i = fields.Int()
             j = fields.Int()
 
         class Parent(Schema):
-            child = fields.Nested(Child, **{modifier: ('i', )})
+            child = fields.Nested(Child, **{modifier: ("i",)})
 
         spec_fixture.openapi.schema2jsonschema(Parent)
-        props = get_definitions(spec_fixture.spec)['Child']['properties']
-        assert ('i' in props) == (modifier == 'only')
-        assert ('j' not in props) == (modifier == 'only')
+        props = get_definitions(spec_fixture.spec)["Child"]["properties"]
+        assert ("i" in props) == (modifier == "only")
+        assert ("j" not in props) == (modifier == "only")
 
-    def test_schema2jsonschema_with_nested_fields_with_adhoc_changes(self, spec_fixture):
+    def test_schema2jsonschema_with_nested_fields_with_adhoc_changes(
+        self, spec_fixture
+    ):
         category_schema = CategorySchema(many=True)
-        category_schema.fields['id'].required = True
+        category_schema.fields["id"].required = True
 
         class PetSchema(Schema):
             category = fields.Nested(category_schema, many=True)
             name = fields.Str()
 
-        spec_fixture.spec.components.schema('Pet', schema=PetSchema)
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
         props = get_definitions(spec_fixture.spec)
 
-        assert props['Category'] == spec_fixture.openapi.schema2jsonschema(category_schema)
-        assert set(props['Category']['items']['required']) == {'id', 'name'}
+        assert props["Category"] == spec_fixture.openapi.schema2jsonschema(
+            category_schema
+        )
+        assert set(props["Category"]["items"]["required"]) == {"id", "name"}
 
-        props['Category']['items']['required'] = ['name']
-        assert props['Category']['items'] == spec_fixture.openapi.schema2jsonschema(CategorySchema)
+        props["Category"]["items"]["required"] = ["name"]
+        assert props["Category"]["items"] == spec_fixture.openapi.schema2jsonschema(
+            CategorySchema
+        )
 
     def test_schema2jsonschema_with_nested_excluded_fields(self, spec):
-        category_schema = CategorySchema(exclude=('breed', ))
+        category_schema = CategorySchema(exclude=("breed",))
 
         class PetSchema(Schema):
             category = fields.Nested(category_schema)
 
-        spec.components.schema('Pet', schema=PetSchema)
+        spec.components.schema("Pet", schema=PetSchema)
 
-        category_props = get_definitions(spec)['Category']['properties']
-        assert 'breed' not in category_props
+        category_props = get_definitions(spec)["Category"]["properties"]
+        assert "breed" not in category_props
 
     def test_nested_field_with_property(self, spec_fixture):
         r_path = ref_path(spec_fixture.spec)
@@ -683,69 +692,76 @@ class TestNesting:
         category_2 = fields.Nested(CategorySchema, dump_only=True)
         category_3 = fields.Nested(CategorySchema, many=True)
         category_4 = fields.Nested(CategorySchema, many=True, dump_only=True)
-        spec_fixture.spec.components.schema('Category', schema=CategorySchema)
+        spec_fixture.spec.components.schema("Category", schema=CategorySchema)
 
         assert spec_fixture.openapi.field2property(category_1) == {
-            '$ref': r_path + 'Category',
+            "$ref": r_path + "Category"
         }
         assert spec_fixture.openapi.field2property(category_2) == {
-            'allOf': [{'$ref': r_path + 'Category'}], 'readOnly': True,
+            "allOf": [{"$ref": r_path + "Category"}],
+            "readOnly": True,
         }
         assert spec_fixture.openapi.field2property(category_3) == {
-            'items': {'$ref': r_path + 'Category'}, 'type': 'array',
+            "items": {"$ref": r_path + "Category"},
+            "type": "array",
         }
         assert spec_fixture.openapi.field2property(category_4) == {
-            'items': {'$ref': r_path + 'Category'}, 'readOnly': True, 'type': 'array',
+            "items": {"$ref": r_path + "Category"},
+            "readOnly": True,
+            "type": "array",
         }
+
 
 def test_openapi_tools_validate_v2():
     ma_plugin = MarshmallowPlugin()
     spec = APISpec(
-        title='Pets',
-        version='0.1',
-        plugins=(ma_plugin, ),
-        openapi_version='2.0',
+        title="Pets", version="0.1", plugins=(ma_plugin,), openapi_version="2.0"
     )
     openapi = ma_plugin.openapi
 
-    spec.components.schema('Category', schema=CategorySchema)
-    spec.components.schema('Pet', schema=PetSchema, extra_fields={'discriminator': 'name'})
+    spec.components.schema("Category", schema=CategorySchema)
+    spec.components.schema(
+        "Pet", schema=PetSchema, extra_fields={"discriminator": "name"}
+    )
 
     spec.path(
         view=None,
-        path='/category/{category_id}',
+        path="/category/{category_id}",
         operations={
-            'get': {
-                'parameters': [
-                    {'name': 'q', 'in': 'query', 'type': 'string'},
-                    {'name': 'category_id', 'in': 'path', 'required': True, 'type': 'string'},
+            "get": {
+                "parameters": [
+                    {"name": "q", "in": "query", "type": "string"},
+                    {
+                        "name": "category_id",
+                        "in": "path",
+                        "required": True,
+                        "type": "string",
+                    },
                     openapi.field2parameter(
                         field=fields.List(
                             fields.Str(),
-                            validate=validate.OneOf(['freddie', 'roger']),
-                            location='querystring',
+                            validate=validate.OneOf(["freddie", "roger"]),
+                            location="querystring",
                         ),
-                        name='body',
+                        name="body",
                     ),
-                ] + openapi.schema2parameters(PageSchema, default_in='query'),
-                'responses': {
-                    200: {
-                        'schema': PetSchema,
-                        'description': 'A pet',
-                    },
-                },
+                ]
+                + openapi.schema2parameters(PageSchema, default_in="query"),
+                "responses": {200: {"schema": PetSchema, "description": "A pet"}},
             },
-            'post': {
-                'parameters': (
-                    [{'name': 'category_id', 'in': 'path', 'required': True, 'type': 'string'}] +
-                    openapi.schema2parameters(CategorySchema, default_in='body')
+            "post": {
+                "parameters": (
+                    [
+                        {
+                            "name": "category_id",
+                            "in": "path",
+                            "required": True,
+                            "type": "string",
+                        }
+                    ]
+                    + openapi.schema2parameters(CategorySchema, default_in="body")
                 ),
-                'responses': {
-                    201: {
-                        'schema': PetSchema,
-                        'description': 'A pet',
-                    },
-                },
+                "responses": {201: {"schema": PetSchema, "description": "A pet"}},
             },
         },
     )
@@ -753,84 +769,67 @@ def test_openapi_tools_validate_v2():
         utils.validate_spec(spec)
     except exceptions.OpenAPIError as error:
         pytest.fail(str(error))
+
 
 def test_openapi_tools_validate_v3():
     ma_plugin = MarshmallowPlugin()
     spec = APISpec(
-        title='Pets',
-        version='0.1',
-        plugins=(ma_plugin, ),
-        openapi_version='3.0.0',
+        title="Pets", version="0.1", plugins=(ma_plugin,), openapi_version="3.0.0"
     )
     openapi = ma_plugin.openapi
 
-    spec.components.schema('Category', schema=CategorySchema)
-    spec.components.schema('Pet', schema=PetSchema)
+    spec.components.schema("Category", schema=CategorySchema)
+    spec.components.schema("Pet", schema=PetSchema)
 
     spec.path(
         view=None,
-        path='/category/{category_id}',
+        path="/category/{category_id}",
         operations={
-            'get': {
-                'parameters': [
+            "get": {
+                "parameters": [
+                    {"name": "q", "in": "query", "schema": {"type": "string"}},
                     {
-                        'name': 'q',
-                        'in': 'query',
-                        'schema': {'type': 'string'},
-                    },
-                    {
-                        'name': 'category_id',
-                        'in': 'path',
-                        'required': True,
-                        'schema': {'type': 'string'},
+                        "name": "category_id",
+                        "in": "path",
+                        "required": True,
+                        "schema": {"type": "string"},
                     },
                     openapi.field2parameter(
                         field=fields.List(
                             fields.Str(),
-                            validate=validate.OneOf(['freddie', 'roger']),
-                            location='querystring',
+                            validate=validate.OneOf(["freddie", "roger"]),
+                            location="querystring",
                         ),
-                        name='body',
+                        name="body",
                     ),
-                ] + openapi.schema2parameters(PageSchema, default_in='query'),
-                'responses': {
+                ]
+                + openapi.schema2parameters(PageSchema, default_in="query"),
+                "responses": {
                     200: {
-                        'description': 'success',
-                        'content': {
-                            'application/json': {
-                                'schema': PetSchema,
-                            },
-                        },
-                    },
+                        "description": "success",
+                        "content": {"application/json": {"schema": PetSchema}},
+                    }
                 },
             },
-            'post': {
-                'parameters': (
+            "post": {
+                "parameters": (
                     [
                         {
-                            'name': 'category_id',
-                            'in': 'path',
-                            'required': True,
-                            'schema': {'type': 'string'},
-                        },
+                            "name": "category_id",
+                            "in": "path",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        }
                     ]
                 ),
-                'requestBody': {
-                    'content': {
-                        'application/json': {
-                            'schema': CategorySchema,
-                        },
-                    },
+                "requestBody": {
+                    "content": {"application/json": {"schema": CategorySchema}}
                 },
-                'responses': {
+                "responses": {
                     201: {
-                        'description': 'created',
-                        'content': {
-                            'application/json': {
-                                'schema': PetSchema,
-                            },
-                        },
-                    },
+                        "description": "created",
+                        "content": {"application/json": {"schema": PetSchema}},
+                    }
                 },
             },
         },
@@ -840,80 +839,84 @@ def test_openapi_tools_validate_v3():
     except exceptions.OpenAPIError as error:
         pytest.fail(str(error))
 
+
 class ValidationSchema(Schema):
     id = fields.Int(dump_only=True)
     range = fields.Int(validate=validate.Range(min=1, max=10))
-    multiple_ranges = fields.Int(validate=[
-        validate.Range(min=1),
-        validate.Range(min=3),
-        validate.Range(max=10),
-        validate.Range(max=7),
-    ])
+    multiple_ranges = fields.Int(
+        validate=[
+            validate.Range(min=1),
+            validate.Range(min=3),
+            validate.Range(max=10),
+            validate.Range(max=7),
+        ]
+    )
     list_length = fields.List(fields.Str, validate=validate.Length(min=1, max=10))
     string_length = fields.Str(validate=validate.Length(min=1, max=10))
-    multiple_lengths = fields.Str(validate=[
-        validate.Length(min=1),
-        validate.Length(min=3),
-        validate.Length(max=10),
-        validate.Length(max=7),
-    ])
-    equal_length = fields.Str(validate=[
-        validate.Length(equal=5),
-        validate.Length(min=1, max=10),
-    ])
+    multiple_lengths = fields.Str(
+        validate=[
+            validate.Length(min=1),
+            validate.Length(min=3),
+            validate.Length(max=10),
+            validate.Length(max=7),
+        ]
+    )
+    equal_length = fields.Str(
+        validate=[validate.Length(equal=5), validate.Length(min=1, max=10)]
+    )
+
 
 class TestFieldValidation:
-
     def test_range(self, spec):
-        spec.components.schema('Validation', schema=ValidationSchema)
-        result = get_definitions(spec)['Validation']['properties']['range']
+        spec.components.schema("Validation", schema=ValidationSchema)
+        result = get_definitions(spec)["Validation"]["properties"]["range"]
 
-        assert 'minimum' in result
-        assert result['minimum'] == 1
-        assert 'maximum' in result
-        assert result['maximum'] == 10
+        assert "minimum" in result
+        assert result["minimum"] == 1
+        assert "maximum" in result
+        assert result["maximum"] == 10
 
     def test_multiple_ranges(self, spec):
-        spec.components.schema('Validation', schema=ValidationSchema)
-        result = get_definitions(spec)['Validation']['properties']['multiple_ranges']
+        spec.components.schema("Validation", schema=ValidationSchema)
+        result = get_definitions(spec)["Validation"]["properties"]["multiple_ranges"]
 
-        assert 'minimum' in result
-        assert result['minimum'] == 3
-        assert 'maximum' in result
-        assert result['maximum'] == 7
+        assert "minimum" in result
+        assert result["minimum"] == 3
+        assert "maximum" in result
+        assert result["maximum"] == 7
 
     def test_list_length(self, spec):
-        spec.components.schema('Validation', schema=ValidationSchema)
-        result = get_definitions(spec)['Validation']['properties']['list_length']
+        spec.components.schema("Validation", schema=ValidationSchema)
+        result = get_definitions(spec)["Validation"]["properties"]["list_length"]
 
-        assert 'minItems' in result
-        assert result['minItems'] == 1
-        assert 'maxItems' in result
-        assert result['maxItems'] == 10
+        assert "minItems" in result
+        assert result["minItems"] == 1
+        assert "maxItems" in result
+        assert result["maxItems"] == 10
 
     def test_string_length(self, spec):
-        spec.components.schema('Validation', schema=ValidationSchema)
-        result = get_definitions(spec)['Validation']['properties']['string_length']
+        spec.components.schema("Validation", schema=ValidationSchema)
+        result = get_definitions(spec)["Validation"]["properties"]["string_length"]
 
-        assert 'minLength' in result
-        assert result['minLength'] == 1
-        assert 'maxLength' in result
-        assert result['maxLength'] == 10
+        assert "minLength" in result
+        assert result["minLength"] == 1
+        assert "maxLength" in result
+        assert result["maxLength"] == 10
 
     def test_multiple_lengths(self, spec):
-        spec.components.schema('Validation', schema=ValidationSchema)
-        result = get_definitions(spec)['Validation']['properties']['multiple_lengths']
+        spec.components.schema("Validation", schema=ValidationSchema)
+        result = get_definitions(spec)["Validation"]["properties"]["multiple_lengths"]
 
-        assert 'minLength' in result
-        assert result['minLength'] == 3
-        assert 'maxLength' in result
-        assert result['maxLength'] == 7
+        assert "minLength" in result
+        assert result["minLength"] == 3
+        assert "maxLength" in result
+        assert result["maxLength"] == 7
 
     def test_equal_length(self, spec):
-        spec.components.schema('Validation', schema=ValidationSchema)
-        result = get_definitions(spec)['Validation']['properties']['equal_length']
+        spec.components.schema("Validation", schema=ValidationSchema)
+        result = get_definitions(spec)["Validation"]["properties"]["equal_length"]
 
-        assert 'minLength' in result
-        assert result['minLength'] == 5
-        assert 'maxLength' in result
-        assert result['maxLength'] == 5
+        assert "minLength" in result
+        assert result["minLength"] == 5
+        assert "maxLength" in result
+        assert result["maxLength"] == 5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,21 +6,20 @@ from apispec.exceptions import APISpecError
 
 
 class TestOpenAPIVersion:
-
-    @pytest.mark.parametrize('version', ('1.0', '4.0'))
+    @pytest.mark.parametrize("version", ("1.0", "4.0"))
     def test_openapi_version_invalid_version(self, version):
         with pytest.raises(APISpecError) as excinfo:
             utils.OpenAPIVersion(version)
-        assert 'Not a valid OpenAPI version number:' in str(excinfo)
+        assert "Not a valid OpenAPI version number:" in str(excinfo)
 
-    @pytest.mark.parametrize('version', ('3.0.1', utils.OpenAPIVersion('3.0.1')))
+    @pytest.mark.parametrize("version", ("3.0.1", utils.OpenAPIVersion("3.0.1")))
     def test_openapi_version_string_or_openapi_version_param(self, version):
-        assert utils.OpenAPIVersion(version) == utils.OpenAPIVersion('3.0.1')
+        assert utils.OpenAPIVersion(version) == utils.OpenAPIVersion("3.0.1")
 
     def test_openapi_version_digits(self):
-        ver = utils.OpenAPIVersion('3.0.1')
+        ver = utils.OpenAPIVersion("3.0.1")
         assert ver.major == 3
         assert ver.minor == 0
         assert ver.patch == 1
-        assert ver.vstring == '3.0.1'
-        assert str(ver) == '3.0.1'
+        assert ver.vstring == "3.0.1"
+        assert str(ver) == "3.0.1"

--- a/tests/test_yaml_utils.py
+++ b/tests/test_yaml_utils.py
@@ -2,6 +2,7 @@
 import pytest
 from apispec import yaml_utils
 
+
 def test_load_yaml_from_docstring():
     def f():
         """
@@ -13,13 +14,16 @@ def test_load_yaml_from_docstring():
         herp: 1
         derp: 2
         """
-    result = yaml_utils.load_yaml_from_docstring(f.__doc__)
-    assert result == {'herp': 1, 'derp': 2}
 
-@pytest.mark.parametrize('docstring', (None, '', '---'))
+    result = yaml_utils.load_yaml_from_docstring(f.__doc__)
+    assert result == {"herp": 1, "derp": 2}
+
+
+@pytest.mark.parametrize("docstring", (None, "", "---"))
 def test_load_yaml_from_docstring_empty_docstring(docstring):
     assert yaml_utils.load_yaml_from_docstring(docstring) == {}
 
-@pytest.mark.parametrize('docstring', (None, '', '---'))
+
+@pytest.mark.parametrize("docstring", (None, "", "---"))
 def test_load_operations_from_docstring_empty_docstring(docstring):
     assert yaml_utils.load_operations_from_docstring(docstring) == {}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,30 +1,36 @@
 # -*- coding: utf-8 -*-
 """Utilities to get elements of generated spec"""
 
+
 def get_definitions(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()['definitions']
-    return spec.to_dict()['components']['schemas']
+        return spec.to_dict()["definitions"]
+    return spec.to_dict()["components"]["schemas"]
+
 
 def get_parameters(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()['parameters']
-    return spec.to_dict()['components']['parameters']
+        return spec.to_dict()["parameters"]
+    return spec.to_dict()["components"]["parameters"]
+
 
 def get_responses(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()['responses']
-    return spec.to_dict()['components']['responses']
+        return spec.to_dict()["responses"]
+    return spec.to_dict()["components"]["responses"]
+
 
 def get_security_schemes(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()['securityDefinitions']
-    return spec.to_dict()['components']['securitySchemes']
+        return spec.to_dict()["securityDefinitions"]
+    return spec.to_dict()["components"]["securitySchemes"]
+
 
 def get_paths(spec):
-    return spec.to_dict()['paths']
+    return spec.to_dict()["paths"]
+
 
 def ref_path(spec):
     if spec.openapi_version.version[0] < 3:
-        return '#/definitions/'
-    return '#/components/schemas/'
+        return "#/definitions/"
+    return "#/components/schemas/"


### PR DESCRIPTION
Same treatment as marshmallow-code/marshmallow#1106

The relevant file changes were made in `setup.py`, `setup.cfg`, and `.pre-commit-config.yaml`.