### PR TITLE
feat: support fields metadata with non-string fields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,3 +63,4 @@ Contributors (chronological)
 - Ashutosh Chaudhary `@codeasashu <https://github.com/codeasashu>`_
 - Fedor Fominykh `@fedorfo <https://github.com/fedorfo>`_
 - Colin Bounouar `@Colin-b <https://github.com/Colin-b>`_
+- Andrea Ghensi `@sanzoghenzo <https://github.com/sanzoghenzo>`_

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -395,18 +395,16 @@ class FieldConverterMixin:
         """
         # Dasherize metadata that starts with x_
         metadata = {
-            key.replace("_", "-")
-            if isinstance(key, str) and key.startswith("x_")
-            else key: value
+            key.replace("_", "-") if key.startswith("x_") else key: value
             for key, value in field.metadata.items()
+            if isinstance(key, str)
         }
 
         # Avoid validation error with "Additional properties not allowed"
         ret = {
             key: value
             for key, value in metadata.items()
-            if key in _VALID_PROPERTIES
-            or (isinstance(key, str) and key.startswith(_VALID_PREFIX))
+            if key in _VALID_PROPERTIES or key.startswith(_VALID_PREFIX)
         }
         return ret
 

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -395,7 +395,7 @@ class FieldConverterMixin:
         """
         # Dasherize metadata that starts with x_
         metadata = {
-            key.replace("_", "-") if key.startswith("x_") else key: value
+            key.replace("_", "-") if str(key).startswith("x_") else key: value
             for key, value in field.metadata.items()
         }
 
@@ -403,7 +403,7 @@ class FieldConverterMixin:
         ret = {
             key: value
             for key, value in metadata.items()
-            if key in _VALID_PROPERTIES or key.startswith(_VALID_PREFIX)
+            if key in _VALID_PROPERTIES or str(key).startswith(_VALID_PREFIX)
         }
         return ret
 

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -395,7 +395,9 @@ class FieldConverterMixin:
         """
         # Dasherize metadata that starts with x_
         metadata = {
-            key.replace("_", "-") if str(key).startswith("x_") else key: value
+            key.replace("_", "-")
+            if isinstance(key, str) and key.startswith("x_")
+            else key: value
             for key, value in field.metadata.items()
         }
 
@@ -403,7 +405,8 @@ class FieldConverterMixin:
         ret = {
             key: value
             for key, value in metadata.items()
-            if key in _VALID_PROPERTIES or str(key).startswith(_VALID_PREFIX)
+            if key in _VALID_PROPERTIES
+            or (isinstance(key, str) and key.startswith(_VALID_PREFIX))
         }
         return ret
 

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -296,7 +296,6 @@ def test_custom_properties_for_custom_fields(spec_fixture):
 
 
 def test_field2property_with_non_string_metadata_keys(spec_fixture):
-
     class _DesertSentinel:
         pass
 

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -293,3 +293,14 @@ def test_custom_properties_for_custom_fields(spec_fixture):
     assert properties["x-customString"] == (
         spec_fixture.openapi.openapi_version == "2.0"
     )
+
+
+def test_field2property_with_non_string_metadata_keys(spec_fixture):
+
+    class _DesertSentinel:
+        pass
+
+    field = fields.Boolean(description="A description")
+    field.metadata[_DesertSentinel()] = "to be ignored"
+    result = spec_fixture.openapi.field2property(field)
+    assert result == {"description": "A description", "type": "boolean"}


### PR DESCRIPTION
This commit solves the issue that I wrongly filed to [flask-apispec repo](https://github.com/jmcarp/flask-apispec/issues/196).

Using desert to convert a dataclass/attrs class to a Schema, the metadata contains a non string key (_DesertSentinel) that causes the metadata2properties method to raise an AttributeError.

This quick fix uses str(key) in the two dict comprehensions to get the string representation of the key and return the dictionary.