### PR TITLE
Uses class hierarchy to find type and format properties

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -55,3 +55,4 @@ Contributors (chronological)
 - Jonathan Beezley `@jbeezley <https://github.com/jbeezley>`_
 - David Stapleton `@dstape <https://github.com/DStape>`_
 - Szabolcs Blága `@blagasz <https://github.com/blagasz>`_
+- Andrew Johnson `@andrjohn <https://github.com/andrjohn>`_

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -163,7 +163,20 @@ class OpenAPIConverter(object):
         :param Field field: A marshmallow field.
         :rtype: dict
         """
-        type_, fmt = self.field_mapping.get(type(field), ("string", None))
+        # If this type isn't directly in the field mapping then check the
+        # hierarchy until we find something that does.
+        for field_class in type(field).__mro__:
+            if field_class in self.field_mapping:
+                type_, fmt = self.field_mapping[field_class]
+                break
+        else:
+            warnings.warn(
+                "Field of type {} does not inherit from marshmallow.Field.".format(
+                    type(field)
+                ),
+                UserWarning,
+            )
+            type_, fmt = "string", None
 
         ret = {"type": type_}
 

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -4,7 +4,6 @@ import re
 import warnings
 
 import pytest
-from pytest import mark
 
 from marshmallow import fields, Schema, validate
 
@@ -21,7 +20,7 @@ class TestMarshmallowFieldToOpenAPI:
         field = fields.String(validate=validate.OneOf(choices))
         assert openapi.field2choices(field) == {"enum": choices}
 
-    @mark.parametrize(
+    @pytest.mark.parametrize(
         ("FieldClass", "jsontype"),
         [
             (fields.Integer, "integer"),
@@ -53,7 +52,7 @@ class TestMarshmallowFieldToOpenAPI:
         assert res["type"] == "array"
         assert res["items"] == openapi.field2property(fields.String())
 
-    @mark.parametrize(
+    @pytest.mark.parametrize(
         ("FieldClass", "expected_format"),
         [
             (fields.Integer, "int32"),

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -826,33 +826,31 @@ def test_openapi_tools_validate_v3():
         pytest.fail(str(error))
 
 
-class ValidationSchema(Schema):
-    id = fields.Int(dump_only=True)
-    range = fields.Int(validate=validate.Range(min=1, max=10))
-    multiple_ranges = fields.Int(
-        validate=[
-            validate.Range(min=1),
-            validate.Range(min=3),
-            validate.Range(max=10),
-            validate.Range(max=7),
-        ]
-    )
-    list_length = fields.List(fields.Str, validate=validate.Length(min=1, max=10))
-    string_length = fields.Str(validate=validate.Length(min=1, max=10))
-    multiple_lengths = fields.Str(
-        validate=[
-            validate.Length(min=1),
-            validate.Length(min=3),
-            validate.Length(max=10),
-            validate.Length(max=7),
-        ]
-    )
-    equal_length = fields.Str(
-        validate=[validate.Length(equal=5), validate.Length(min=1, max=10)]
-    )
-
-
 class TestFieldValidation:
+    class ValidationSchema(Schema):
+        id = fields.Int(dump_only=True)
+        range = fields.Int(validate=validate.Range(min=1, max=10))
+        multiple_ranges = fields.Int(
+            validate=[
+                validate.Range(min=1),
+                validate.Range(min=3),
+                validate.Range(max=10),
+                validate.Range(max=7),
+            ]
+        )
+        list_length = fields.List(fields.Str, validate=validate.Length(min=1, max=10))
+        string_length = fields.Str(validate=validate.Length(min=1, max=10))
+        multiple_lengths = fields.Str(
+            validate=[
+                validate.Length(min=1),
+                validate.Length(min=3),
+                validate.Length(max=10),
+                validate.Length(max=7),
+            ]
+        )
+        equal_length = fields.Str(
+            validate=[validate.Length(equal=5), validate.Length(min=1, max=10)]
+        )
 
     @pytest.mark.parametrize(
         ("field", "properties"),
@@ -866,7 +864,7 @@ class TestFieldValidation:
         ],
     )
     def test_properties(self, field, properties, spec):
-        spec.components.schema("Validation", schema=ValidationSchema)
+        spec.components.schema("Validation", schema=self.ValidationSchema)
         result = get_schemas(spec)["Validation"]["properties"][field]
 
         for attr, expected_value in properties.items():

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -853,56 +853,22 @@ class ValidationSchema(Schema):
 
 
 class TestFieldValidation:
-    def test_range(self, spec):
+
+    @pytest.mark.parametrize(
+        ("field", "properties"),
+        [
+            ("range", {"minimum": 1, "maximum": 10}),
+            ("multiple_ranges", {"minimum": 3, "maximum": 7}),
+            ("list_length", {"minItems": 1, "maxItems": 10}),
+            ("string_length", {"minLength": 1, "maxLength": 10}),
+            ("multiple_lengths", {"minLength": 3, "maxLength": 7}),
+            ("equal_length", {"minLength": 5, "maxLength": 5}),
+        ],
+    )
+    def test_properties(self, field, properties, spec):
         spec.components.schema("Validation", schema=ValidationSchema)
-        result = get_schemas(spec)["Validation"]["properties"]["range"]
+        result = get_schemas(spec)["Validation"]["properties"][field]
 
-        assert "minimum" in result
-        assert result["minimum"] == 1
-        assert "maximum" in result
-        assert result["maximum"] == 10
-
-    def test_multiple_ranges(self, spec):
-        spec.components.schema("Validation", schema=ValidationSchema)
-        result = get_schemas(spec)["Validation"]["properties"]["multiple_ranges"]
-
-        assert "minimum" in result
-        assert result["minimum"] == 3
-        assert "maximum" in result
-        assert result["maximum"] == 7
-
-    def test_list_length(self, spec):
-        spec.components.schema("Validation", schema=ValidationSchema)
-        result = get_schemas(spec)["Validation"]["properties"]["list_length"]
-
-        assert "minItems" in result
-        assert result["minItems"] == 1
-        assert "maxItems" in result
-        assert result["maxItems"] == 10
-
-    def test_string_length(self, spec):
-        spec.components.schema("Validation", schema=ValidationSchema)
-        result = get_schemas(spec)["Validation"]["properties"]["string_length"]
-
-        assert "minLength" in result
-        assert result["minLength"] == 1
-        assert "maxLength" in result
-        assert result["maxLength"] == 10
-
-    def test_multiple_lengths(self, spec):
-        spec.components.schema("Validation", schema=ValidationSchema)
-        result = get_schemas(spec)["Validation"]["properties"]["multiple_lengths"]
-
-        assert "minLength" in result
-        assert result["minLength"] == 3
-        assert "maxLength" in result
-        assert result["maxLength"] == 7
-
-    def test_equal_length(self, spec):
-        spec.components.schema("Validation", schema=ValidationSchema)
-        result = get_schemas(spec)["Validation"]["properties"]["equal_length"]
-
-        assert "minLength" in result
-        assert result["minLength"] == 5
-        assert "maxLength" in result
-        assert result["maxLength"] == 5
+        for attr, expected_value in properties.items():
+            assert attr in result
+            assert result[attr] == expected_value


### PR DESCRIPTION
When sub-classing a marshmallow type then the type and format properties are not found because those properties are looked up in a mapping using concrete types. Other properties are added using `isinstance` to check if the type is a form or `List` or `Nested`.

This change uses the class hierarchy (using the MRO) to do a better job of finding a match in the field mapping. This will reduce the need for custom classes to be added to the field mapping, although that always remains an option if the user wants to control it.

This resolves #433 and #250
This also seems related to #429
