### PR TITLE
Allow yaml dump options

### DIFF
--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -221,11 +221,14 @@ class APISpec:
         ret = deepupdate(ret, self.options)
         return ret
 
-    def to_yaml(self):
-        """Render the spec to YAML. Requires PyYAML to be installed."""
-        from .yaml_utils import dict_to_yaml
+    def to_yaml(self, **kwargs):
+        """Render the spec to YAML. Requires PyYAML to be installed.
 
-        return dict_to_yaml(self.to_dict())
+        :param dict kwargs: parameters used by :meth:`yaml.dump`
+        """
+        from .yaml_utils import yaml, YAMLDumper
+
+        return yaml.dump(self.to_dict(), Dumper=YAMLDumper, **kwargs)
 
     def tag(self, tag):
         """ Store information about a tag.

--- a/src/apispec/yaml_utils.py
+++ b/src/apispec/yaml_utils.py
@@ -15,10 +15,6 @@ class YAMLDumper(yaml.Dumper):
 yaml.add_representer(OrderedDict, YAMLDumper._represent_dict, Dumper=YAMLDumper)
 
 
-def dict_to_yaml(dic):
-    return yaml.dump(dic, Dumper=YAMLDumper)
-
-
 def load_yaml_from_docstring(docstring):
     """Loads YAML from docstring."""
     split_lines = trim_docstring(docstring).split("\n")


### PR DESCRIPTION
### What I did
I made `spec.to_yaml` accept keyword arguments and pass them to the `yaml.dump`.

### Why
It's good to have more control on the dump behavior. I write many chinese characters in the doc, and `allow_unicode=True` option can make generated yaml more readable.