### PR TITLE
Allow to access APISpec components in plugin init_spec

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -62,3 +62,4 @@ Contributors (chronological)
 - Bastien Gerard `@bagerard <https://github.com/bagerard>`_
 - Ashutosh Chaudhary `@codeasashu <https://github.com/codeasashu>`_
 - Fedor Fominykh `@fedorfo <https://github.com/fedorfo>`_
+- Colin Bounouar `@Colin-b <https://github.com/colin-b>`_

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -190,18 +190,18 @@ class APISpec:
         self.version = version
         self.openapi_version = OpenAPIVersion(openapi_version)
         self.options = options
+        self.plugins = plugins
 
         # Metadata
         self._tags = []
         self._paths = OrderedDict()
 
-        # Plugins
-        self.plugins = plugins
-        for plugin in self.plugins:
-            plugin.init_spec(self)
-
         # Components
         self.components = Components(self.plugins, self.openapi_version)
+
+        # Plugins
+        for plugin in self.plugins:
+            plugin.init_spec(self)
 
     def to_dict(self):
         ret = {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -276,6 +276,19 @@ class TestComponents:
         spec.components.schema("Pet", properties=self.properties, enum=enum)
         assert spec.to_dict() == yaml.safe_load(spec.to_yaml())
 
+    def test_components_can_be_accessed_by_plugin_in_init_spec(self):
+        class TestPlugin(BasePlugin):
+            def init_spec(self, spec):
+                spec.components.schema(
+                    "TestSchema", {"properties": {"key": {"type": "string"}}, "type": "object"}
+                )
+
+        spec = APISpec("Test API", version="0.0.1", openapi_version="2.0", plugins=[TestPlugin()])
+        metadata = spec.to_dict()
+        assert metadata["definitions"] == {
+            'TestSchema': {'properties': {'key': {'type': 'string'}}, 'type': 'object'}
+        }
+
 
 class TestPath:
     paths = {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -280,13 +280,15 @@ class TestComponents:
         class TestPlugin(BasePlugin):
             def init_spec(self, spec):
                 spec.components.schema(
-                    "TestSchema", {"properties": {"key": {"type": "string"}}, "type": "object"}
+                    "TestSchema",
+                    {"properties": {"key": {"type": "string"}}, "type": "object"},
                 )
 
-        spec = APISpec("Test API", version="0.0.1", openapi_version="2.0", plugins=[TestPlugin()])
-        metadata = spec.to_dict()
-        assert metadata["definitions"] == {
-            'TestSchema': {'properties': {'key': {'type': 'string'}}, 'type': 'object'}
+        spec = APISpec(
+            "Test API", version="0.0.1", openapi_version="2.0", plugins=[TestPlugin()]
+        )
+        assert get_schemas(spec) == {
+            "TestSchema": {"properties": {"key": {"type": "string"}}, "type": "object"}
         }
 
 


### PR DESCRIPTION
closes #538 

Note that I tried to manually follow flake8 as my corporate network is using a self signed certificate to perform "man in the middle" preventing Git to access flake8 repo on gitlab (so pre-commit was failing).