### PR TITLE
Fixed example app, added route to serve apispec.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,6 @@ Example Application
 .. code-block:: python
 
     import json
-    import yaml
     from collections import Counter
     from apispec import APISpec
     from apispec.ext.marshmallow import MarshmallowPlugin

--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Example Application
     
     
     # Optional Flask support
-    # navigate to /swagger.json or /swagger.yml for generated spec.
+    # navigate to /swagger.json or /swagger.yml for genreated spec.
     app = Flask(__name__)
     
     pet_hits = Counter()
@@ -108,10 +108,7 @@ Example Application
     def get_apispec_json():
         swagger_spec_json = json.dumps(spec.to_dict(), indent=2)
     
-        return Response(
-            swagger_spec_json,
-            mimetype="text/json"
-        )
+        return Response(swagger_spec_json, mimetype="text/json")
     
     
     # Flask route to generated spec as YAML.
@@ -119,11 +116,7 @@ Example Application
     def get_apispec_yaml():
         swagger_spec_yaml = spec.to_yaml()
     
-        return Response(
-            swagger_spec_yaml,
-            mimetype="text/yaml"
-        )
-
+        return Response(swagger_spec_yaml, mimetype="text/yaml")
 
 
 Generated OpenAPI Spec

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Example Application
     
     
     # Optional Flask support
-    # navigate to /swagger.json or /swagger.yml for genreated spec.
+    # navigate to /swagger.json or /swagger.yml for generated spec.
     app = Flask(__name__)
     
     pet_hits = Counter()


### PR DESCRIPTION
Made the example application not return 500 when you try and use it (the 'get_random_pet function' did not exist).
Added flask routes to serve the generated apispec at /swagger.json and /swagger.yml.

This would have made me feel warm and fuzzy when I encountered this project half an hour ago, hopefully it will now do that for somebody else.