### PR TITLE
Update CHANGELOG (component refs by ID), docs (upgrading to 2.0.0)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Other changes:
 
 - *Backwards-incompatible*: All plugin helpers must accept extra `**kwargs`
   (:issue:`453`).
+- *Backwards-incompatible*: Components must be referenced by ID, not full path
+  (:issue:`463`).
 
 1.3.3 (2019-05-05)
 ++++++++++++++++++

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -41,13 +41,7 @@ Add paths to your spec using `path <apispec.APISpec.path>`.
         path="/gist/{gist_id}",
         operations=dict(
             get=dict(
-                responses={
-                    "200": {
-                        "content": {
-                            "application/json": {"schema": {"$ref": "#/definitions/Gist"}}
-                        }
-                    }
-                }
+                responses={"200": {"content": {"application/json": {"schema": "Gist"}}}}
             )
         ),
     )

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -3,6 +3,69 @@ Upgrading to Newer Releases
 
 This section documents migration paths to new releases.
 
+Upgrading to 2.0.0
+------------------
+
+plugin helpers must accept extra `**kwargs`
+*******************************************
+
+Since custom plugins helpers may define extra kwargs and those kwargs are passed
+to all plugin helpers by :meth:`APISpec.path <APISpec.path>`, all plugins should
+accept unknown kwargs.
+
+The example plugin below defines an additional `func` argument and accepts extra
+`**kwargs`.
+
+.. code-block:: python
+    :emphasize-lines: 2
+
+    class MyPlugin(BasePlugin):
+        def path_helper(self, path, func, **kwargs):
+            """Path helper that parses docstrings for operations. Adds a
+            ``func`` parameter to `apispec.APISpec.path`.
+            """
+            operations = load_operations_from_docstring(func.__doc__)
+            return Path(path=path, operations=operations)
+
+Components must be referenced by ID, not full path
+**************************************************
+
+While apispec 1.x would let the user reference components by path or ID,
+apispec 2.x only accepts references by ID.
+
+.. code-block:: python
+
+    # apispec<2.0.0
+    spec.path(
+        path="/gist/{gist_id}",
+        operations=dict(
+            get=dict(
+                responses={
+                    "200": {
+                        "content": {
+                            "application/json": {"schema": {"$ref": "#/definitions/Gist"}}
+                        }
+                    }
+                }
+            )
+        ),
+    )
+
+    # apispec>=2.0.0
+    spec.path(
+        path="/gist/{gist_id}",
+        operations=dict(
+            get=dict(
+                responses={"200": {"content": {"application/json": {"schema": "Gist"}}}}
+            )
+        ),
+    )
+
+References by ID are accepted by both apispec 1.x ad 2.x and are a better
+choice because they delegate the creation of the full component path to apispec.
+This allows more flexibility as apispec creates the component path according to
+the OpenAPI version.
+
 Upgrading to 1.0.0
 ------------------
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -269,10 +269,7 @@ class TestPath:
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "schema": {"$ref": "#/definitions/Pet"},
-                        "description": "successful operation",
-                    },
+                    "200": {"schema": "Pet", "description": "successful operation"},
                     "400": {"description": "Invalid ID supplied"},
                     "404": {"description": "Pet not found"},
                 },


### PR DESCRIPTION
Fix docs. See https://github.com/marshmallow-code/apispec/issues/463.

Maybe we could also add a YAML example in the "upgrading to 2.0.0" section.