### PR TITLE
Remove useless field.metadata.pop("many", None)

### DIFF
--- a/apispec/ext/marshmallow/openapi.py
+++ b/apispec/ext/marshmallow/openapi.py
@@ -412,9 +412,6 @@ class OpenAPIConverter(object):
 
         if isinstance(field, marshmallow.fields.Nested):
             del ret["type"]
-            # marshmallow>=2.7.0 compat
-            field.metadata.pop("many", None)
-
             schema_dict = self.resolve_nested_schema(field.schema)
             if ret and "$ref" in schema_dict:
                 ret.update({"allOf": [schema_dict]})


### PR DESCRIPTION
See discussion in https://github.com/marshmallow-code/apispec/pull/386.

When that change was introduced in #64, there was a line below in the code that would include all metadata unconditionally:

https://github.com/lucasrcosta/apispec/blob/d9697baebfbba67808d42ec5a90de0cebc0cae29/apispec/ext/marshmallow/swagger.py#L129

```py
ret.update(field.metadata)
```

This was before `VALID_PROPERTIES` were introduced.

It can now be safely removed.