### PR TITLE
tox/pre-commit: show-diff-on-failure

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands = pytest {posargs}
 [testenv:lint]
 deps = pre-commit~=1.14
 skip_install = true
-commands = pre-commit run --all-files
+commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:docs]
 deps = -rdocs/requirements.txt


### PR DESCRIPTION
This changes displays the diff in travis log. I picked it from werkzeug tox config: https://github.com/pallets/werkzeug/blob/master/tox.ini#L24.

Useful for people who didn't install pre-commit (occasional contributors, Python 3.5 users,...).

I checked it works by adding a dummy commit with intentional errors. 