### PR TITLE
Don't warn when using string "default" as status code in OASv2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+3.1.1 (unreleased)
+******************
+
+Bug fixes:
+
+- Don't emit a warning when passing "default" as response status code in OASv2
+  (:pr:`521`).
+
 3.1.0 (2019-11-04)
 ******************
 
@@ -8,7 +16,7 @@ Support:
 
 - Add `apispec.core.Components.example` for adding Example Objects
   (:pr:`515`). Thanks :user:`codeasashu` for the PR.
-- Test against Python 3.8 (pr:`150`).
+- Test against Python 3.8 (:pr:`510`).
 
 3.0.0 (2019-09-17)
 ++++++++++++++++++

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -371,7 +371,7 @@ class APISpec:
                     try:
                         code = int(code)  # handles IntEnums like http.HTTPStatus
                     except (TypeError, ValueError):
-                        if self.openapi_version.major < 3:
+                        if self.openapi_version.major < 3 and code != "default":
                             warnings.warn("Non-integer code not allowed in OpenAPI < 3")
 
                     responses[str(code)] = self.get_ref("response", response)


### PR DESCRIPTION
This warning was introduced in #436.

According to https://swagger.io/docs/specification/2-0/describing-responses/ (section "Default Response"), `"default"` is a valid code.

Since the warning is not tested, I didn't modify any test.