### PR TITLE
adding support for marshmallow_enun.EnumFields

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -13,7 +13,7 @@ import warnings
 
 import marshmallow
 from marshmallow.orderedset import OrderedSet
-
+import marshmallow_enum
 
 RegexType = type(re.compile(""))
 
@@ -101,6 +101,7 @@ class FieldConverterMixin:
             self.nested2properties,
             self.list2properties,
             self.dict2properties,
+            self.enum2properties,
         ]
 
     def map_to_openapi_type(self, *args):
@@ -458,3 +459,13 @@ class FieldConverterMixin:
                 if value_field:
                     ret["additionalProperties"] = self.field2property(value_field)
         return ret
+
+    def enum2properties(self, field, **kwargs):
+        """Return a dictionary of properties from :class:`Enum <marshmallow_enum.EnumField>` fields.
+
+        :param Field field: A marshmallow field.
+        :rtype: dict
+        """
+        if isinstance(field, marshmallow_enum.EnumField):
+            return {"type": "string", "enum": [m.value for m in field.enum]}
+        return {}

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -3,7 +3,9 @@ import json
 import pytest
 
 from marshmallow.fields import Field, DateTime, Dict, String, Nested, List
+from marshmallow_enum import EnumField
 from marshmallow import Schema
+from enum import Enum
 
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
@@ -880,3 +882,33 @@ class TestList:
 
         result = get_schemas(spec)["SchemaWithList"]["properties"]["list_field"]
         assert result == {"items": build_ref(spec, "schema", "Pet"), "type": "array"}
+
+
+class TestEnum:
+    def test_numeric_enum(self, spec):
+        class StopLight(Enum):
+            green = 1
+            yellow = 2
+            red = 3
+
+        class SchemaWithEnum(Schema):
+            enum_field = EnumField(StopLight)
+
+        spec.components.schema("SchemaWithEnum", schema=SchemaWithEnum)
+
+        result = get_schemas(spec)["SchemaWithEnum"]["properties"]["enum_field"]
+        assert result == {"type": "string", "enum": [1, 2, 3]}
+
+    def test_string_enum(self, spec):
+        class StopLight(Enum):
+            GREEN = "green"
+            YELLOW = "yellow"
+            RED = "red"
+
+        class SchemaWithEnum(Schema):
+            enum_field = EnumField(StopLight)
+
+        spec.components.schema("SchemaWithEnum", schema=SchemaWithEnum)
+
+        result = get_schemas(spec)["SchemaWithEnum"]["properties"]["enum_field"]
+        assert result == {"type": "string", "enum": ["green", "yellow", "red"]}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=
     py{35,36,37,38}-marshmallow2
     py{35,36,37,38}-marshmallow3
     py38-marshmallowdev
+    marshmallow_enum
     docs
 
 [testenv]


### PR DESCRIPTION
Adding support to the Marshmallow plugin to populate marshmallow_enum.EnumFields into openapi 'enum' statements. 

Note:  this introduces a dependency in the Marshmallow plugin to the marshmallow_enum library.  I think this is worth having to have automatic encoding of enum values.   If the dependency is a no-no I'll think about wrapping this as a plugin. 