### PR TITLE
Don't document int format as int32 and float format as float

### DIFF
--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -60,8 +60,7 @@ with `"x-"` (vendor extension).
     #                                      'format': 'date-time',
     #                                      'readOnly': True,
     #                                      'type': 'string'},
-    #                          'id': {'format': 'int32',
-    #                                 'readOnly': True,
+    #                          'id': {'readOnly': True,
     #                                 'type': 'integer'},
     #                          'name': {'description': "The user's name",
     #                                   'type': 'string'}},
@@ -140,7 +139,7 @@ class MarshmallowPlugin(BasePlugin):
             class MyCustomField(Integer):
                 # ...
 
-            @ma_plugin.map_to_openapi_type(Integer)  # will map to ('integer', 'int32')
+            @ma_plugin.map_to_openapi_type(Integer)  # will map to ('integer', None)
             class MyCustomFieldThatsKindaLikeAnInteger(Integer):
                 # ...
         """

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -19,9 +19,9 @@ RegexType = type(re.compile(""))
 
 # marshmallow field => (JSON Schema type, format)
 DEFAULT_FIELD_MAPPING = {
-    marshmallow.fields.Integer: ("integer", "int32"),
+    marshmallow.fields.Integer: ("integer", None),
     marshmallow.fields.Number: ("number", None),
-    marshmallow.fields.Float: ("number", "float"),
+    marshmallow.fields.Float: ("number", None),
     marshmallow.fields.Decimal: ("number", None),
     marshmallow.fields.String: ("string", None),
     marshmallow.fields.Boolean: ("boolean", None),

--- a/src/apispec/ext/marshmallow/schema_resolver.py
+++ b/src/apispec/ext/marshmallow/schema_resolver.py
@@ -38,7 +38,7 @@ class SchemaResolver:
 
             #Output
             [
-                {"in": "query", "name": "id", "required": False, "schema": {"type": "integer", "format": "int32"}},
+                {"in": "query", "name": "id", "required": False, "schema": {"type": "integer"}},
                 {"in": "query", "name": "name", "required": False, "schema": {"type": "string"}}
             ]
 

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -59,8 +59,6 @@ def test_formatted_field_translates_to_array(ListClass, spec_fixture):
 @pytest.mark.parametrize(
     ("FieldClass", "expected_format"),
     [
-        (fields.Integer, "int32"),
-        (fields.Float, "float"),
         (fields.UUID, "uuid"),
         (fields.DateTime, "date-time"),
         (fields.Date, "date"),


### PR DESCRIPTION
These are dependent on the machine running the code. We could try to play smart and use `sys` to adapt to the machine, but the doc might be generated on another machine than the one serving the code, so I don't think it is worth it.

Changing to int64 / double as it is the most common case.

Sort of "breaking" change. 4.0 would be the right moment for that.