### PR TITLE
Specify list parameters

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -67,3 +67,4 @@ Contributors (chronological)
 - David Bishop `@teancom <https://github.com/teancom>`_
 - Andrea Ghensi `@sanzoghenzo <https://github.com/sanzoghenzo>`_
 - `@timsilvers <https://github.com/timsilvers>`_
+- Simon Charbonneau `@simon19921 <https://github.com/simon19921>`_

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -70,6 +70,9 @@ _VALID_PROPERTIES = {
     "xml",
     "externalDocs",
     "example",
+    "collectionFormat",
+    "style",
+    "explode"
 }
 
 

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -153,7 +153,7 @@ class OpenAPIConverter(FieldConverterMixin):
             ret.update(prop)
         else:
             if multiple:
-                if prop.get("explode", None):
+                if prop.get("explode", None) is not None:
                     ret["explode"] = prop.pop("explode")
                 else:
                     ret["explode"] = True

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -146,12 +146,21 @@ class OpenAPIConverter(FieldConverterMixin):
 
         if self.openapi_version.major < 3:
             if multiple:
-                ret["collectionFormat"] = "multi"
+                if prop.get("collectionFormat", None):
+                    ret["collectionFormat"] = prop.pop("collectionFormat")
+                else:
+                    ret["collectionFormat"] = "multi"
             ret.update(prop)
         else:
             if multiple:
-                ret["explode"] = True
-                ret["style"] = "form"
+                if prop.get("explode", None):
+                    ret["explode"] = prop.pop("explode")
+                else:
+                    ret["explode"] = True
+                if prop.get("style", None):
+                    ret["style"] = prop.pop("style")
+                else:
+                    ret["style"] = "form"
             if prop.get("description", None):
                 ret["description"] = prop.pop("description")
             ret["schema"] = prop


### PR DESCRIPTION
This change is to allow users to specify the parameters for List fields instead of always using the default. It's specifically useful when working with webargs DelimitedFieldMixin fields allowing the query parameters format to be separated by a delimiter instead of just being exploded.