### PR TITLE
Fix documentation of default from missing with marshmallow 3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Features:
   ``Schema`` class. This allows a custom resolver to generate different names
   depending on schema modifiers used in a ``Schema`` instance. (:pr:`476`)
 
+Bug fixes:
+
+- MarshmallowPlugin: With marshmallow 3, the default value of a field in the
+  documentation is the dump of the ``missing`` attribute, not ``missing``
+  itself (:pr:`490`).
+
 Other changes:
 
 - Drop support for Python 2 (:issue:`491`). Thanks :user:`hugovk` for the PR.

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -1,4 +1,4 @@
-"""Marshmallow plugin for apispec. Allows passing a marshmallow
+"""marshmallow plugin for apispec. Allows passing a marshmallow
 `Schema` to `spec.components.schema <apispec.core.Components.schema>`,
 `spec.components.parameter <apispec.core.Components.parameter>`,
 `spec.components.response <apispec.core.Components.response>`
@@ -10,11 +10,10 @@ Requires marshmallow>=2.15.2.
 ``MarshmallowPlugin`` maps marshmallow ``Field`` classes with OpenAPI types and
 formats.
 
-It inspects field attributes to create corresponding OpenAPI documentation,
-allowing to automatically document properties such as read/write-only, range or
-length constraints, etc.
+It inspects field attributes to automatically document properties
+such as read/write-only, range and length constraints, etc.
 
-OpenAPI properties can also be passed as metadata in the ``Field`` instance
+OpenAPI properties can also be passed as metadata to the ``Field`` instance
 if they can't be inferred from the field attributes (`description`,...), or to
 override automatic documentation (`readOnly`,...). A metadata attribute is used
 in the documentation either if it is a valid OpenAPI property, or if it starts
@@ -22,14 +21,13 @@ with `"x-"` (vendor extension).
 
 .. warning::
 
-    ``MarshmallowPlugin`` infers the `default` property from the ``missing``
-    attribute of the ``Field``. This only applies if ``missing`` is not a
-    callable. Besides, when using marshmallow 3, default values are entered in
-    deserialized form, so the value must be serialized first using the
-    ``Field`` instance. This may lead to inaccurate documentation in very
-    specific cases. The default value to display in the documentation can be
-    specified explicitly by passing ``doc_default`` as metadata (``default`` is
-    a valid OpenAPI property, but it is a reserved marshmallow attribute).
+    ``MarshmallowPlugin`` infers the ``default`` property from the ``missing``
+    attribute of the ``Field`` (unless ``missing`` is a callable).
+    In marshmallow 3, default values are entered in deserialized form,
+    so the value is serialized by the ``Field`` instance.
+    This may lead to inaccurate documentation in very specific cases.
+    The default value to display in the documentation can be
+    specified explicitly by passing ``doc_default`` as metadata.
 
 ::
 

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -7,6 +7,30 @@
 
 Requires marshmallow>=2.15.2.
 
+``MarshmallowPlugin`` maps marshmallow ``Field`` classes with OpenAPI types and
+formats.
+
+It inspects field attributes to create corresponding OpenAPI documentation,
+allowing to automatically document properties such as read/write-only, range or
+length constraints, etc.
+
+OpenAPI properties can also be passed as metadata in the ``Field`` instance
+if they can't be inferred from the field attributes (`description`,...), or to
+override automatic documentation (`readOnly`,...). A metadata attribute is used
+in the documentation either if it is a valid OpenAPI property, or if it starts
+with `"x-"` (vendor extension).
+
+.. warning::
+
+    ``MarshmallowPlugin`` infers the `default` property from the ``missing``
+    attribute of the ``Field``. This only applies if ``missing`` is not a
+    callable. Besides, when using marshmallow 3, default values are entered in
+    deserialized form, so the value must be serialized first using the
+    ``Field`` instance. This may lead to inaccurate documentation in very
+    specific cases. The default value to display in the documentation can be
+    specified explicitly by passing ``doc_default`` as metadata (``default`` is
+    a valid OpenAPI property, but it is a reserved marshmallow attribute).
+
 ::
 
     from pprint import pprint

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -206,8 +206,9 @@ class FieldConverterMixin:
         else:
             default = field.missing
             if default is not marshmallow.missing and not callable(default):
+                if MARSHMALLOW_VERSION_INFO[0] >= 3:
+                    default = field._serialize(default, None, None)
                 ret["default"] = default
-
         return ret
 
     def field2choices(self, field, **kwargs):

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import re
 
 import pytest
@@ -5,6 +6,7 @@ from marshmallow import fields, validate
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
+from apispec.ext.marshmallow.openapi import MARSHMALLOW_VERSION_INFO
 
 from .schemas import CategorySchema, CustomList, CustomStringField, CustomIntegerField
 from .utils import build_ref
@@ -84,10 +86,19 @@ def test_field_with_missing(spec_fixture):
     assert res["default"] == "bar"
 
 
-def test_field_with_boolean_false_missing(spec_fixture):
+def test_boolean_field_with_false_missing(spec_fixture):
     field = fields.Boolean(default=None, missing=False)
     res = spec_fixture.openapi.field2property(field)
     assert res["default"] is False
+
+
+def test_datetime_field_with_missing(spec_fixture):
+    if MARSHMALLOW_VERSION_INFO[0] < 3:
+        field = fields.Date(missing=dt.date(2014, 7, 18).isoformat())
+    else:
+        field = fields.Date(missing=dt.date(2014, 7, 18))
+    res = spec_fixture.openapi.field2property(field)
+    assert res["default"] == dt.date(2014, 7, 18).isoformat()
 
 
 def test_field_with_missing_callable(spec_fixture):


### PR DESCRIPTION
Addresses #342.

It sucks not being able to document default values automatically, especially since it would probably work most of the times, but I don't see a safe way to do it.

Without this feature removal, we may pass to the spec dict objects that are not json serializable, which will trigger an exception when serializing the spec file.