### PR TITLE
Marshmallow exclude field allows for tuple

### DIFF
--- a/src/apispec/ext/marshmallow/common.py
+++ b/src/apispec/ext/marshmallow/common.py
@@ -95,7 +95,7 @@ def filter_excluded_fields(fields, Meta, exclude_dump_only):
     :param Meta: the schema's Meta class
     :param bool exclude_dump_only: whether to filter fields in Meta.dump_only
     """
-    exclude = getattr(Meta, "exclude", [])
+    exclude = list(getattr(Meta, "exclude", []))
     if exclude_dump_only:
         exclude += getattr(Meta, "dump_only", [])
 

--- a/src/apispec/ext/marshmallow/common.py
+++ b/src/apispec/ext/marshmallow/common.py
@@ -97,7 +97,7 @@ def filter_excluded_fields(fields, Meta, exclude_dump_only):
     """
     exclude = list(getattr(Meta, "exclude", []))
     if exclude_dump_only:
-        exclude += getattr(Meta, "dump_only", [])
+        exclude.extend(getattr(Meta, "dump_only", []))
 
     filtered_fields = OrderedDict(
         (key, value) for key, value in fields.items() if key not in exclude


### PR DESCRIPTION
Correct unnecessary error when Marshmallow exclude field is defined as a tuple.