### PR TITLE
Fix Marshmallow Schema's Meta exclude field error

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -54,3 +54,4 @@ Contributors (chronological)
 - Marcin Lulek `@ergo <https://github.com/ergo>`_
 - Jonathan Beezley `@jbeezley <https://github.com/jbeezley>`_
 - David Stapleton `@dstape <https://github.com/DStape>`_
+- Szabolcs Blága `@blagasz <https://github.com/blagasz>`_

--- a/src/apispec/ext/marshmallow/common.py
+++ b/src/apispec/ext/marshmallow/common.py
@@ -73,7 +73,7 @@ def warn_if_fields_defined_in_meta(fields, Meta):
     """Warns user that fields defined in Meta.fields or Meta.additional will
     be ignored
 
-    :param dict fields: A dictionary of of fields name field object pairs
+    :param dict fields: A dictionary of fields name field object pairs
     :param Meta: the schema's Meta class
     """
     if getattr(Meta, "fields", None) or getattr(Meta, "additional", None):
@@ -91,13 +91,13 @@ def warn_if_fields_defined_in_meta(fields, Meta):
 def filter_excluded_fields(fields, Meta, exclude_dump_only):
     """Filter fields that should be ignored in the OpenAPI spec
 
-    :param dict fields: A dictionary of of fields name field object pairs
+    :param dict fields: A dictionary of fields name field object pairs
     :param Meta: the schema's Meta class
     :param bool exclude_dump_only: whether to filter fields in Meta.dump_only
     """
-    exclude = getattr(Meta, "exclude", [])
+    exclude = list(getattr(Meta, "exclude", []))
     if exclude_dump_only:
-        exclude += getattr(Meta, "dump_only", [])
+        exclude.extend(getattr(Meta, "dump_only", []))
 
     filtered_fields = OrderedDict(
         (key, value) for key, value in fields.items() if key not in exclude

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -53,6 +53,30 @@ class OrderedSchema(Schema):
         ordered = True
 
 
+class ExcludeSchema(Schema):
+    field1 = fields.Int()
+    field2 = fields.Int()
+    field3 = fields.Int()
+    field4 = fields.Int()
+    field5 = fields.Int()
+
+    class Meta:
+        exclude = ("field2", "field4")
+        dump_only = ["field3"]
+
+
+class ExcludeSchema2(Schema):
+    field1 = fields.Int()
+    field2 = fields.Int()
+    field3 = fields.Int()
+    field4 = fields.Int()
+    field5 = fields.Int()
+
+    class Meta:
+        exclude = ["field3", "field5"]
+        dump_only = ("field1",)
+
+
 class DefaultValuesSchema(Schema):
     number_auto_default = fields.Int(missing=12)
     number_manual_default = fields.Int(missing=12, doc_default=42)

--- a/tests/test_ext_marshmallow_common.py
+++ b/tests/test_ext_marshmallow_common.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from apispec.ext.marshmallow.common import make_schema_key, get_unique_schema_name
-from .schemas import PetSchema, SampleSchema
+from apispec.ext.marshmallow.common import (
+    make_schema_key,
+    get_unique_schema_name,
+    get_fields,
+)
+from .schemas import PetSchema, SampleSchema, ExcludeSchema, ExcludeSchema2
 
 
 class TestMakeSchemaKey:
@@ -43,3 +47,21 @@ class TestUniqueName:
         ):
             name_2 = get_unique_schema_name(spec.components, "Pet")
         assert name_2 == "Pet2"
+
+
+class TestMetaExclude:
+    def test_meta_tuple_in_exclude(self):
+        keys = set(get_fields(ExcludeSchema).keys())
+        assert keys == {"field1", "field3", "field5"}
+
+    def test_meta_list_in_exclude(self):
+        keys = set(get_fields(ExcludeSchema2).keys())
+        assert keys == {"field1", "field2", "field4"}
+
+    def test_meta_tuple_in_dump_only(self):
+        keys = set(get_fields(ExcludeSchema, exclude_dump_only=True).keys())
+        assert keys == {"field1", "field5"}
+
+    def test_meta_list_in_dump_only(self):
+        keys = set(get_fields(ExcludeSchema2, exclude_dump_only=True).keys())
+        assert keys == {"field2", "field4"}


### PR DESCRIPTION
Mixing tuple and list when collecting fields in the Marshmallow extension may result in error.