### PR TITLE
Rework name resolver

### DIFF
--- a/docs/api_ext.rst
+++ b/docs/api_ext.rst
@@ -12,3 +12,8 @@ apispec.ext.marshmallow.openapi
 
 .. automodule:: apispec.ext.marshmallow.openapi
     :members:
+
+apispec.ext.marshmallow.common
+++++++++++++++++++++++++++++++
+.. automodule:: apispec.ext.marshmallow.common
+    :members:

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -214,8 +214,12 @@ function will resolve a name based on the schema's class `__name__`, dropping a
 trailing "Schema" so that `class PetSchema(Schema)` resolves to "Pet".
 
 To change the behavior of the name resolution simply pass a
-function accepting a `Schema` class and returning a string to the plugin's
-constructor. If the `schema_name_resolver` function returns a value that
+function accepting a `Schema` class, `Schema` instance or a string that resolves
+to a `Schema` class and returning a string to the plugin's
+constructor. To easily work with these argument types the marshmallow plugin provides
+`resolve_schema_cls <apispec.ext.marshmallow.common.resolve_schema_cls>`
+and `resolve_schema_instance <apispec.ext.marshmallow.common.resolve_schema_instance>`
+functions. If the `schema_name_resolver` function returns a value that
 evaluates to `False` in a boolean context the nested schema will not be added to
 the spec and instead defined in-line.
 

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -52,14 +52,15 @@ import warnings
 
 from apispec import BasePlugin
 from apispec.compat import itervalues
-from .common import resolve_schema_instance, make_schema_key
+from .common import resolve_schema_instance, make_schema_key, resolve_schema_cls
 from .openapi import OpenAPIConverter
 
 
 def resolver(schema):
     """Default implementation of a schema name resolver function
     """
-    name = schema.__name__
+    schema_cls = resolve_schema_cls(schema)
+    name = schema_cls.__name__
     if name.endswith("Schema"):
         return name[:-6] or name
     return name

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -76,8 +76,11 @@ class MarshmallowPlugin(BasePlugin):
 
         Example: ::
 
+            from apispec.ext.marshmallow.common import resolve_schema_cls
+
             def schema_name_resolver(schema):
-                return schema.__name__
+                schema_cls = resolve_schema_cls(schema)
+                return schema_cls.__name__
     """
 
     def __init__(self, schema_name_resolver=None):

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -20,7 +20,6 @@ from marshmallow.orderedset import OrderedSet
 from apispec.compat import RegexType, iteritems
 from apispec.utils import OpenAPIVersion, build_reference
 from .common import (
-    resolve_schema_cls,
     get_fields,
     make_schema_key,
     resolve_schema_instance,
@@ -721,11 +720,3 @@ class OpenAPIConverter(object):
             return schema
 
         return self.resolve_nested_schema(schema)
-
-    def resolve_schema_class(self, schema):
-        """Return schema class for given schema (instance or class)
-
-        :param type|Schema|str: instance, class or class name of marshmallow.Schema
-        :return: schema class of given schema (instance or class)
-        """
-        return resolve_schema_cls(schema)

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -461,8 +461,7 @@ class OpenAPIConverter(object):
         schema_instance = resolve_schema_instance(schema)
         schema_key = make_schema_key(schema_instance)
         if schema_key not in self.refs:
-            schema_cls = self.resolve_schema_class(schema)
-            name = self.schema_name_resolver(schema_cls)
+            name = self.schema_name_resolver(schema)
             if not name:
                 try:
                     json_schema = self.schema2jsonschema(schema)


### PR DESCRIPTION
Changes the `schema_name_resolver` function to be able to accept either a `Schema` class, `Schema` instance or a string that resolves to a `Schema` class.

resolves #475 