### PR TITLE
Populate additionalProperties from Meta.unknown

### DIFF
--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -178,6 +178,8 @@ class OpenAPIConverter(FieldConverterMixin):
             jsonschema["title"] = Meta.title
         if hasattr(Meta, "description"):
             jsonschema["description"] = Meta.description
+        if hasattr(Meta, "unknown"):
+            jsonschema["additionalProperties"] = Meta.unknown == marshmallow.INCLUDE
 
         return jsonschema
 

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -1,7 +1,7 @@
 import pytest
 from datetime import datetime
 
-from marshmallow import fields, Schema, validate
+from marshmallow import fields, INCLUDE, RAISE, Schema, validate
 
 from apispec.ext.marshmallow import MarshmallowPlugin
 from apispec import exceptions, utils, APISpec
@@ -131,6 +131,26 @@ class TestMarshmallowSchemaToModelDefinition:
 
         res = openapi.schema2jsonschema(WhiteStripesSchema)
         assert set(res["properties"].keys()) == {"guitarist", "drummer"}
+
+    def test_unknown_values_disallow(self, openapi):
+        class UnknownRaiseSchema(Schema):
+            class Meta:
+                unknown = RAISE
+
+            first = fields.Str()
+
+        res = openapi.schema2jsonschema(UnknownRaiseSchema)
+        assert res["additionalProperties"] is False
+
+    def test_unknown_values_allow(self, openapi):
+        class UnknownIncludeSchema(Schema):
+            class Meta:
+                unknown = INCLUDE
+
+            first = fields.Str()
+
+        res = openapi.schema2jsonschema(UnknownIncludeSchema)
+        assert res["additionalProperties"] is True
 
     def test_only_explicitly_declared_fields_are_translated(self, openapi):
         class UserSchema(Schema):


### PR DESCRIPTION
Derive the value of additionalProperties from Meta.unknown, if defined.
additionalProperties will be true only if Meta.unknown == INCLUDE

Background here: https://marshmallow.readthedocs.io/en/stable/quickstart.html#handling-unknown-fields

If I am missing an existing way of doing this then I'll be happy to hear about it ...