### PR TITLE
Ignore "location" field metadata

### DIFF
--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -110,7 +110,7 @@ class OpenAPIConverter(FieldConverterMixin):
         return self.get_ref_dict(schema_instance)
 
     def schema2parameters(
-        self, schema, *, location="body", name="body", required=False, description=None
+        self, schema, *, location, name="body", required=False, description=None
     ):
         """Return an array of OpenAPI parameters given a given marshmallow
         :class:`Schema <marshmallow.Schema>`. If `location` is "body", then return an array

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -196,20 +196,16 @@ class OpenAPIConverter(FieldConverterMixin):
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject
         """
-        location = field.metadata.get("location", None)
         prop = self.field2property(field)
         return self.property2parameter(
             prop,
             name=name,
             required=field.required,
             multiple=isinstance(field, marshmallow.fields.List),
-            location=location,
             default_in=default_in,
         )
 
-    def property2parameter(
-        self, prop, *, name, required, multiple, location, default_in
-    ):
+    def property2parameter(self, prop, *, name, required, multiple, default_in):
         """Return the Parameter Object definition for a JSON Schema property.
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject
@@ -218,13 +214,11 @@ class OpenAPIConverter(FieldConverterMixin):
         :param str name: Field name
         :param bool required: Parameter is required
         :param bool multiple: Parameter is repeated
-        :param str location: Location to look for ``name``
-        :param str default_in: Default location to look for ``name``
+        :param str default_in: Location to look for ``name``
         :raise: TranslationError if arg object cannot be translated to a Parameter Object schema.
         :rtype: dict, a Parameter Object
         """
-        openapi_default_in = __location_map__.get(default_in, default_in)
-        openapi_location = __location_map__.get(location, openapi_default_in)
+        openapi_location = __location_map__.get(default_in, default_in)
         ret = {"in": openapi_location, "name": name}
 
         if openapi_location == "body":

--- a/src/apispec/ext/marshmallow/schema_resolver.py
+++ b/src/apispec/ext/marshmallow/schema_resolver.py
@@ -76,7 +76,7 @@ class SchemaResolver:
             ):
                 schema_instance = resolve_schema_instance(parameter.pop("schema"))
                 resolved += self.converter.schema2parameters(
-                    schema_instance, default_in=parameter.pop("in"), **parameter
+                    schema_instance, location=parameter.pop("in"), **parameter
                 )
             else:
                 self.resolve_schema(parameter)

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -440,12 +440,12 @@ class TestOperationHelper:
         p = get_paths(spec_fixture.spec)["/pet"]
         get = p["get"]
         assert get["parameters"] == spec_fixture.openapi.schema2parameters(
-            PetSchema(), default_in="query"
+            PetSchema(), location="query"
         )
         post = p["post"]
         assert post["parameters"] == spec_fixture.openapi.schema2parameters(
             PetSchema,
-            default_in="body",
+            location="body",
             required=True,
             name="pet",
             description="a pet schema",
@@ -469,7 +469,7 @@ class TestOperationHelper:
         p = get_paths(spec_fixture.spec)["/pet"]
         get = p["get"]
         assert get["parameters"] == spec_fixture.openapi.schema2parameters(
-            PetSchema(), default_in="query"
+            PetSchema(), location="query"
         )
         for parameter in get["parameters"]:
             description = parameter.get("description", False)

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -819,7 +819,7 @@ class TestOperationHelper:
 
     def test_schema_global_state_untouched_2parameters(self, spec_fixture):
         assert get_nested_schema(RunSchema, "sample") is None
-        data = spec_fixture.openapi.schema2parameters(RunSchema)
+        data = spec_fixture.openapi.schema2parameters(RunSchema, location="json")
         json.dumps(data)
         assert get_nested_schema(RunSchema, "sample") is None
 

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -268,7 +268,7 @@ class TestMarshmallowSchemaToParameters:
 
     def test_invalid_schema(self, openapi):
         with pytest.raises(ValueError):
-            openapi.schema2parameters(None)
+            openapi.schema2parameters(None, location="json")
 
     # json/body is invalid for OpenAPI 3
     @pytest.mark.parametrize("openapi", ("2.0",), indirect=True)

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -19,26 +19,6 @@ class TestMarshmallowFieldToOpenAPI:
         else:
             assert res[0]["schema"]["default"] == "bar"
 
-    # json/body is invalid for OpenAPI 3
-    @pytest.mark.parametrize("openapi", ("2.0",), indirect=True)
-    def test_fields_with_multiple_json_locations(self, openapi):
-        field_dict = {
-            "field1": fields.Str(required=True),
-            "field2": fields.Str(required=True),
-            "field3": fields.Str(),
-        }
-        res = openapi.fields2parameters(field_dict, location="json")
-        assert len(res) == 1
-        assert res[0]["in"] == "body"
-        assert res[0]["required"] is False
-        assert "field1" in res[0]["schema"]["properties"]
-        assert "field2" in res[0]["schema"]["properties"]
-        assert "field3" in res[0]["schema"]["properties"]
-        assert "required" in res[0]["schema"]
-        assert len(res[0]["schema"]["required"]) == 2
-        assert "field1" in res[0]["schema"]["required"]
-        assert "field2" in res[0]["schema"]["required"]
-
     def test_fields_location_mapping(self, openapi):
         field_dict = {"field": fields.Str()}
         res = openapi.fields2parameters(field_dict, location="cookies")


### PR DESCRIPTION
Same rationale as https://github.com/marshmallow-code/webargs/pull/420. Ignore "location" in field metadata.

TODO:

- [x] Rename `default_in` as `location` or `in`. It is not a default anymore.
- [x] ~Remove dead code as per https://github.com/marshmallow-code/apispec/issues/500.~ Addressed in #581.