### PR TITLE
Don't document kwargs as dict in docstrings

### DIFF
--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -90,7 +90,7 @@ class Components:
 
         :param str component_id: ref_id to use as reference
         :param dict component: response fields
-        :param dict kwargs: plugin-specific arguments
+        :param kwargs: plugin-specific arguments
         """
         if component_id in self._responses:
             raise DuplicateComponentNameError(
@@ -115,7 +115,7 @@ class Components:
         :param str param_id: identifier by which parameter may be referenced.
         :param str location: location of the parameter.
         :param dict component: parameter fields.
-        :param dict kwargs: plugin-specific arguments
+        :param kwargs: plugin-specific arguments
         """
         if component_id in self._parameters:
             raise DuplicateComponentNameError(
@@ -160,7 +160,7 @@ class Components:
         """Add a security scheme which can be referenced.
 
         :param str component_id: component_id to use as reference
-        :param dict kwargs: security scheme fields
+        :param dict component: security scheme fields
         """
         if component_id in self._security_schemes:
             raise DuplicateComponentNameError(
@@ -181,7 +181,7 @@ class APISpec:
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#infoObject
     :param str|OpenAPIVersion openapi_version: OpenAPI Specification version.
         Should be in the form '2.x' or '3.x.x' to comply with the OpenAPI standard.
-    :param dict options: Optional top-level keys
+    :param options: Optional top-level keys
         See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#openapi-object
     """
 
@@ -254,7 +254,7 @@ class APISpec:
         :param str summary: short summary relevant to all operations in this path
         :param str description: long description relevant to all operations in this path
         :param list|None parameters: list of parameters relevant to all operations in this path
-        :param dict kwargs: parameters used by any path helpers see :meth:`register_path_helper`
+        :param kwargs: parameters used by any path helpers see :meth:`register_path_helper`
         """
         # operations and parameters must be deepcopied because they are mutated
         # in clean_operations and operation helpers and path may be called twice

--- a/src/apispec/plugin.py
+++ b/src/apispec/plugin.py
@@ -18,7 +18,7 @@ class BasePlugin:
 
         :param str name: Identifier by which schema may be referenced
         :param dict definition: Schema definition
-        :param dict kwargs: All additional keywords arguments sent to `APISpec.schema()`
+        :param kwargs: All additional keywords arguments sent to `APISpec.schema()`
         """
         raise PluginMethodNotImplementedError
 
@@ -26,7 +26,7 @@ class BasePlugin:
         """May return response component description as a dict.
 
         :param dict response: Response fields
-        :param dict kwargs: All additional keywords arguments sent to `APISpec.response()`
+        :param kwargs: All additional keywords arguments sent to `APISpec.response()`
         """
         raise PluginMethodNotImplementedError
 
@@ -34,7 +34,7 @@ class BasePlugin:
         """May return parameter component description as a dict.
 
         :param dict parameter: Parameter fields
-        :param dict kwargs: All additional keywords arguments sent to `APISpec.parameter()`
+        :param kwargs: All additional keywords arguments sent to `APISpec.parameter()`
         """
         raise PluginMethodNotImplementedError
 
@@ -47,7 +47,7 @@ class BasePlugin:
         :param list parameters: A `list` of parameters objects or references for the path. See
             https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameterObject
             and https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#referenceObject
-        :param dict kwargs: All additional keywords arguments sent to `APISpec.path()`
+        :param kwargs: All additional keywords arguments sent to `APISpec.path()`
 
         Return value should be a string or None. If a string is returned, it
         is set as the path.
@@ -64,6 +64,6 @@ class BasePlugin:
         :param str path: Path to the resource
         :param dict operations: A `dict` mapping HTTP methods to operation object.
             See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operationObject
-        :param dict kwargs: All additional keywords arguments sent to `APISpec.path()`
+        :param kwargs: All additional keywords arguments sent to `APISpec.path()`
         """
         raise PluginMethodNotImplementedError


### PR DESCRIPTION
Fixes #534.

Apparently, the type indicated here is not the type of `kwargs` itself (always a `dict`) but the type of its values.

Also fixes a typo: doctstring reading `kwargs` instead of `component`.