### PR TITLE
Test against Python 3.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,16 +26,18 @@ jobs:
   parameters:
     toxenvs:
       - lint
+
       - py35-marshmallow2
       - py35-marshmallow3
 
-      - py36-marshmallow2
       - py36-marshmallow3
 
-      - py37-marshmallow2
       - py37-marshmallow3
 
-      - py37-marshmallowdev
+      - py38-marshmallow2
+      - py38-marshmallow3
+
+      - py38-marshmallowdev
 
       - docs
     os: linux

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only",
     ],
     test_suite="tests",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
     lint
-    py{35,36,37}-marshmallow2
-    py{35,36,37}-marshmallow3
+    py{35,36,37,38}-marshmallow2
+    py{35,36,37,38}-marshmallow3
     py37-marshmallowdev
     docs
 


### PR DESCRIPTION
That's a lot of combinations and wasted computer cycles.

On flask-smorest, I test MA2 and MA3 on oldest and latest PY and only MA3 on the others. I'd like to do the same here:

```
      - lint

      - py35-marshmallow2
      - py35-marshmallow3

      - py36-marshmallow3

      - py37-marshmallow3

      - py38-marshmallow2
      - py38-marshmallow3

      - py38-marshmallowdev
```

@sloria?