### PR TITLE
Change OpenAPIConverter into OpenAPIConverterMixin

### DIFF
--- a/docs/api_ext.rst
+++ b/docs/api_ext.rst
@@ -6,18 +6,17 @@ apispec.ext.marshmallow
 
 .. automodule:: apispec.ext.marshmallow
     :members:
+    :inherited-members:
 
 apispec.ext.marshmallow.openapi
 +++++++++++++++++++++++++++++++
 
 .. automodule:: apispec.ext.marshmallow.openapi
-    :members:
 
 apispec.ext.marshmallow.field_converter
 +++++++++++++++++++++++++++++++++++++++
 
 .. automodule:: apispec.ext.marshmallow.field_converter
-    :members:
 
 apispec.ext.marshmallow.common
 ++++++++++++++++++++++++++++++

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -54,8 +54,7 @@ from .openapi import OpenAPIConverterMixin
 
 
 def resolver(schema):
-    """Default implementation of a schema name resolver function
-    """
+    """Default schema name resolver function that strips 'Schema' from the end of the class name."""
     schema_cls = resolve_schema_cls(schema)
     name = schema_cls.__name__
     if name.endswith("Schema"):
@@ -64,7 +63,7 @@ def resolver(schema):
 
 
 class MarshmallowPlugin(OpenAPIConverterMixin, BasePlugin):
-    """APISpec plugin handling marshmallow schemas
+    """APISpec plugin for translating marshmallow schemas to OpenAPI/JSONSchema format.
 
     :param callable schema_name_resolver: Callable to generate the schema definition name.
         Receives the `Schema` class and returns the name to be used in refs within

--- a/src/apispec/ext/marshmallow/common.py
+++ b/src/apispec/ext/marshmallow/common.py
@@ -11,7 +11,7 @@ MODIFIERS = ["only", "exclude", "load_only", "dump_only", "partial"]
 
 
 def resolve_schema_instance(schema):
-    """Return schema instance for given schema (instance or class)
+    """Return schema instance for given schema (instance or class).
 
     :param type|Schema|str schema: instance, class or class name of marshmallow.Schema
     :return: schema instance of given schema (instance or class)
@@ -25,12 +25,12 @@ def resolve_schema_instance(schema):
     except marshmallow.exceptions.RegistryError:
         raise ValueError(
             "{!r} is not a marshmallow.Schema subclass or instance and has not"
-            " been registered in the Marshmallow class registry.".format(schema)
+            " been registered in the marshmallow class registry.".format(schema)
         )
 
 
 def resolve_schema_cls(schema):
-    """Return schema class for given schema (instance or class)
+    """Return schema class for given schema (instance or class).
 
     :param type|Schema|str: instance, class or class name of marshmallow.Schema
     :return: schema class of given schema (instance or class)
@@ -44,12 +44,12 @@ def resolve_schema_cls(schema):
     except marshmallow.exceptions.RegistryError:
         raise ValueError(
             "{!r} is not a marshmallow.Schema subclass or instance and has not"
-            " been registered in the Marshmallow class registry.".format(schema)
+            " been registered in the marshmallow class registry.".format(schema)
         )
 
 
 def get_fields(schema, exclude_dump_only=False):
-    """Return fields from schema
+    """Return fields from schema.
 
     :param Schema schema: A marshmallow Schema instance or a class object
     :param bool exclude_dump_only: whether to filter fields in Meta.dump_only
@@ -69,8 +69,7 @@ def get_fields(schema, exclude_dump_only=False):
 
 
 def warn_if_fields_defined_in_meta(fields, Meta):
-    """Warns user that fields defined in Meta.fields or Meta.additional will
-    be ignored
+    """Warns user that fields defined in Meta.fields or Meta.additional will be ignored.
 
     :param dict fields: A dictionary of fields name field object pairs
     :param Meta: the schema's Meta class
@@ -88,7 +87,7 @@ def warn_if_fields_defined_in_meta(fields, Meta):
 
 
 def filter_excluded_fields(fields, Meta, exclude_dump_only):
