### PR TITLE
add_attribute_function: bind function to OpenAPIConverter instance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Features:
 
 - Add support for generating user-defined OpenAPI properties for custom field
-  classes via an ``add_attribute_function`` method (:pr:`478`).
+  classes via an ``add_attribute_function`` method (:pr:`478` and :pr:`498`).
 - [apispec.ext.marshmallow]: *Backwards-incompatible* ``fields.Raw`` and ``fields.Field`` are
   now represented by OpenAPI `Any Type <https://swagger.io/docs/specification/data-models/data-types/#any>`_
   (:pr:`495`).

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -279,16 +279,20 @@ method. Continuing from the example above:
 
 .. code-block:: python
 
-    def my_custom_field2properties(field, **kwargs):
+    def my_custom_field2properties(self, field, **kwargs):
         """Add an OpenAPI extension flag to MyCustomField instances
         """
         ret = {}
         if isinstance(field, MyCustomField):
-            ret["x-customField"] = True
+            if self.openapi_version.major > 2:
+                ret["x-customString"] = True
         return ret
 
 
     ma_plugin.converter.add_attribute_function(my_custom_field2properties)
+
+The function passed to `add_attribute_function` will be bound to the converter.
+It must accept the converter instance as first positional argument.
 
 Next Steps
 ----------

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -129,10 +129,14 @@ class FieldConverterMixin:
         that will be called on a field to convert it from a field to an OpenAPI
         property.
 
-        :param func func: the attribute function to add - will be called for each
-            field in a schema with a `field <marshmallow.fields.Field>` instance
-            positional argument and `self <apispec.ext.marshmallow.openapi.OpenAPIConverter>`
-            and `ret <dict>` keyword arguments.
+        :param func func: the attribute function to add
+            The attribute function will be bound to the
+            `OpenAPIConverter <apispec.ext.marshmallow.openapi.OpenAPIConverter>`
+            instance.
+            It will be called for each field in a schema with
+            `self <apispec.ext.marshmallow.openapi.OpenAPIConverter>` and a
+            `field <marshmallow.fields.Field>` instance
+            positional arguments and `ret <dict>` keyword argument.
             Must return a dictionary of OpenAPI properties that will be shallow
             merged with the return values of all other attribute functions called on the field.
             User added attribute functions will be called after all built-in attribute
@@ -140,7 +144,9 @@ class FieldConverterMixin:
             previously called attribute functions are accessable via the `ret`
             argument.
         """
-        self.attribute_functions.append(functools.partial(func, self=self))
+        bound_func = func.__get__(self)
+        setattr(self, func.__name__, bound_func)
+        self.attribute_functions.append(bound_func)
 
     def field2property(self, field):
         """Return the JSON Schema property definition given a marshmallow


### PR DESCRIPTION
This achieves the same goal as #497.

It makes things more consistent to have custom attribute functions be bound to the instance like the default ones.

This means all custom functions **must** accept `self` (even if they don't use it). I think consistency is worth this (little) inconvenience.