### PR TITLE
Strip empty component sections from docs

### DIFF
--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -8,7 +8,7 @@ from .exceptions import (
     PluginMethodNotImplementedError,
     DuplicateComponentNameError,
 )
-from .utils import OpenAPIVersion, deepupdate, COMPONENT_SUBSECTIONS, reference_path
+from .utils import OpenAPIVersion, deepupdate, COMPONENT_SUBSECTIONS, build_reference
 
 VALID_METHODS_OPENAPI_V2 = ["get", "post", "put", "patch", "delete", "head", "options"]
 
@@ -51,7 +51,7 @@ def clean_operations(operations, openapi_major_version):
         """
         if isinstance(obj, dict):
             return obj
-        return {"$ref": reference_path(obj_type, openapi_major_version) + obj}
+        return build_reference(obj_type, openapi_major_version, obj)
 
     for operation in (operations or {}).values():
         if "parameters" in operation:

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -8,7 +8,7 @@ from .exceptions import (
     PluginMethodNotImplementedError,
     DuplicateComponentNameError,
 )
-from .utils import OpenAPIVersion, deepupdate
+from .utils import OpenAPIVersion, deepupdate, COMPONENT_SUBSECTIONS, reference_path
 
 VALID_METHODS_OPENAPI_V2 = ["get", "post", "put", "patch", "delete", "head", "options"]
 
@@ -51,13 +51,7 @@ def clean_operations(operations, openapi_major_version):
         """
         if isinstance(obj, dict):
             return obj
-
-        ref_paths = {
-            "parameter": {2: "parameters", 3: "components/parameters"},
-            "response": {2: "responses", 3: "components/responses"},
-        }
-        ref_path = ref_paths[obj_type][openapi_major_version]
-        return {"$ref": "#/{}/{}".format(ref_path, obj)}
+        return {"$ref": reference_path(obj_type, openapi_major_version) + obj}
 
     for operation in (operations or {}).values():
         if "parameters" in operation:
@@ -95,17 +89,15 @@ class Components(object):
         self._security_schemes = {}
 
     def to_dict(self):
-        if self.openapi_version.major < 3:
-            schemas_key = "definitions"
-            security_key = "securityDefinitions"
-        else:
-            schemas_key = "schemas"
-            security_key = "securitySchemes"
+        subsections = {
+            "schema": self._schemas,
+            "parameter": self._parameters,
+            "response": self._responses,
+            "security_scheme": self._security_schemes,
+        }
         return {
-            "parameters": self._parameters,
-            "responses": self._responses,
-            schemas_key: self._schemas,
-            security_key: self._security_schemes,
+            COMPONENT_SUBSECTIONS[self.openapi_version.major][s]: subsections[s]
+            for s in ('schema', 'parameter', 'response', 'security_scheme')
         }
 
     def schema(self, name, component=None, **kwargs):

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -96,8 +96,9 @@ class Components(object):
             "security_scheme": self._security_schemes,
         }
         return {
-            COMPONENT_SUBSECTIONS[self.openapi_version.major][s]: subsections[s]
-            for s in ('schema', 'parameter', 'response', 'security_scheme')
+            COMPONENT_SUBSECTIONS[self.openapi_version.major][k]: v
+            for k, v in subsections.items()
+            if v != {}
         }
 
     def schema(self, name, component=None, **kwargs):
@@ -245,7 +246,9 @@ class APISpec(object):
             ret.update(self.components.to_dict())
         else:
             ret["openapi"] = self.openapi_version.vstring
-            ret.update({"components": self.components.to_dict()})
+            components_dict = self.components.to_dict()
+            if components_dict:
+                ret["components"] = components_dict
         ret = deepupdate(ret, self.options)
         return ret
 

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -19,7 +19,7 @@ from marshmallow.compat import iteritems
 from marshmallow.orderedset import OrderedSet
 
 from apispec.compat import RegexType
