### PR TITLE
WIP - Add Components.build_ref

### DIFF
--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -86,6 +86,21 @@ class Components(object):
     They became sub-fields of "components" top-level field in OAS v3.
     """
 
+    COMPONENT_SUBSECTIONS = {
+        2: {
+            'schema': 'definitions',
+            'parameter': 'parameters',
+            'response': 'responses',
+            'security_scheme': 'securityDefinitions',
+        },
+        3: {
+            'schema': 'schemas',
+            'parameter': 'parameters',
+            'response': 'responses',
+            'security_scheme': 'securitySchemes',
+        },
+    }
+
     def __init__(self, plugins, openapi_version):
         self._plugins = plugins
         self.openapi_version = openapi_version
@@ -95,17 +110,12 @@ class Components(object):
         self._security_schemes = {}
 
     def to_dict(self):
-        if self.openapi_version.major < 3:
-            schemas_key = "definitions"
-            security_key = "securityDefinitions"
-        else:
-            schemas_key = "schemas"
-            security_key = "securitySchemes"
+        component_subsections = self.COMPONENT_SUBSECTIONS[self.openapi_version.major]
         return {
-            "parameters": self._parameters,
-            "responses": self._responses,
-            schemas_key: self._schemas,
-            security_key: self._security_schemes,
+            component_subsections["schema"]: self._schemas,
+            component_subsections["parameter"]: self._parameters,
+            component_subsections["response"]: self._responses,
+            component_subsections["security_scheme"]: self._security_schemes,
         }
 
     def schema(self, name, component=None, **kwargs):

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -220,6 +220,29 @@ class Components(object):
         self._security_schemes[component_id] = component
         return self
 
+    def build_ref(self, component_type, component_id):
+        """Build component reference
+
+        Provides an abstraction to reference a component without having to deal with
+        component paths that depend on OAS version.
+
+        :param str component_type: Component type
+            Must be one of ["schema", "parameter", "response", "security_scheme"]
+        :param str component_id: ID of the component to reference
+
+        Example: ::
+
+            spec.components.build_ref('schema', 'MySchema')
+            # '#/components/schemas/MySchema'
+            spec.components.build_ref('security_scheme', 'MySecurityScheme')
+            # '#/components/securitySchemes/MySecurityScheme')
+        """
+        return '#/{path}{subsection}/{component_id}'.format(
+            path=('components/' if self.openapi_version.major >= 3 else ''),
+            subsection=self.COMPONENT_SUBSECTIONS[self.openapi_version.major][component_type],
+            component_id=component_id,
+        )
+
 
 class APISpec(object):
     """Stores metadata that describes a RESTful API using the OpenAPI specification.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -245,6 +245,26 @@ class TestComponents:
         spec.components.schema("Pet", properties=self.properties, enum=enum)
         assert spec.to_dict() == yaml.safe_load(spec.to_yaml())
 
+    @pytest.mark.parametrize("spec", ("2.0",), indirect=True)
+    def test_build_ref_v2(self, spec):
+        assert spec.components.build_ref('schema', 'Schema') == '#/definitions/Schema'
+        assert spec.components.build_ref('parameter', 'Parameter') == '#/parameters/Parameter'
+        assert spec.components.build_ref('response', 'Response') == '#/responses/Response'
+        assert spec.components.build_ref('security_scheme', 'SecurityScheme') == (
+            '#/securityDefinitions/SecurityScheme')
+
+    @pytest.mark.parametrize("spec", ("3.0",), indirect=True)
+    def test_build_ref_v3(self, spec):
+        assert spec.components.build_ref(
+            'schema', 'Schema') == '#/components/schemas/Schema'
+        assert spec.components.build_ref(
+            'parameter', 'Parameter') == '#/components/parameters/Parameter'
+        assert spec.components.build_ref(
+            'response', 'Response') == '#/components/responses/Response'
+        assert spec.components.build_ref(
+            'security_scheme', 'SecurityScheme') == (
+            '#/components/securitySchemes/SecurityScheme')
+
 
 class TestPath:
     paths = {


### PR DESCRIPTION
Provides an abstraction to reference a component without having to deal with component paths that depend on OAS version.

```python
            # OAS 2
            spec.components.build_ref('schema', 'MySchema')
            # '#/definitions/MySchema'
            spec.components.build_ref('security_scheme', 'MySecurityScheme')
            # '#/securityDefinitions/MySecurityScheme')
            # OAS 3
            spec.components.build_ref('schema', 'MySchema')
            # '#/components/schemas/MySchema'
            spec.components.build_ref('security_scheme', 'MySecurityScheme')
            # '#/components/securitySchemes/MySecurityScheme')
```