### PR TITLE
Add match_info -> path to __location_map__

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -61,3 +61,4 @@ Contributors (chronological)
 - Hugo van Kemenade `@hugovk <https://github.com/hugovk>`_
 - Bastien Gerard `@bagerard <https://github.com/bagerard>`_
 - Ashutosh Chaudhary `@codeasashu <https://github.com/codeasashu>`_
+- Fedor Fominykh `@fedorfo <https://github.com/fedorfo>`_

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -28,6 +28,7 @@ MARSHMALLOW_VERSION_INFO = tuple(
 
 
 __location_map__ = {
+    "match_info": "path",
     "query": "query",
     "querystring": "query",
     "json": "body",


### PR DESCRIPTION
### Before

If we add `@match_info_schema(SomeSchema)` to our method and do `setup_aiohttp_apispec`, we will have duplicated parameters in swagger.json. For example this method:

```
@docs(tags=["Tag"])
@match_info_schema(MatchInfoSchema)
@routes.get(r"/entity/{alias}")
async def get_entity(self) -> Tuple[Any, int]:
    ...
```

will add to swagger:

```
"parameters": [          
          {
            "in": "match_info",
            "name": "alias",
            "required": true,
            "type": "string"
          },
          {
            "in": "path",
            "name": "alias",
            "required": true,
            "type": "string"
          }
        ],
```

### After fix

All fields from match_info schema will be put in parameters with `in == "path"`