### PR TITLE
Inheritance polymorphism

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,3 +63,4 @@ Contributors (chronological)
 - Ashutosh Chaudhary `@codeasashu <https://github.com/codeasashu>`_
 - Fedor Fominykh `@fedorfo <https://github.com/fedorfo>`_
 - Colin Bounouar `@Colin-b <https://github.com/Colin-b>`_
+- Leander Fiedler `@lfiedler <https://github.com/lfiedler>`_


### PR DESCRIPTION
This is a draft adressing issue #557. It is based on the pr #554. 

I copied the changes proposed there and adjusted them to the needs in #557. In particular, when cleaning `operations` it will now check for
keywords `allOf`. `anyOf`, `oneOf` and `not` at response or request contents. 
Depending on openapi version not all keywords are checked. The places at which are checked also depend on the version.