### PR TITLE
Refactor openapi converter

### DIFF
--- a/src/apispec/ext/marshmallow/common.py
+++ b/src/apispec/ext/marshmallow/common.py
@@ -91,14 +91,16 @@ def filter_excluded_fields(fields, Meta, *, exclude_dump_only):
 
     :param dict fields: A dictionary of fields name field object pairs
     :param Meta: the schema's Meta class
-    :param bool exclude_dump_only: whether to filter fields in Meta.dump_only
+    :param bool exclude_dump_only: whether to filter dump_only fields
     """
     exclude = list(getattr(Meta, "exclude", []))
     if exclude_dump_only:
         exclude.extend(getattr(Meta, "dump_only", []))
 
     filtered_fields = OrderedDict(
-        (key, value) for key, value in fields.items() if key not in exclude
+        (key, value)
+        for key, value in fields.items()
+        if key not in exclude and not (exclude_dump_only and value.dump_only)
     )
 
     return filtered_fields

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -170,29 +170,11 @@ class OpenAPIConverter(FieldConverterMixin):
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject
         """
-        return self._property2parameter(
-            self.field2property(field),
-            name=name,
-            required=field.required,
-            multiple=isinstance(field, marshmallow.fields.List),
-            location=location,
-        )
-
-    def _property2parameter(self, prop, *, name, required, multiple, location):
-        """Return the Parameter Object definition for a JSON Schema property.
-
-        https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject
-
-        :param dict prop: JSON Schema property
-        :param str name: Field name
-        :param bool required: Parameter is required
-        :param bool multiple: Parameter is repeated
-        :param str location: Location to look for ``name``
-        :raise: TranslationError if arg object cannot be translated to a Parameter Object schema.
-        :rtype: dict, a Parameter Object
-        """
         openapi_location = __location_map__.get(location, location)
-        ret = {"in": openapi_location, "name": name, "required": required}
+        ret = {"in": openapi_location, "name": name, "required": field.required}
+
+        prop = self.field2property(field)
+        multiple = isinstance(field, marshmallow.fields.List)
 
         if self.openapi_version.major < 3:
             if multiple:

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -161,7 +161,6 @@ class OpenAPIConverter(FieldConverterMixin):
                 location=location,
             )
             for field_name, field_obj in fields.items()
-            if not field_obj.dump_only
         ]
 
     def _field2parameter(self, field, *, name, location):

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -122,11 +122,11 @@ class OpenAPIConverter(FieldConverterMixin):
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject
         """
-        openapi_location = __location_map__.get(location, location)
+        location = __location_map__.get(location, location)
         # OAS 2 body parameter
-        if openapi_location == "body":
+        if location == "body":
             param = {
-                "in": openapi_location,
+                "in": location,
                 "required": required,
                 "name": name,
                 "schema": self.resolve_nested_schema(schema),
@@ -156,8 +156,7 @@ class OpenAPIConverter(FieldConverterMixin):
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject
         """
-        openapi_location = __location_map__.get(location, location)
-        ret = {"in": openapi_location, "name": name, "required": field.required}
+        ret = {"in": location, "name": name, "required": field.required}
 
         prop = self.field2property(field)
         multiple = isinstance(field, marshmallow.fields.List)

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -117,6 +117,9 @@ class OpenAPIConverter(FieldConverterMixin):
         of a single parameter; else return an array of a parameter for each included field in
         the :class:`Schema <marshmallow.Schema>`.
 
