### PR TITLE
In resolve_nested_schema(), add newly found nested schema to refs dict

### DIFF
--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -473,6 +473,8 @@ class OpenAPIConverter(object):
                 return json_schema
             name = get_unique_schema_name(self.spec.components, name)
             self.spec.components.schema(name, schema=schema)
+            # add nested schema name to the refs dict, otherwise get_ref_dict() fails
+            self.refs[schema_key] = name
         return self.get_ref_dict(schema_instance)
 
     def schema2parameters(


### PR DESCRIPTION
In OpenAPIConverter.resolve_nested_schema() of apispec.ext.marshallow.openapi, in the case where the schema key is not found in self.refs, a name is resolved for the nested schema but that name and the schema key are never added to self.refs, causing self.get_ref_dict() to fail on previous line 701 with "KeyError: SchemaKey(SchemaClass=<class '[some.class.Name]'>, ...'. This simple patch correctly adds the dictionary entry for the nested schema to self.refs.