### PR TITLE
Fix MarshmallowPlugin.resolve_schema for OAS3 content without schema

### DIFF
--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -36,6 +36,7 @@ from __future__ import absolute_import
 import warnings
 
 from apispec import BasePlugin
+from apispec.compat import itervalues
 from .common import resolve_schema_instance, make_schema_key
 from .openapi import OpenAPIConverter
 
@@ -123,11 +124,11 @@ class MarshmallowPlugin(BasePlugin):
         # OAS 3 component except header
         if self.openapi_version.major >= 3:
             if "content" in data:
-                for content_type in data["content"]:
-                    schema = data["content"][content_type]["schema"]
-                    data["content"][content_type][
-                        "schema"
-                    ] = self.openapi.resolve_schema_dict(schema)
+                for content in itervalues(data["content"]):
+                    if "schema" in content:
+                        content["schema"] = self.openapi.resolve_schema_dict(
+                            content["schema"]
+                        )
 
     def map_to_openapi_type(self, *args):
         """Decorator to set mapping for custom fields.

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -245,6 +245,13 @@ class TestComponentResponseHelper:
         assert resolved_schema["properties"]["name"]["type"] == "string"
         assert resolved_schema["properties"]["password"]["type"] == "string"
 
+    @pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
+    def test_content_without_schema(self, spec):
+        resp = {"content": {"application/json": {"example": {"name": "Example"}}}}
+        spec.components.response("GetPetOk", resp)
+        response = get_responses(spec)["GetPetOk"]
+        assert response == resp
+
 
 class TestCustomField:
     def test_can_use_custom_field_decorator(self, spec_fixture):


### PR DESCRIPTION
https://swagger.io/specification/#mediaTypeObject

`schema` is not required, so there can be content without schema. This PR fixes this use case (and reworks the loop using `itervalues`).