### PR TITLE
Allow adding schema with an existing name if it is identical to the existing schema

### DIFF
--- a/apispec/core.py
+++ b/apispec/core.py
@@ -129,10 +129,6 @@ class Components(object):
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject
         """
-        if name in self._schemas:
-            raise DuplicateComponentNameError(
-                'Another schema with name "{}" is already registered.'.format(name)
-            )
         component = component or {}
         ret = component.copy()
         # Execute all helpers from plugins
@@ -141,6 +137,12 @@ class Components(object):
                 ret.update(plugin.schema_helper(name, component, **kwargs) or {})
             except PluginMethodNotImplementedError:
                 continue
+
+        if name in self._schemas and ret != self._schemas[name]:
+            raise DuplicateComponentNameError(
+                'A different schema with name "{}" is already registered.'.format(name)
+            )
+
         self._schemas[name] = ret
         return self
 

--- a/apispec/exceptions.py
+++ b/apispec/exceptions.py
@@ -11,7 +11,7 @@ class PluginMethodNotImplementedError(APISpecError, NotImplementedError):
 
 
 class DuplicateComponentNameError(APISpecError):
-    """Raised when registering two components with the same name"""
+    """Raised when registering two different components with the same name"""
 
 
 class OpenAPIError(APISpecError):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -168,11 +168,18 @@ class TestComponents:
 
     def test_schema_duplicate_name(self, spec):
         spec.components.schema("Pet", {"properties": self.properties})
+
+        # Registering the same identical schema with the same name is fine
+        spec.components.schema("Pet", {"properties": self.properties})
+
+        # Registering a different component with the same name is an error
         with pytest.raises(
             DuplicateComponentNameError,
-            match='Another schema with name "Pet" is already registered.',
+            match='A different schema with name "Pet" is already registered.',
         ):
-            spec.components.schema("Pet", properties=self.properties)
+            spec.components.schema(
+                "Pet", properties={"name": {"type": "string", "example": "foobar"}}
+            )
 
     def test_parameter(self, spec):
         parameter = {"format": "int64", "type": "integer"}


### PR DESCRIPTION
Fixes #402.

It simply moves the check for the duplicate name _after_ the new schema has been constructed and compares the existing one to the new one. The `DuplicateComponentNameError` is raised only if the new schema is different to the existing one.

I also tweaked the test so that it first adds the same schema again under the same name (which should succeed) and afterwards tries to add a different schema under the same name (which should fail).

Any comments are welcome.