### PR TITLE
Optionally disable 'nullable' values to follow Typescript convention.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,3 +63,4 @@ Contributors (chronological)
 - Ashutosh Chaudhary `@codeasashu <https://github.com/codeasashu>`_
 - Fedor Fominykh `@fedorfo <https://github.com/fedorfo>`_
 - Colin Bounouar `@Colin-b <https://github.com/Colin-b>`_
+- Samuel Hoffstaetter `@h <https://github.com/h>`_

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -105,13 +105,22 @@ class MarshmallowPlugin(BasePlugin):
     Converter = OpenAPIConverter
     Resolver = SchemaResolver
 
-    def __init__(self, schema_name_resolver=None):
+    def __init__(self, schema_name_resolver=None, allow_null=True):
+        """
+        When `allow_null` is True, then None values can be represented either
+        with a `null` value, or by leaving the value empty.
+
+        When `allow_null` is False, then None values must be represented by
+        leaving the value empty (null is disallowed), which is the convention
+        followed by Typescript.
+        """
         super().__init__()
         self.schema_name_resolver = schema_name_resolver or resolver
         self.spec = None
         self.openapi_version = None
         self.converter = None
         self.resolver = None
+        self.allow_null = allow_null
 
     def init_spec(self, spec):
         super().init_spec(spec)
@@ -121,6 +130,7 @@ class MarshmallowPlugin(BasePlugin):
             openapi_version=spec.openapi_version,
             schema_name_resolver=self.schema_name_resolver,
             spec=spec,
+            allow_null=self.allow_null,
         )
         self.resolver = self.Resolver(
             openapi_version=spec.openapi_version, converter=self.converter

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -211,7 +211,9 @@ class FieldConverterMixin:
             ret["default"] = field.metadata["doc_default"]
         else:
             default = field.missing
-            if default is not marshmallow.missing and not callable(default):
+            if not self.allow_null and default is None:
+                return {}
+            elif default is not marshmallow.missing and not callable(default):
                 if MARSHMALLOW_VERSION_INFO[0] >= 3:
                     default = field._serialize(default, None, None)
                 ret["default"] = default
@@ -271,6 +273,9 @@ class FieldConverterMixin:
         :param Field field: A marshmallow field.
         :rtype: dict
         """
+        if not self.allow_null:
+            return {}
+
         attributes = {}
         if field.allow_none:
             attributes[

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -52,13 +52,14 @@ class OpenAPIConverter(FieldConverterMixin):
         spec
     """
 
-    def __init__(self, openapi_version, schema_name_resolver, spec):
+    def __init__(self, openapi_version, schema_name_resolver, spec, allow_null):
         self.openapi_version = OpenAPIVersion(openapi_version)
         self.schema_name_resolver = schema_name_resolver
         self.spec = spec
         self.init_attribute_functions()
         # Schema references
         self.refs = {}
+        self.allow_null = allow_null
 
     @staticmethod
     def _observed_name(field, name):


### PR DESCRIPTION
Previously, apispec.ext.marshmallow accepted both undefined and `null`
values for optional fields. This is different from the convention
followed by Typescript, which uses only undefined values in preference
over `null`.

See: https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#null-and-undefined

This commit adds an option called `allow_null` that enables the new
functionality. By default, the previous convention is followed for
backward compatibility.