### PR TITLE
Strip empty component sections from doc

### DIFF
--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -98,6 +98,7 @@ class Components(object):
         return {
             COMPONENT_SUBSECTIONS[self.openapi_version.major][k]: v
             for k, v in iteritems(subsections)
+            if v != {}
         }
 
     def schema(self, name, component=None, **kwargs):
@@ -245,7 +246,9 @@ class APISpec(object):
             ret.update(self.components.to_dict())
         else:
             ret["openapi"] = self.openapi_version.vstring
-            ret.update({"components": self.components.to_dict()})
+            components_dict = self.components.to_dict()
+            if components_dict:
+                ret["components"] = components_dict
         ret = deepupdate(ret, self.options)
         return ret
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -51,7 +51,8 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        assert get_schemas(spec) is None
+        with pytest.raises(KeyError):
+            get_schemas(spec)
 
         spec.components.schema("analysis", schema=schema)
         spec.path(
@@ -84,7 +85,8 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        assert get_schemas(spec) is None
+        with pytest.raises(KeyError):
+            get_schemas(spec)
 
         spec.components.schema("analysis", schema=schema)
         spec.path(
@@ -115,7 +117,8 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        assert get_schemas(spec) is None
+        with pytest.raises(KeyError):
+            get_schemas(spec)
 
         with pytest.raises(
             APISpecError, match="Name resolver returned None for schema"

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -51,7 +51,7 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        assert {} == get_schemas(spec)
+        assert get_schemas(spec) is None
 
         spec.components.schema("analysis", schema=schema)
         spec.path(
@@ -84,7 +84,7 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        assert {} == get_schemas(spec)
+        assert get_schemas(spec) is None
 
         spec.components.schema("analysis", schema=schema)
         spec.path(
@@ -115,7 +115,7 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        assert {} == get_schemas(spec)
+        assert get_schemas(spec) is None
 
         with pytest.raises(
             APISpecError, match="Name resolver returned None for schema"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,30 +6,30 @@ from apispec.utils import build_reference
 
 def get_schemas(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["definitions"]
-    return spec.to_dict()["components"]["schemas"]
+        return spec.to_dict().get("definitions")
+    return spec.to_dict()["components"].get("schemas")
 
 
 def get_parameters(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["parameters"]
-    return spec.to_dict()["components"]["parameters"]
+        return spec.to_dict().get("parameters")
+    return spec.to_dict()["components"].get("parameters")
 
 
 def get_responses(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["responses"]
-    return spec.to_dict()["components"]["responses"]
+        return spec.to_dict().get("responses")
+    return spec.to_dict()["components"].get("responses")
 
 
 def get_security_schemes(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["securityDefinitions"]
-    return spec.to_dict()["components"]["securitySchemes"]
+        return spec.to_dict().get("securityDefinitions")
+    return spec.to_dict()["components"].get("securitySchemes")
 
 
 def get_paths(spec):
-    return spec.to_dict()["paths"]
+    return spec.to_dict().get("paths")
 
 
 def build_ref(spec, component_type, obj):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,30 +6,30 @@ from apispec.utils import build_reference
 
 def get_schemas(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict().get("definitions")
-    return spec.to_dict()["components"].get("schemas")
+        return spec.to_dict()["definitions"]
+    return spec.to_dict()["components"]["schemas"]
 
 
 def get_parameters(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict().get("parameters")
-    return spec.to_dict()["components"].get("parameters")
+        return spec.to_dict()["parameters"]
+    return spec.to_dict()["components"]["parameters"]
 
 
 def get_responses(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict().get("responses")
-    return spec.to_dict()["components"].get("responses")
+        return spec.to_dict()["responses"]
+    return spec.to_dict()["components"]["responses"]
 
 
 def get_security_schemes(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict().get("securityDefinitions")
-    return spec.to_dict()["components"].get("securitySchemes")
+        return spec.to_dict()["securityDefinitions"]
+    return spec.to_dict()["components"]["securitySchemes"]
 
 
 def get_paths(spec):
-    return spec.to_dict().get("paths")
+    return spec.to_dict()["paths"]
 
 
 def build_ref(spec, component_type, obj):


### PR DESCRIPTION
This PR removes empty component subsections (parameters, responses, etc.) from the docs.

I'm tempted not to consider that a breaking change.