-    """Filter fields that should be ignored in the OpenAPI spec
+    """Filter fields that should be ignored in the OpenAPI spec.
 
     :param dict fields: A dictionary of fields name field object pairs
     :param Meta: the schema's Meta class

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -111,6 +111,16 @@ class FieldConverterMixin:
 
         - a pair of the form ``(type, format)``
         - a core marshmallow field type (in which case we reuse that type's mapping)
+
+        Examples: ::
+
+            @ma_plugin.map_to_openapi_type('string', 'uuid')
+            class MyCustomField(Integer):
+                # ...
+
+            @ma_plugin.map_to_openapi_type(Integer)  # will map to ('integer', 'int32')
+            class MyCustomFieldThatsKindaLikeAnInteger(Integer):
+                # ...
         """
         if len(args) == 1 and args[0] in self.field_mapping:
             openapi_type_field = self.field_mapping[args[0]]

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -83,7 +83,7 @@ _VALID_PREFIX = "x-"
 
 
 class FieldConverterMixin:
-    """Mixin class to convert fields to an OpenAPI property"""
+    """Adds methods for converting marshmallow fields to an OpenAPI properties."""
 
     field_mapping = DEFAULT_FIELD_MAPPING
 
@@ -138,7 +138,7 @@ class FieldConverterMixin:
     def add_attribute_function(self, func):
         """Method to add an attribute function to the list of attribute functions
         that will be called on a field to convert it from a field to an OpenAPI
-        property
+        property.
 
         :param func func: the attribute function to add - will be called for each
             field in a schema with a `field <marshmallow.fields.Field>` instance
@@ -173,8 +173,7 @@ class FieldConverterMixin:
         return ret
 
     def field2type_and_format(self, field, **kwargs):
-        """Return the dictionary of OpenAPI type and format based on the field
-        type
+        """Return the dictionary of OpenAPI type and format based on the field type.
 
         :param Field field: A marshmallow field.
         :rtype: dict
@@ -202,7 +201,7 @@ class FieldConverterMixin:
         return ret
 
     def field2default(self, field, **kwargs):
-        """Return the dictionary containing the field's default value
+        """Return the dictionary containing the field's default value.
 
         Will first look for a `doc_default` key in the field's metadata and then
         fall back on the field's `missing` parameter. A callable passed to the
@@ -222,7 +221,7 @@ class FieldConverterMixin:
         return ret
 
     def field2choices(self, field, **kwargs):
-        """Return the dictionary of OpenAPI field attributes for valid choices definition
+        """Return the dictionary of OpenAPI field attributes for valid choices definition.
 
         :param Field field: A marshmallow field.
         :rtype: dict
@@ -381,7 +380,7 @@ class FieldConverterMixin:
         return attributes
 
     def metadata2properties(self, field, **kwargs):
-        """Return a dictionary of properties extracted from field Metadata
+        """Return a dictionary of properties extracted from field metadata.
 
         Will include field metadata that are valid properties of `OpenAPI schema
         objects
@@ -412,8 +411,7 @@ class FieldConverterMixin:
         return ret
 
     def nested2properties(self, field, ret):
-        """Return a dictionary of properties from :class:`Nested <marshmallow.fields.Nested`
-        fields
+        """Return a dictionary of properties from :class:`Nested <marshmallow.fields.Nested` fields.
 
         Typically provides a reference object and will add the schema to the spec
         if it is not already present
@@ -433,8 +431,7 @@ class FieldConverterMixin:
         return ret
 
     def list2properties(self, field, **kwargs):
-        """Return a dictionary of properties from :class:`List <marshmallow.fields.List`
-        fields
+        """Return a dictionary of properties from :class:`List <marshmallow.fields.List>` fields.
 
         Will provide an `items` property based on the field's `inner` attribute
 
@@ -450,8 +447,7 @@ class FieldConverterMixin:
         return ret
 
     def dict2properties(self, field, **kwargs):
-        """Return a dictionary of properties from :class:`Dict <marshmallow.fields.Dict`
-        fields
+        """Return a dictionary of properties from :class:`Dict <marshmallow.fields.Dict>` fields.
 
         Only applicable for Marshmallow versions greater than 3. Will provide an
         `additionalProperties` property based on the field's `value_field` attribute

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 import marshmallow
 from marshmallow.utils import is_collection
 
-from apispec.utils import OpenAPIVersion, build_reference
+from apispec.utils import build_reference
 from apispec.exceptions import APISpecError
 from .field_converter import FieldConverterMixin
 from .common import (
@@ -38,7 +38,7 @@ __location_map__ = {
 }
 
 
-class OpenAPIConverter(FieldConverterMixin):
+class OpenAPIConverterMixin(FieldConverterMixin):
     """Converter generating OpenAPI specification from Marshmallow schemas and fields
 
     :param str|OpenAPIVersion openapi_version: The OpenAPI version to use.
@@ -50,14 +50,6 @@ class OpenAPIConverter(FieldConverterMixin):
     :param APISpec spec: An initalied spec. Nested schemas will be added to the
         spec
     """
-
-    def __init__(self, openapi_version, schema_name_resolver, spec):
-        self.openapi_version = OpenAPIVersion(openapi_version)
-        self.schema_name_resolver = schema_name_resolver
-        self.spec = spec
-        self.init_attribute_functions()
-        # Schema references
-        self.refs = {}
 
     @staticmethod
     def _observed_name(field, name):

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -39,7 +39,7 @@ __location_map__ = {
 
 
 class OpenAPIConverterMixin(FieldConverterMixin):
-    """Converter generating OpenAPI specification from Marshmallow schemas and fields
+    """Adds methods for generating OpenAPI specification from marshmallow schemas and fields.
 
     :param str|OpenAPIVersion openapi_version: The OpenAPI version to use.
         Should be in the form '2.x' or '3.x.x' to comply with the OpenAPI standard.
@@ -67,7 +67,7 @@ class OpenAPIConverterMixin(FieldConverterMixin):
         return field.data_key or name
 
     def resolve_nested_schema(self, schema):
-        """Return the Open API representation of a marshmallow Schema.
+        """Return the OpenAPI representation of a marshmallow Schema.
 
         Adds the schema to the spec if it isn't already present.
 
@@ -248,28 +248,6 @@ class OpenAPIConverterMixin(FieldConverterMixin):
         provide the ``title`` and ``description`` class Meta options.
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject
-
-        Example: ::
-
-            class UserSchema(Schema):
-                _id = fields.Int()
-                email = fields.Email(description='email address of the user')
-                name = fields.Str()
-
-                class Meta:
-                    title = 'User'
-                    description = 'A registered user'
-
-            oaic = OpenAPIConverter(openapi_version='3.0.2', schema_name_resolver=resolver, spec=spec)
-            pprint(oaic.schema2jsonschema(UserSchema))
-            # {'description': 'A registered user',
-            #  'properties': {'_id': {'format': 'int32', 'type': 'integer'},
-            #                 'email': {'description': 'email address of the user',
-            #                           'format': 'email',
-            #                           'type': 'string'},
-            #                 'name': {'type': 'string'}},
-            #  'title': 'User',
-            #  'type': 'object'}
 
         :param Schema schema: A marshmallow Schema instance
         :rtype: dict, a JSON Schema Object

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,7 @@ def make_spec(openapi_version):
         openapi_version=openapi_version,
         plugins=(ma_plugin,),
     )
-    return namedtuple("Spec", ("spec", "marshmallow_plugin", "openapi"))(
-        spec, ma_plugin, ma_plugin.openapi
-    )
+    return namedtuple("Spec", ("spec", "ma_plugin"))(spec, ma_plugin)
 
 
 @pytest.fixture(params=("2.0", "3.0.0"))
@@ -30,6 +28,5 @@ def spec(request):
 
 
 @pytest.fixture(params=("2.0", "3.0.0"))
-def openapi(request):
-    spec = make_spec(request.param)
-    return spec.openapi
+def ma_plugin(request):
+    return make_spec(request.param).ma_plugin

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -282,17 +282,17 @@ class TestComponentResponseHelper:
 
 class TestCustomField:
     def test_can_use_custom_field_decorator(self, spec_fixture):
-        @spec_fixture.marshmallow_plugin.map_to_openapi_type(DateTime)
+        @spec_fixture.ma_plugin.map_to_openapi_type(DateTime)
         class CustomNameA(Field):
             pass
 
-        @spec_fixture.marshmallow_plugin.map_to_openapi_type("integer", "int32")
+        @spec_fixture.ma_plugin.map_to_openapi_type("integer", "int32")
         class CustomNameB(Field):
             pass
 
         with pytest.raises(TypeError):
 
-            @spec_fixture.marshmallow_plugin.map_to_openapi_type("integer")
+            @spec_fixture.ma_plugin.map_to_openapi_type("integer")
             class BadCustomField(Field):
                 pass
 
@@ -366,7 +366,7 @@ class TestOperationHelper:
         assert header_reference == build_ref(spec_fixture.spec, "schema", "Pet")
         assert len(spec_fixture.spec.components._schemas) == 1
         resolved_schema = spec_fixture.spec.components._schemas["Pet"]
-        assert resolved_schema == spec_fixture.openapi.schema2jsonschema(PetSchema)
+        assert resolved_schema == spec_fixture.ma_plugin.schema2jsonschema(PetSchema)
         assert get["responses"]["200"]["description"] == "successful operation"
 
     @pytest.mark.parametrize(
@@ -415,7 +415,7 @@ class TestOperationHelper:
         assert header_reference == build_ref(spec_fixture.spec, "schema", "Pet")
         assert len(spec_fixture.spec.components._schemas) == 1
         resolved_schema = spec_fixture.spec.components._schemas["Pet"]
-        assert resolved_schema == spec_fixture.openapi.schema2jsonschema(PetSchema)
+        assert resolved_schema == spec_fixture.ma_plugin.schema2jsonschema(PetSchema)
         assert get["responses"]["200"]["description"] == "successful operation"
 
     @pytest.mark.parametrize("spec_fixture", ("2.0",), indirect=True)
@@ -439,11 +439,11 @@ class TestOperationHelper:
         )
         p = get_paths(spec_fixture.spec)["/pet"]
         get = p["get"]
-        assert get["parameters"] == spec_fixture.openapi.schema2parameters(
+        assert get["parameters"] == spec_fixture.ma_plugin.schema2parameters(
             PetSchema(), default_in="query"
         )
         post = p["post"]
-        assert post["parameters"] == spec_fixture.openapi.schema2parameters(
+        assert post["parameters"] == spec_fixture.ma_plugin.schema2parameters(
             PetSchema,
             default_in="body",
             required=True,
@@ -468,7 +468,7 @@ class TestOperationHelper:
         )
         p = get_paths(spec_fixture.spec)["/pet"]
         get = p["get"]
-        assert get["parameters"] == spec_fixture.openapi.schema2parameters(
+        assert get["parameters"] == spec_fixture.ma_plugin.schema2parameters(
             PetSchema(), default_in="query"
         )
         for parameter in get["parameters"]:
@@ -477,7 +477,7 @@ class TestOperationHelper:
             name = parameter["name"]
             assert description == PetSchema.description[name]
         post = p["post"]
-        post_schema = spec_fixture.openapi.resolve_schema_dict(PetSchema)
+        post_schema = spec_fixture.ma_plugin.resolve_schema_dict(PetSchema)
         assert (
             post["requestBody"]["content"]["application/json"]["schema"] == post_schema
         )
@@ -760,15 +760,15 @@ class TestOperationHelper:
             "200": build_ref(spec_fixture.spec, "response", "Pet")
         }
 
-    def test_schema_global_state_untouched_2json(self, spec_fixture):
+    def test_schema_global_state_untouched_2json(self, ma_plugin):
         assert get_nested_schema(RunSchema, "sample") is None
-        data = spec_fixture.openapi.schema2jsonschema(RunSchema)
+        data = ma_plugin.schema2jsonschema(RunSchema)
         json.dumps(data)
         assert get_nested_schema(RunSchema, "sample") is None
 
-    def test_schema_global_state_untouched_2parameters(self, spec_fixture):
+    def test_schema_global_state_untouched_2parameters(self, ma_plugin):
         assert get_nested_schema(RunSchema, "sample") is None
-        data = spec_fixture.openapi.schema2parameters(RunSchema)
+        data = ma_plugin.schema2parameters(RunSchema)
         json.dumps(data)
         assert get_nested_schema(RunSchema, "sample") is None
 


### PR DESCRIPTION
What I suggested in https://github.com/marshmallow-code/apispec/pull/478#issuecomment-526732974.

This makes it easier to subclass `MarshmallowPlugin`.