### PR TITLE
Remove unused defaults in OpenAPIConverter methods

### DIFF
--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -142,7 +142,7 @@ class OpenAPIConverter(FieldConverterMixin):
 
         return self.fields2parameters(fields, default_in=default_in)
 
-    def fields2parameters(self, fields, default_in):
+    def fields2parameters(self, fields, *, default_in):
         """Return an array of OpenAPI parameters given a mapping between field names and
         :class:`Field <marshmallow.Field>` objects. If `default_in` is "body", then return an array
         of a single parameter; else return an array of a parameter for each included field in
@@ -183,7 +183,7 @@ class OpenAPIConverter(FieldConverterMixin):
                 parameters.append(param)
         return parameters
 
-    def field2parameter(self, field, name, default_in):
+    def field2parameter(self, field, *, name, default_in):
         """Return an OpenAPI parameter as a `dict`, given a marshmallow
         :class:`Field <marshmallow.Field>`.
 
@@ -200,7 +200,9 @@ class OpenAPIConverter(FieldConverterMixin):
             default_in=default_in,
         )
 
-    def property2parameter(self, prop, name, required, multiple, location, default_in):
+    def property2parameter(
+        self, prop, *, name, required, multiple, location, default_in
+    ):
         """Return the Parameter Object definition for a JSON Schema property.
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -183,7 +183,7 @@ class OpenAPIConverter(FieldConverterMixin):
                 parameters.append(param)
         return parameters
 
-    def field2parameter(self, field, name="body", default_in="body"):
+    def field2parameter(self, field, name, default_in="body"):
         """Return an OpenAPI parameter as a `dict`, given a marshmallow
         :class:`Field <marshmallow.Field>`.
 
@@ -203,7 +203,7 @@ class OpenAPIConverter(FieldConverterMixin):
     def property2parameter(
         self,
         prop,
-        name="body",
+        name,
         required=False,
         multiple=False,
         location=None,
@@ -229,11 +229,8 @@ class OpenAPIConverter(FieldConverterMixin):
         if openapi_location == "body":
             ret["required"] = False
             ret["name"] = "body"
-            ret["schema"] = {
-                "type": "object",
-                "properties": {name: prop} if name else {},
-            }
-            if name and required:
+            ret["schema"] = {"type": "object", "properties": {name: prop}}
+            if required:
                 ret["schema"]["required"] = [name]
         else:
             ret["required"] = required

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -142,7 +142,7 @@ class OpenAPIConverter(FieldConverterMixin):
 
         return self.fields2parameters(fields, default_in=default_in)
 
-    def fields2parameters(self, fields, default_in="body"):
+    def fields2parameters(self, fields, default_in):
         """Return an array of OpenAPI parameters given a mapping between field names and
         :class:`Field <marshmallow.Field>` objects. If `default_in` is "body", then return an array
         of a single parameter; else return an array of a parameter for each included field in
@@ -183,7 +183,7 @@ class OpenAPIConverter(FieldConverterMixin):
                 parameters.append(param)
         return parameters
 
-    def field2parameter(self, field, name, default_in="body"):
+    def field2parameter(self, field, name, default_in):
         """Return an OpenAPI parameter as a `dict`, given a marshmallow
         :class:`Field <marshmallow.Field>`.
 
@@ -200,15 +200,7 @@ class OpenAPIConverter(FieldConverterMixin):
             default_in=default_in,
         )
 
-    def property2parameter(
-        self,
-        prop,
-        name,
-        required=False,
-        multiple=False,
-        location=None,
-        default_in="body",
-    ):
+    def property2parameter(self, prop, name, required, multiple, location, default_in):
         """Return the Parameter Object definition for a JSON Schema property.
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -262,7 +262,7 @@ class TestMarshmallowSchemaToParameters:
     @pytest.mark.parametrize("ListClass", [fields.List, CustomList])
     def test_field_multiple(self, ListClass, openapi):
         field = ListClass(fields.Str, location="querystring")
-        res = openapi.field2parameter(field, name="field")
+        res = openapi.field2parameter(field, name="field", default_in=None)
         assert res["in"] == "query"
         if openapi.openapi_version.major < 3:
             assert res["type"] == "array"
@@ -276,7 +276,7 @@ class TestMarshmallowSchemaToParameters:
 
     def test_field_required(self, openapi):
         field = fields.Str(required=True, location="query")
-        res = openapi.field2parameter(field, name="field")
+        res = openapi.field2parameter(field, name="field", default_in=None)
         assert res["required"] is True
 
     def test_invalid_schema(self, openapi):
@@ -356,14 +356,6 @@ class TestMarshmallowSchemaToParameters:
 
         with pytest.raises(AssertionError):
             openapi.schema2parameters(UserSchema(many=True), default_in="query")
-
-    # json/body is invalid for OpenAPI 3
-    @pytest.mark.parametrize("openapi", ("2.0",), indirect=True)
-    def test_fields_default_in_body(self, openapi):
-        field_dict = {"name": fields.Str(), "email": fields.Email()}
-        res = openapi.fields2parameters(field_dict)
-        assert len(res) == 1
-        assert set(res[0]["schema"]["properties"].keys()) == {"name", "email"}
 
     def test_fields_query(self, openapi):
         field_dict = {"name": fields.Str(), "email": fields.Email()}
@@ -491,6 +483,7 @@ def test_openapi_tools_validate_v2():
                             validate=validate.OneOf(["freddie", "roger"]),
                             location="querystring",
                         ),
+                        default_in=None,
                         name="body",
                     ),
                 ]
@@ -548,6 +541,7 @@ def test_openapi_tools_validate_v3():
                             validate=validate.OneOf(["freddie", "roger"]),
                             location="querystring",
                         ),
+                        default_in=None,
                         name="body",
                     ),
                 ]


### PR DESCRIPTION
Those default values are never used because the methods are always called with a value.

Note: We're reworking webargs to remove the `location` field metadata. Ultimately, it won't be parsed in apispec either, and `default_in` will be a mandatory location.