### PR TITLE
Fix stringification of response codes

### DIFF
--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -3,16 +3,13 @@
 from collections import OrderedDict
 import warnings
 
-from apispec.compat import iterkeys, iteritems, PY2
+from apispec.compat import iterkeys, iteritems
 from .exceptions import (
     APISpecError,
     PluginMethodNotImplementedError,
     DuplicateComponentNameError,
 )
 from .utils import OpenAPIVersion, deepupdate, COMPONENT_SUBSECTIONS, build_reference
-
-if not PY2:
-    from http import HTTPStatus
 
 VALID_METHODS_OPENAPI_V2 = ["get", "post", "put", "patch", "delete", "head", "options"]
 
@@ -73,14 +70,11 @@ def clean_operations(operations, openapi_major_version):
         if "responses" in operation:
             responses = OrderedDict()
             for code, response in iteritems(operation["responses"]):
-                if openapi_major_version < 3:
-                    try:
-                        code = int(code)
-                    except (TypeError, ValueError):
+                try:
+                    code = int(code)  # handles IntEnums like http.HTTPStatus
+                except (TypeError, ValueError):
+                    if openapi_major_version < 3:
                         warnings.warn("Non-integer code not allowed in OpenAPI < 3")
-                elif not PY2:
-                    if isinstance(code, HTTPStatus):
-                        code = code.value
 
                 responses[str(code)] = get_ref(
                     "response", response, openapi_major_version

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 
 import pytest
 import sys
-import warnings
 import yaml
 
 from apispec import APISpec, BasePlugin
@@ -438,20 +437,17 @@ class TestPath:
 
         assert "200" in get_paths(spec)["/pet/{petId}"]["get"]["responses"]
 
-    def test_response_with_status_code_range(self, spec):
+    def test_response_with_status_code_range(self, spec, recwarn):
         status_code = "2XX"
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
-            spec.path(
-                path="/pet/{petId}",
-                operations={"get": {"responses": {status_code: "test_response"}}},
-            )
+        spec.path(
+            path="/pet/{petId}",
+            operations={"get": {"responses": {status_code: "test_response"}}},
+        )
 
         if spec.openapi_version.major < 3:
-            assert len(w) == 1
-            assert issubclass(w[-1].category, UserWarning)
+            assert len(recwarn) == 1
+            assert recwarn.pop(UserWarning)
 
         assert status_code in get_paths(spec)["/pet/{petId}"]["get"]["responses"]
 

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import re
-import warnings
 
 import pytest
 from pytest import mark
@@ -380,7 +379,7 @@ class TestMarshmallowSchemaToModelDefinition:
         res = openapi.schema2jsonschema(WhiteStripesSchema)
         assert set(res["properties"].keys()) == {"guitarist", "drummer"}
 
-    def test_only_explicitly_declared_fields_are_translated(self, recwarn, openapi):
+    def test_only_explicitly_declared_fields_are_translated(self, openapi):
         class UserSchema(Schema):
             _id = fields.Int()
 
@@ -388,19 +387,15 @@ class TestMarshmallowSchemaToModelDefinition:
                 title = "User"
                 fields = ("_id", "email")
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("always")
+        with pytest.warns(
+            UserWarning,
+            match="Only explicitly-declared fields will be included in the Schema Object.",
+        ):
             res = openapi.schema2jsonschema(UserSchema)
             assert res["type"] == "object"
             props = res["properties"]
             assert "_id" in props
             assert "email" not in props
-            warning = recwarn.pop()
-            expected_msg = (
-                "Only explicitly-declared fields will be included in the Schema Object."
-            )
-            assert expected_msg in str(warning.message)
-            assert issubclass(warning.category, UserWarning)
 
     def test_observed_field_name_for_required_field(self, openapi):
         if MARSHMALLOW_VERSION_INFO[0] < 3:


### PR DESCRIPTION
OpenAPI 2 states that the available status codes are described by RFC
7231. The RFC states that the, "status-code element is a three-digit integer
code", therefore we interpret that as OpenAPI 2 does not allow
non-integer characters to be present in status codes.

OpenAPI 3 on the other hand is a lot less ambiguous and states that the
status code field "MAY contain the uppercase wild character X",
therefore meaning non-integer characters are valid (e.g. '2XX').

Also add support for parsing Python 3's in-built http.HTTPStatus.

Addresses issue #426 