### PR TITLE
FieldConverterMixin: inject field as kwarg in field2property

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -157,7 +157,7 @@ class FieldConverterMixin:
         ret = {}
 
         for attr_func in self.attribute_functions:
-            ret.update(attr_func(field, ret=ret))
+            ret.update(attr_func(field=field, ret=ret))
 
         return ret
 


### PR DESCRIPTION
This change allow to write a custom field with `self` as first argument.

Because `field2property` injects `self` as `kwarg`, this is only possible if `field` is a `kwarg` too.

IOT, without the change, one would have to write:

```py
    def custom_string2properties(field, self, **kwargs):  # <- hurts the eye
        ret = {}
        if isinstance(field, CustomStringField):
            if self.openapi_version.major == 2:
                ret["x-customString"] = True
            else:
                ret["x-customString"] = False
        return ret
```