+        In OpenAPI 3, only "query", "header", "path" or "cookie" are allowed for the location
+        of parameters. "requestBody" is used when fields are in the body.
+
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject
         """
         openapi_location = __location_map__.get(location, location)
@@ -138,22 +141,6 @@ class OpenAPIConverter(FieldConverterMixin):
 
         fields = get_fields(schema, exclude_dump_only=True)
 
-        return self._fields2parameters(fields, location=location)
-
-    def _fields2parameters(self, fields, *, location):
-        """Return an array of OpenAPI parameters given a mapping between field names and
-        :class:`Field <marshmallow.Field>` objects. If `location` is "body", then return an array
-        of a single parameter; else return an array of a parameter for each included field in
-        the :class:`Schema <marshmallow.Schema>`.
-
-        In OpenAPI 3, only "query", "header", "path" or "cookie" are allowed for the location
-        of parameters. In OpenAPI 3, "requestBody" is used when fields are in the body.
-
-        This function always returns a list, with a parameter
-        for each included field in the :class:`Schema <marshmallow.Schema>`.
-
-        https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameterObject
-        """
         return [
             self._field2parameter(
                 field_obj,

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -43,9 +43,7 @@ class TestMarshmallowFieldToOpenAPI:
         class UserSchema(Schema):
             name = fields.Str(dump_only=True)
 
-        res = openapi._fields2parameters(UserSchema._declared_fields, location="query")
-        assert len(res) == 0
-        res = openapi._fields2parameters(UserSchema().fields, location="query")
+        res = openapi.schema2parameters(schema=UserSchema(), location="query")
         assert len(res) == 0
 
         class UserSchema(Schema):
@@ -54,7 +52,7 @@ class TestMarshmallowFieldToOpenAPI:
             class Meta:
                 dump_only = ("name",)
 
-        res = openapi.schema2parameters(schema=UserSchema, location="query")
+        res = openapi.schema2parameters(schema=UserSchema(), location="query")
         assert len(res) == 0
 
 

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -219,7 +219,7 @@ class TestMarshmallowSchemaToParameters:
     @pytest.mark.parametrize("ListClass", [fields.List, CustomList])
     def test_field_multiple(self, ListClass, openapi):
         field = ListClass(fields.Str)
-        res = openapi._field2parameter(field, name="field", location="querystring")
+        res = openapi._field2parameter(field, name="field", location="query")
         assert res["in"] == "query"
         if openapi.openapi_version.major < 3:
             assert res["type"] == "array"
@@ -441,7 +441,7 @@ def test_openapi_tools_validate_v2():
                         field=fields.List(
                             fields.Str(), validate=validate.OneOf(["freddie", "roger"]),
                         ),
-                        location="querystring",
+                        location="query",
                         name="body",
                     ),
                 ]
@@ -497,7 +497,7 @@ def test_openapi_tools_validate_v3():
                         field=fields.List(
                             fields.Str(), validate=validate.OneOf(["freddie", "roger"]),
                         ),
-                        location="querystring",
+                        location="query",
                         name="body",
                     ),
                 ]

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -19,16 +19,6 @@ class TestMarshmallowFieldToOpenAPI:
         else:
             assert res[0]["schema"]["default"] == "bar"
 
-    def test_fields_location_mapping(self, openapi):
-        field_dict = {"field": fields.Str()}
-        res = openapi._fields2parameters(field_dict, location="cookies")
-        assert res[0]["in"] == "cookie"
-
-    def test_fields_default_location_mapping(self, openapi):
-        field_dict = {"field": fields.Str()}
-        res = openapi._fields2parameters(field_dict, location="headers")
-        assert res[0]["in"] == "header"
-
     # json/body is invalid for OpenAPI 3
     @pytest.mark.parametrize("openapi", ("2.0",), indirect=True)
     def test_fields_default_location_mapping_if_schema_many(self, openapi):

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -12,8 +12,10 @@ from .utils import get_schemas, build_ref
 
 class TestMarshmallowFieldToOpenAPI:
     def test_fields_with_missing_load(self, openapi):
-        field_dict = {"field": fields.Str(default="foo", missing="bar")}
-        res = openapi._fields2parameters(field_dict, location="query")
+        class MySchema(Schema):
+            field = fields.Str(default="foo", missing="bar")
+
+        res = openapi.schema2parameters(MySchema, location="query")
         if openapi.openapi_version.major < 3:
             assert res[0]["default"] == "bar"
         else:
@@ -313,8 +315,11 @@ class TestMarshmallowSchemaToParameters:
             openapi.schema2parameters(UserSchema(many=True), location="query")
 
     def test_fields_query(self, openapi):
-        field_dict = {"name": fields.Str(), "email": fields.Email()}
-        res = openapi._fields2parameters(field_dict, location="query")
+        class MySchema(Schema):
+            name = fields.Str()
+            email = fields.Email()
+
+        res = openapi.schema2parameters(MySchema, location="query")
         assert len(res) == 2
         res.sort(key=lambda param: param["name"])
         assert res[0]["name"] == "email"

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -13,7 +13,7 @@ from .utils import get_schemas, build_ref
 class TestMarshmallowFieldToOpenAPI:
     def test_fields_with_missing_load(self, openapi):
         field_dict = {"field": fields.Str(default="foo", missing="bar")}
-        res = openapi.fields2parameters(field_dict, location="query")
+        res = openapi._fields2parameters(field_dict, location="query")
         if openapi.openapi_version.major < 3:
             assert res[0]["default"] == "bar"
         else:
@@ -21,12 +21,12 @@ class TestMarshmallowFieldToOpenAPI:
 
     def test_fields_location_mapping(self, openapi):
         field_dict = {"field": fields.Str()}
-        res = openapi.fields2parameters(field_dict, location="cookies")
+        res = openapi._fields2parameters(field_dict, location="cookies")
         assert res[0]["in"] == "cookie"
 
     def test_fields_default_location_mapping(self, openapi):
         field_dict = {"field": fields.Str()}
-        res = openapi.fields2parameters(field_dict, location="headers")
+        res = openapi._fields2parameters(field_dict, location="headers")
         assert res[0]["in"] == "header"
 
     # json/body is invalid for OpenAPI 3
@@ -43,9 +43,9 @@ class TestMarshmallowFieldToOpenAPI:
         class UserSchema(Schema):
             name = fields.Str(dump_only=True)
 
-        res = openapi.fields2parameters(UserSchema._declared_fields, location="query")
+        res = openapi._fields2parameters(UserSchema._declared_fields, location="query")
         assert len(res) == 0
-        res = openapi.fields2parameters(UserSchema().fields, location="query")
+        res = openapi._fields2parameters(UserSchema().fields, location="query")
         assert len(res) == 0
 
         class UserSchema(Schema):
@@ -229,7 +229,7 @@ class TestMarshmallowSchemaToParameters:
     @pytest.mark.parametrize("ListClass", [fields.List, CustomList])
     def test_field_multiple(self, ListClass, openapi):
         field = ListClass(fields.Str)
-        res = openapi.field2parameter(field, name="field", location="querystring")
+        res = openapi._field2parameter(field, name="field", location="querystring")
         assert res["in"] == "query"
         if openapi.openapi_version.major < 3:
             assert res["type"] == "array"
@@ -243,7 +243,7 @@ class TestMarshmallowSchemaToParameters:
 
     def test_field_required(self, openapi):
         field = fields.Str(required=True)
-        res = openapi.field2parameter(field, name="field", location="query")
+        res = openapi._field2parameter(field, name="field", location="query")
         assert res["required"] is True
 
     def test_invalid_schema(self, openapi):
@@ -326,7 +326,7 @@ class TestMarshmallowSchemaToParameters:
 
     def test_fields_query(self, openapi):
         field_dict = {"name": fields.Str(), "email": fields.Email()}
-        res = openapi.fields2parameters(field_dict, location="query")
+        res = openapi._fields2parameters(field_dict, location="query")
         assert len(res) == 2
         res.sort(key=lambda param: param["name"])
         assert res[0]["name"] == "email"
@@ -444,7 +444,7 @@ def test_openapi_tools_validate_v2():
                         "required": True,
                         "type": "string",
                     },
-                    openapi.field2parameter(
+                    openapi._field2parameter(
                         field=fields.List(
                             fields.Str(), validate=validate.OneOf(["freddie", "roger"]),
                         ),
@@ -500,7 +500,7 @@ def test_openapi_tools_validate_v3():
                         "required": True,
                         "schema": {"type": "string"},
                     },
-                    openapi.field2parameter(
+                    openapi._field2parameter(
                         field=fields.List(
                             fields.Str(), validate=validate.OneOf(["freddie", "roger"]),
                         ),


### PR DESCRIPTION
Based on #526.

Implements refactor discussed in #500 and #526.

I did not address handling webargs field dicts (https://github.com/marshmallow-code/apispec/issues/500#issuecomment-570598012). It can be done later anytime (perhaps easier once MA2 is dropped).

Once #526 is merged, I can rebase this for a clearer diff.