### PR TITLE
Convert test usages of field metadata to new style

### DIFF
--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -3,14 +3,16 @@ from marshmallow import Schema, fields
 
 class PetSchema(Schema):
     description = dict(id="Pet id", name="Pet name", password="Password")
-    id = fields.Int(dump_only=True, description=description["id"])
+    id = fields.Int(dump_only=True, metadata=dict(description=description["id"]))
     name = fields.Str(
         required=True,
-        deprecated=False,
-        allowEmptyValue=False,
-        description=description["name"],
+        metadata=dict(
+            deprecated=False, allowEmptyValue=False, description=description["name"]
+        ),
     )
-    password = fields.Str(load_only=True, description=description["password"])
+    password = fields.Str(
+        load_only=True, metadata=dict(description=description["password"])
+    )
 
 
 class SampleSchema(Schema):
@@ -32,8 +34,8 @@ class AnalysisWithListSchema(Schema):
 
 
 class PatternedObjectSchema(Schema):
-    count = fields.Int(dump_only=True, **{"x-count": 1})
-    count2 = fields.Int(dump_only=True, x_count2=2)
+    count = fields.Int(dump_only=True, metadata={"x-count": 1})
+    count2 = fields.Int(dump_only=True, metadata=dict(x_count2=2))
 
 
 class SelfReferencingSchema(Schema):
@@ -55,9 +57,11 @@ class OrderedSchema(Schema):
 
 class DefaultValuesSchema(Schema):
     number_auto_default = fields.Int(missing=12)
-    number_manual_default = fields.Int(missing=12, doc_default=42)
+    number_manual_default = fields.Int(missing=12, metadata=dict(doc_default=42))
     string_callable_default = fields.Str(missing=lambda: "Callable")
-    string_manual_default = fields.Str(missing=lambda: "Callable", doc_default="Manual")
+    string_manual_default = fields.Str(
+        missing=lambda: "Callable", metadata=dict(doc_default="Manual")
+    )
     numbers = fields.List(fields.Int, missing=list)
 
 

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -1,12 +1,10 @@
 import pytest
-
-from marshmallow import fields, Schema, validate
-
+from apispec import APISpec, exceptions, utils
 from apispec.ext.marshmallow import MarshmallowPlugin
-from apispec import exceptions, utils, APISpec
+from marshmallow import Schema, fields, validate
 
 from .schemas import CustomList, CustomStringField
-from .utils import get_schemas, build_ref
+from .utils import build_ref, get_schemas
 
 
 class TestMarshmallowFieldToOpenAPI:
@@ -51,7 +49,7 @@ class TestMarshmallowSchemaToModelDefinition:
     def test_schema2jsonschema_with_explicit_fields(self, openapi):
         class UserSchema(Schema):
             _id = fields.Int()
-            email = fields.Email(description="email address of the user")
+            email = fields.Email(metadata=dict(description="email address of the user"))
             name = fields.Str()
 
             class Meta:
@@ -168,8 +166,10 @@ class TestMarshmallowSchemaToModelDefinition:
         class NotASchema:
             pass
 
-        expected_error = "{!r} doesn't have either `fields` or `_declared_fields`.".format(
-            NotASchema
+        expected_error = (
+            "{!r} doesn't have either `fields` or `_declared_fields`.".format(
+                NotASchema
+            )
         )
         with pytest.raises(ValueError, match=expected_error):
             openapi.schema2jsonschema(NotASchema)
@@ -287,8 +287,8 @@ class TestMarshmallowSchemaToParameters:
         class NotASchema:
             pass
 
-        expected_error = "{!r} doesn't have either `fields` or `_declared_fields`".format(
-            NotASchema
+        expected_error = (
+            "{!r} doesn't have either `fields` or `_declared_fields`".format(NotASchema)
         )
         with pytest.raises(ValueError, match=expected_error):
             openapi.schema2jsonschema(NotASchema)
@@ -395,7 +395,8 @@ def test_openapi_tools_validate_v2():
                     },
                     openapi._field2parameter(
                         field=fields.List(
-                            fields.Str(), validate=validate.OneOf(["freddie", "roger"]),
+                            fields.Str(),
+                            validate=validate.OneOf(["freddie", "roger"]),
                         ),
                         location="query",
                         name="body",
@@ -451,7 +452,8 @@ def test_openapi_tools_validate_v3():
                     },
                     openapi._field2parameter(
                         field=fields.List(
-                            fields.Str(), validate=validate.OneOf(["freddie", "roger"]),
+                            fields.Str(),
+                            validate=validate.OneOf(["freddie", "roger"]),
                         ),
                         location="query",
                         name="body",


### PR DESCRIPTION
Rather than passing extra keyword args, use `metadata=dict(...)`
This makes the tests only compatible with the latest version of marshmallow. (At time of writing, a PR branch, in fact.)

---

This is really meant as a counterpart to https://github.com/marshmallow-code/marshmallow/pull/1702
It can't merge until/unless that merges and releases. It would make the tests only compatible with very new versions of `marshmallow` though... So I'm not sure if we would want to do that or not? If we don't do this then the tests would start showing the deprecation warnings.

I didn't find any cases of metadata kwargs to fields being used in `docs/` but maybe I missed it.