### PR TITLE
Fix date range

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -290,17 +290,16 @@ class FieldConverterMixin:
         ]
 
         attributes = {}
-        for validator in validators:
-            if validator.min is not None:
-                if hasattr(attributes, "minimum"):
-                    attributes["minimum"] = max(attributes["minimum"], validator.min)
-                else:
-                    attributes["minimum"] = validator.min
-            if validator.max is not None:
-                if hasattr(attributes, "maximum"):
-                    attributes["maximum"] = min(attributes["maximum"], validator.max)
-                else:
-                    attributes["maximum"] = validator.max
+        min_list = [
+            validator.min for validator in validators if validator.min is not None
+        ]
+        max_list = [
+            validator.max for validator in validators if validator.max is not None
+        ]
+        if min_list:
+            attributes["minimum"] = max(min_list)
+        if max_list:
+            attributes["maximum"] = min(max_list)
         return attributes
 
     def field2length(self, field, **kwargs):
@@ -328,22 +327,22 @@ class FieldConverterMixin:
         min_attr = "minItems" if is_array else "minLength"
         max_attr = "maxItems" if is_array else "maxLength"
 
-        for validator in validators:
-            if validator.min is not None:
-                if hasattr(attributes, min_attr):
-                    attributes[min_attr] = max(attributes[min_attr], validator.min)
-                else:
-                    attributes[min_attr] = validator.min
-            if validator.max is not None:
-                if hasattr(attributes, max_attr):
-                    attributes[max_attr] = min(attributes[max_attr], validator.max)
-                else:
-                    attributes[max_attr] = validator.max
+        equal_list = [
+            validator.equal for validator in validators if validator.equal is not None
+        ]
+        if equal_list:
+            return {min_attr: equal_list[0], max_attr: equal_list[0]}
 
-        for validator in validators:
-            if validator.equal is not None:
-                attributes[min_attr] = validator.equal
-                attributes[max_attr] = validator.equal
+        min_list = [
+            validator.min for validator in validators if validator.min is not None
+        ]
+        max_list = [
+            validator.max for validator in validators if validator.max is not None
+        ]
+        if min_list:
+            attributes[min_attr] = max(min_list)
+        if max_list:
+            attributes[max_attr] = min(max_list)
         return attributes
 
     def field2pattern(self, field, **kwargs):

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -290,6 +290,11 @@ class FieldConverterMixin:
         ]
 
         attributes = {}
+        min_attr, max_attr = (
+            ("minimum", "maximum")
+            if marshmallow.fields.Number in type(field).mro()
+            else ("x-minimum", "x-maximum")
+        )
         min_list = [
             validator.min for validator in validators if validator.min is not None
         ]
@@ -297,9 +302,9 @@ class FieldConverterMixin:
             validator.max for validator in validators if validator.max is not None
         ]
         if min_list:
-            attributes["minimum"] = max(min_list)
+            attributes[min_attr] = max(min_list)
         if max_list:
-            attributes["maximum"] = min(max_list)
+            attributes[max_attr] = min(max_list)
         return attributes
 
     def field2length(self, field, **kwargs):

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -83,6 +83,8 @@ class FieldConverterMixin:
 
     def init_attribute_functions(self):
         self.attribute_functions = [
+            # self.field2type_and_format should run first
+            # as other functions may rely on its output
             self.field2type_and_format,
             self.field2default,
             self.field2choices,
@@ -272,7 +274,7 @@ class FieldConverterMixin:
             ] = True
         return attributes
 
-    def field2range(self, field, **kwargs):
+    def field2range(self, field, ret):
         """Return the dictionary of OpenAPI field attributes for a set of
         :class:`Range <marshmallow.validators.Range>` validators.
 
@@ -291,7 +293,7 @@ class FieldConverterMixin:
 
         min_attr, max_attr = (
             ("minimum", "maximum")
-            if marshmallow.fields.Number in type(field).mro()
+            if ret.get("type") in {"number", "integer"}
             else ("x-minimum", "x-maximum")
         )
         return make_min_max_attributes(validators, min_attr, max_attr)

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -498,6 +498,7 @@ class TestFieldValidation:
     class ValidationSchema(Schema):
         id = fields.Int(dump_only=True)
         range = fields.Int(validate=validate.Range(min=1, max=10))
+        range_no_upper = fields.Int(validate=validate.Range(min=1))
         multiple_ranges = fields.Int(
             validate=[
                 validate.Range(min=1),
@@ -528,6 +529,7 @@ class TestFieldValidation:
         ("field", "properties"),
         [
             ("range", {"minimum": 1, "maximum": 10}),
+            ("range_no_upper", {"minimum": 1}),
             ("multiple_ranges", {"minimum": 3, "maximum": 7}),
             ("list_length", {"minItems": 1, "maxItems": 10}),
             ("custom_list_length", {"minItems": 1, "maxItems": 10}),

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime
 
 from marshmallow import fields, Schema, validate
 
@@ -524,6 +525,7 @@ class TestFieldValidation:
         equal_length = fields.Str(
             validate=[validate.Length(equal=5), validate.Length(min=1, max=10)]
         )
+        date_range = fields.DateTime(validate=validate.Range(min=datetime(1900, 1, 1),))
 
     @pytest.mark.parametrize(
         ("field", "properties"),
@@ -537,6 +539,7 @@ class TestFieldValidation:
             ("custom_field_length", {"minLength": 1, "maxLength": 10}),
             ("multiple_lengths", {"minLength": 3, "maxLength": 7}),
             ("equal_length", {"minLength": 5, "maxLength": 5}),
+            ("date_range", {"x-minimum": datetime(1900, 1, 1)}),
         ],
     )
     def test_properties(self, field, properties, spec):

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -499,7 +499,7 @@ class TestFieldValidation:
     class ValidationSchema(Schema):
         id = fields.Int(dump_only=True)
         range = fields.Int(validate=validate.Range(min=1, max=10))
-        range_no_upper = fields.Int(validate=validate.Range(min=1))
+        range_no_upper = fields.Float(validate=validate.Range(min=1))
         multiple_ranges = fields.Int(
             validate=[
                 validate.Range(min=1),


### PR DESCRIPTION
Fixes #614.

Uses an OpenAPI extension to indicate a range if a field is not a number field such as a date. Also refactors the logic for creating range and length attributes.