-from apispec.utils import OpenAPIVersion, reference_path
+from apispec.utils import OpenAPIVersion, build_reference
 from .common import (
     resolve_schema_cls,
     get_fields,
@@ -684,9 +684,8 @@ class OpenAPIConverter(object):
         """Method to create a dictionary containing a JSON reference to the
         schema in the spec
         """
-        ref_path = reference_path('schema', self.openapi_version.major)
         schema_key = make_schema_key(schema)
-        ref_schema = {"$ref": ref_path + self.refs[schema_key]}
+        ref_schema = build_reference('schema', self.openapi_version.major, self.refs[schema_key])
         if getattr(schema, "many", False):
             return {"type": "array", "items": ref_schema}
         return ref_schema

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -19,7 +19,7 @@ from marshmallow.compat import iteritems
 from marshmallow.orderedset import OrderedSet
 
 from apispec.compat import RegexType
-from apispec.utils import OpenAPIVersion
+from apispec.utils import OpenAPIVersion, reference_path
 from .common import (
     resolve_schema_cls,
     get_fields,
@@ -684,21 +684,12 @@ class OpenAPIConverter(object):
         """Method to create a dictionary containing a JSON reference to the
         schema in the spec
         """
-        ref_path = self.get_ref_path()
+        ref_path = reference_path('schema', self.openapi_version.major)
         schema_key = make_schema_key(schema)
-        ref_schema = {"$ref": "#/{}/{}".format(ref_path, self.refs[schema_key])}
+        ref_schema = {"$ref": ref_path + self.refs[schema_key]}
         if getattr(schema, "many", False):
             return {"type": "array", "items": ref_schema}
         return ref_schema
-
-    def get_ref_path(self):
-        """Return the path for references based on the openapi version
-
-        :param int openapi_version.major: The major version of the OpenAPI standard
-            to use. Supported values are 2 and 3.
-        """
-        ref_paths = {2: "definitions", 3: "components/schemas"}
-        return ref_paths[self.openapi_version.major]
 
     def resolve_schema_dict(self, schema):
         if isinstance(schema, dict):

--- a/src/apispec/utils.py
+++ b/src/apispec/utils.py
@@ -26,16 +26,18 @@ COMPONENT_SUBSECTIONS = {
 }
 
 
-def reference_path(component_type, openapi_major_version):
+def build_reference(component_type, openapi_major_version, component_name):
     """Return path to reference
 
     :param str component_type: Component type (schema, parameter, response, security_scheme)
     :param int openapi_major_version: OpenAPI major version (2 or 3)
+    :param str component_name: Name of component to reference
     """
-    return '#/{}{}/'.format(
+    return {"$ref": "#/{}{}/{}".format(
         'components/' if openapi_major_version >= 3 else '',
-        COMPONENT_SUBSECTIONS[openapi_major_version][component_type]
-    )
+        COMPONENT_SUBSECTIONS[openapi_major_version][component_type],
+        component_name
+    )}
 
 
 def validate_spec(spec):

--- a/src/apispec/utils.py
+++ b/src/apispec/utils.py
@@ -10,6 +10,34 @@ from distutils import version
 from apispec import exceptions
 
 
+COMPONENT_SUBSECTIONS = {
+    2: {
+        'schema': 'definitions',
+        'parameter': 'parameters',
+        'response': 'responses',
+        'security_scheme': 'securityDefinitions',
+    },
+    3: {
+        'schema': 'schemas',
+        'parameter': 'parameters',
+        'response': 'responses',
+        'security_scheme': 'securitySchemes',
+    },
+}
+
+
+def reference_path(component_type, openapi_major_version):
+    """Return path to reference
+
+    :param str component_type: Component type (schema, parameter, response, security_scheme)
+    :param int openapi_major_version: OpenAPI major version (2 or 3)
+    """
+    return '#/{}{}/'.format(
+        'components/' if openapi_major_version >= 3 else '',
+        COMPONENT_SUBSECTIONS[openapi_major_version][component_type]
+    )
+
+
 def validate_spec(spec):
     """Validate the output of an :class:`APISpec` object against the
     OpenAPI specification.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,6 +13,7 @@ from .utils import (
     get_parameters,
     get_responses,
     get_security_schemes,
+    build_ref,
 )
 
 
@@ -386,15 +387,12 @@ class TestPath:
         metadata = spec.to_dict()
         p = get_paths(spec)["/pet/{petId}"]["get"]
 
+        assert p["parameters"][0] == build_ref(spec, "parameter", "test_parameter")
         if spec.openapi_version.major < 3:
-            assert p["parameters"][0] == {"$ref": "#/parameters/test_parameter"}
             assert (
                 route_spec["parameters"][0] == metadata["parameters"]["test_parameter"]
             )
         else:
-            assert p["parameters"][0] == {
-                "$ref": "#/components/parameters/test_parameter"
-            }
             assert (
                 route_spec["parameters"][0]
                 == metadata["components"]["parameters"]["test_parameter"]
@@ -413,15 +411,12 @@ class TestPath:
         metadata = spec.to_dict()
         p = get_paths(spec)["/pet/{petId}"]["get"]
 
+        assert p["responses"]["200"] == build_ref(spec, "response", "test_response")
         if spec.openapi_version.major < 3:
-            assert p["responses"]["200"] == {"$ref": "#/responses/test_response"}
             assert (
                 route_spec["responses"]["200"] == metadata["responses"]["test_response"]
             )
         else:
-            assert p["responses"]["200"] == {
-                "$ref": "#/components/responses/test_response"
-            }
             assert (
                 route_spec["responses"]["200"]
                 == metadata["components"]["responses"]["test_response"]

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -22,7 +22,7 @@ from .schemas import (
     AnalysisWithListSchema,
 )
 
-from .utils import get_schemas, get_parameters, get_responses, get_paths, ref_path
+from .utils import get_schemas, get_parameters, get_responses, get_paths, build_ref
 
 
 class TestDefinitionHelper:
@@ -58,7 +58,7 @@ class TestDefinitionHelper:
             "/test",
             operations={
                 "get": {
-                    "responses": {"200": {"schema": {"$ref": "#/definitions/analysis"}}}
+                    "responses": {"200": {"schema": build_ref(spec, "schema", "analysis")}}
                 }
             },
         )
@@ -89,7 +89,7 @@ class TestDefinitionHelper:
             "/test",
             operations={
                 "get": {
-                    "responses": {"200": {"schema": {"$ref": "#/definitions/analysis"}}}
+                    "responses": {"200": {"schema": build_ref(spec, "schema", "analysis")}}
                 }
             },
         )
@@ -138,10 +138,10 @@ class TestDefinitionHelper:
         pet_unmodified_ref = definitions["MultiModifierSchema"]["properties"][
             "pet_unmodified"
         ]
-        assert pet_unmodified_ref == {"$ref": ref_path(spec) + "Pet"}
+        assert pet_unmodified_ref == build_ref(spec, "schema", "Pet")
 
         pet_exclude = definitions["MultiModifierSchema"]["properties"]["pet_exclude"]
-        assert pet_exclude == {"$ref": ref_path(spec) + "Pet_Exclude"}
+        assert pet_exclude == build_ref(spec, "schema", "Pet_Exclude")
 
     def test_schema_with_clashing_names(self, spec):
         class Pet(PetSchema):
@@ -197,7 +197,7 @@ class TestComponentParameterHelper:
             reference = parameter["schema"]
         else:
             reference = parameter["content"]["application/json"]["schema"]
-        assert reference == {"$ref": ref_path(spec) + "Pet"}
+        assert reference == build_ref(spec, "schema", "Pet")
 
         resolved_schema = spec.components._schemas["Pet"]
         assert resolved_schema["properties"]["name"]["type"] == "string"
@@ -218,7 +218,7 @@ class TestComponentResponseHelper:
             reference = response["schema"]
         else:
             reference = response["content"]["application/json"]["schema"]
-        assert reference == {"$ref": ref_path(spec) + "Pet"}
+        assert reference == build_ref(spec, "schema", "Pet")
 
         resolved_schema = spec.components._schemas["Pet"]
         assert resolved_schema["properties"]["id"]["type"] == "integer"
@@ -231,7 +231,7 @@ class TestComponentResponseHelper:
         spec.components.response("GetPetOk", resp)
         response = get_responses(spec)["GetPetOk"]
         reference = response["headers"]["PetHeader"]["schema"]
-        assert reference == {"$ref": ref_path(spec) + "Pet"}
+        assert reference == build_ref(spec, "schema", "Pet")
 
         resolved_schema = spec.components._schemas["Pet"]
         assert resolved_schema["properties"]["id"]["type"] == "integer"
@@ -314,8 +314,8 @@ class TestOperationHelper:
         else:
             schema_reference = get["responses"][200]["schema"]
             header_reference = get["responses"][200]["headers"]["PetHeader"]["schema"]
-        assert schema_reference == {"$ref": ref_path(spec_fixture.spec) + "Pet"}
-        assert header_reference == {"$ref": ref_path(spec_fixture.spec) + "Pet"}
+        assert schema_reference == build_ref(spec_fixture.spec, "schema", "Pet")
+        assert header_reference == build_ref(spec_fixture.spec, "schema", "Pet")
         assert len(spec_fixture.spec.components._schemas) == 1
         resolved_schema = spec_fixture.spec.components._schemas["Pet"]
         assert resolved_schema == spec_fixture.openapi.schema2jsonschema(PetSchema)
@@ -363,8 +363,8 @@ class TestOperationHelper:
             ]
             header_reference = get["responses"][200]["headers"]["PetHeader"]["schema"]
 
-        assert schema_reference == {"$ref": ref_path(spec_fixture.spec) + "Pet"}
-        assert header_reference == {"$ref": ref_path(spec_fixture.spec) + "Pet"}
+        assert schema_reference == build_ref(spec_fixture.spec, "schema", "Pet")
+        assert header_reference == build_ref(spec_fixture.spec, "schema", "Pet")
         assert len(spec_fixture.spec.components._schemas) == 1
         resolved_schema = spec_fixture.spec.components._schemas["Pet"]
         assert resolved_schema == spec_fixture.openapi.schema2jsonschema(PetSchema)
@@ -443,10 +443,7 @@ class TestOperationHelper:
             path="/pet", operations={"get": {"responses": {200: {"schema": PetSchema}}}}
         )
         get = get_paths(spec_fixture.spec)["/pet"]["get"]
-        assert (
-            get["responses"][200]["schema"]["$ref"]
-            == ref_path(spec_fixture.spec) + "Pet"
-        )
+        assert get["responses"][200]["schema"] == build_ref(spec_fixture.spec, "schema", "Pet")
 
     @pytest.mark.parametrize("spec_fixture", ("3.0.0",), indirect=True)
     def test_schema_uses_ref_if_available_v3(self, spec_fixture):
@@ -463,8 +460,8 @@ class TestOperationHelper:
         )
         get = get_paths(spec_fixture.spec)["/pet"]["get"]
         assert (
-            get["responses"][200]["content"]["application/json"]["schema"]["$ref"]
-            == ref_path(spec_fixture.spec) + "Pet"
+            get["responses"][200]["content"]["application/json"]["schema"]
+            == build_ref(spec_fixture.spec, "schema", "Pet")
         )
 
     def test_schema_uses_ref_if_available_name_resolver_returns_none_v2(self):
@@ -482,7 +479,7 @@ class TestOperationHelper:
             path="/pet", operations={"get": {"responses": {200: {"schema": PetSchema}}}}
         )
         get = get_paths(spec)["/pet"]["get"]
-        assert get["responses"][200]["schema"]["$ref"] == ref_path(spec) + "Pet"
+        assert get["responses"][200]["schema"] == build_ref(spec, "schema", "Pet")
 
     def test_schema_uses_ref_if_available_name_resolver_returns_none_v3(self):
         def resolver(schema):
@@ -507,8 +504,8 @@ class TestOperationHelper:
         )
         get = get_paths(spec)["/pet"]["get"]
         assert (
-            get["responses"][200]["content"]["application/json"]["schema"]["$ref"]
-            == ref_path(spec) + "Pet"
+            get["responses"][200]["content"]["application/json"]["schema"]
+            == build_ref(spec, "schema", "Pet")
         )
 
     @pytest.mark.parametrize("spec_fixture", ("2.0",), indirect=True)
@@ -527,10 +524,7 @@ class TestOperationHelper:
         assert "schema" not in p["get"]["parameters"][0]
         post = p["post"]
         assert len(post["parameters"]) == 1
-        assert (
-            post["parameters"][0]["schema"]["$ref"]
-            == ref_path(spec_fixture.spec) + "Pet"
-        )
+        assert post["parameters"][0]["schema"] == build_ref(spec_fixture.spec, "schema", "Pet")
 
     @pytest.mark.parametrize("spec_fixture", ("3.0.0",), indirect=True)
     def test_schema_uses_ref_in_parameters_and_request_body_if_available_v3(
@@ -552,7 +546,7 @@ class TestOperationHelper:
         assert "schema" in p["get"]["parameters"][0]
         post = p["post"]
         schema_ref = post["requestBody"]["content"]["application/json"]["schema"]
-        assert schema_ref == {"$ref": ref_path(spec_fixture.spec) + "Pet"}
+        assert schema_ref == build_ref(spec_fixture.spec, "schema", "Pet")
 
     @pytest.mark.parametrize("spec_fixture", ("2.0",), indirect=True)
     def test_schema_array_uses_ref_if_available_v2(self, spec_fixture):
@@ -574,7 +568,7 @@ class TestOperationHelper:
         len(get["parameters"]) == 1
         resolved_schema = {
             "type": "array",
-            "items": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
+            "items": build_ref(spec_fixture.spec, "schema", "Pet"),
         }
         assert get["parameters"][0]["schema"] == resolved_schema
         assert get["responses"][200]["schema"] == resolved_schema
@@ -613,7 +607,7 @@ class TestOperationHelper:
         op = p["get"]
         resolved_schema = {
             "type": "array",
-            "items": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
+            "items": build_ref(spec_fixture.spec, "schema", "Pet"),
         }
         request_schema = op["parameters"][0]["content"]["application/json"]["schema"]
         assert request_schema == resolved_schema
@@ -645,8 +639,8 @@ class TestOperationHelper:
         assert get["responses"][200]["schema"] == {
             "type": "object",
             "properties": {
-                "mother": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
-                "father": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
+                "mother": build_ref(spec_fixture.spec, "schema", "Pet"),
+                "father": build_ref(spec_fixture.spec, "schema", "Pet"),
             },
         }
 
@@ -679,8 +673,8 @@ class TestOperationHelper:
         assert get["responses"][200]["content"]["application/json"]["schema"] == {
             "type": "object",
             "properties": {
-                "mother": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
-                "father": {"$ref": ref_path(spec_fixture.spec) + "Pet"},
+                "mother": build_ref(spec_fixture.spec, "schema", "Pet"),
+                "father": build_ref(spec_fixture.spec, "schema", "Pet"),
             },
         }
 
@@ -701,8 +695,8 @@ class TestCircularReference:
     def test_circular_referencing_schemas(self, spec):
         spec.components.schema("Analysis", schema=AnalysisSchema)
         definitions = get_schemas(spec)
-        ref = definitions["Analysis"]["properties"]["sample"]["$ref"]
-        assert ref == ref_path(spec) + "Sample"
+        ref = definitions["Analysis"]["properties"]["sample"]
+        assert ref == build_ref(spec, "schema", "Sample")
 
 
 # Regression tests for issue #55
@@ -710,8 +704,8 @@ class TestSelfReference:
     def test_self_referencing_field_single(self, spec):
         spec.components.schema("SelfReference", schema=SelfReferencingSchema)
         definitions = get_schemas(spec)
-        ref = definitions["SelfReference"]["properties"]["single"]["$ref"]
-        assert ref == ref_path(spec) + "SelfReference"
+        ref = definitions["SelfReference"]["properties"]["single"]
+        assert ref == build_ref(spec, "schema", "SelfReference")
 
     def test_self_referencing_field_many(self, spec):
         spec.components.schema("SelfReference", schema=SelfReferencingSchema)
@@ -719,7 +713,7 @@ class TestSelfReference:
         result = definitions["SelfReference"]["properties"]["many"]
         assert result == {
             "type": "array",
-            "items": {"$ref": ref_path(spec) + "SelfReference"},
+            "items": build_ref(spec, "schema", "SelfReference"),
         }
 
 
@@ -786,7 +780,7 @@ class TestDictValues:
 
         result = get_schemas(spec)["SchemaWithDict"]["properties"]["dict_field"]
         assert result == {
-            "additionalProperties": {"$ref": ref_path(spec) + "Pet"},
+            "additionalProperties": build_ref(spec, "schema", "Pet"),
             "type": "object",
         }
 
@@ -801,4 +795,4 @@ class TestList:
         assert len(get_schemas(spec)) == 2
 
         result = get_schemas(spec)["SchemaWithList"]["properties"]["list_field"]
-        assert result == {"items": {"$ref": ref_path(spec) + "Pet"}, "type": "array"}
+        assert result == {"items": build_ref(spec, "schema", "Pet"), "type": "array"}

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -51,7 +51,7 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        assert {} == get_schemas(spec)
+        assert get_schemas(spec) is None
 
         spec.components.schema("analysis", schema=schema)
         spec.path(
@@ -82,7 +82,7 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        assert {} == get_schemas(spec)
+        assert get_schemas(spec) is None
 
         spec.components.schema("analysis", schema=schema)
         spec.path(
@@ -111,7 +111,7 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        assert {} == get_schemas(spec)
+        assert get_schemas(spec) is None
 
         with pytest.raises(
             APISpecError, match="Name resolver returned None for schema"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,3 +23,14 @@ class TestOpenAPIVersion:
         assert ver.patch == 1
         assert ver.vstring == "3.0.1"
         assert str(ver) == "3.0.1"
+
+
+def test_reference_path():
+    assert utils.reference_path('schema', 2) == '#/definitions/'
+    assert utils.reference_path('parameter', 2) == '#/parameters/'
+    assert utils.reference_path('response', 2) == '#/responses/'
+    assert utils.reference_path('security_scheme', 2) == '#/securityDefinitions/'
+    assert utils.reference_path('schema', 3) == '#/components/schemas/'
+    assert utils.reference_path('parameter', 3) == '#/components/parameters/'
+    assert utils.reference_path('response', 3) == '#/components/responses/'
+    assert utils.reference_path('security_scheme', 3) == '#/components/securitySchemes/'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,12 +25,20 @@ class TestOpenAPIVersion:
         assert str(ver) == "3.0.1"
 
 
-def test_reference_path():
-    assert utils.reference_path('schema', 2) == '#/definitions/'
-    assert utils.reference_path('parameter', 2) == '#/parameters/'
-    assert utils.reference_path('response', 2) == '#/responses/'
-    assert utils.reference_path('security_scheme', 2) == '#/securityDefinitions/'
-    assert utils.reference_path('schema', 3) == '#/components/schemas/'
-    assert utils.reference_path('parameter', 3) == '#/components/parameters/'
-    assert utils.reference_path('response', 3) == '#/components/responses/'
-    assert utils.reference_path('security_scheme', 3) == '#/components/securitySchemes/'
+def test_build_reference():
+    assert utils.build_reference("schema", 2, "Test") == {
+        "$ref": "#/definitions/Test"}
+    assert utils.build_reference("parameter", 2, "Test") == {
+        "$ref": "#/parameters/Test"}
+    assert utils.build_reference("response", 2, "Test") == {
+        "$ref": "#/responses/Test"}
+    assert utils.build_reference("security_scheme", 2, "Test") == {
+        "$ref": "#/securityDefinitions/Test"}
+    assert utils.build_reference("schema", 3, "Test") == {
+        "$ref": "#/components/schemas/Test"}
+    assert utils.build_reference("parameter", 3, "Test") == {
+        "$ref": "#/components/parameters/Test"}
+    assert utils.build_reference("response", 3, "Test") == {
+        "$ref": "#/components/responses/Test"}
+    assert utils.build_reference("security_scheme", 3, "Test") == {
+        "$ref": "#/components/securitySchemes/Test"}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Utilities to get elements of generated spec"""
 
+from apispec.utils import build_reference
+
 
 def get_schemas(spec):
     if spec.openapi_version.major < 3:
@@ -30,7 +32,5 @@ def get_paths(spec):
     return spec.to_dict()["paths"]
 
 
-def ref_path(spec):
-    if spec.openapi_version.version[0] < 3:
-        return "#/definitions/"
-    return "#/components/schemas/"
+def build_ref(spec, component_type, obj):
+    return build_reference(component_type, spec.openapi_version.major, obj)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,30 +6,30 @@ from apispec.utils import build_reference
 
 def get_schemas(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["definitions"]
-    return spec.to_dict()["components"]["schemas"]
+        return spec.to_dict().get("definitions")
+    return spec.to_dict()["components"].get("schemas")
 
 
 def get_parameters(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["parameters"]
-    return spec.to_dict()["components"]["parameters"]
+        return spec.to_dict().get("parameters")
+    return spec.to_dict()["components"].get("parameters")
 
 
 def get_responses(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["responses"]
-    return spec.to_dict()["components"]["responses"]
+        return spec.to_dict().get("responses")
+    return spec.to_dict()["components"].get("responses")
 
 
 def get_security_schemes(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["securityDefinitions"]
-    return spec.to_dict()["components"]["securitySchemes"]
+        return spec.to_dict().get("securityDefinitions")
+    return spec.to_dict()["components"].get("securitySchemes")
 
 
 def get_paths(spec):
-    return spec.to_dict()["paths"]
+    return spec.to_dict().get("paths")
 
 
 def build_ref(spec, component_type, obj):


### PR DESCRIPTION
This PR removes empty component subsections (parameters, responses, etc.) from the docs.

It is based on https://github.com/marshmallow-code/apispec/pull/419. I can send it again once #419 is merged, for a clearer diff.