### PR TITLE
Allow to_yaml to pass options to yaml.dump

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -67,3 +67,4 @@ Contributors (chronological)
 - David Bishop `@teancom <https://github.com/teancom>`_
 - Andrea Ghensi `@sanzoghenzo <https://github.com/sanzoghenzo>`_
 - `@timsilvers <https://github.com/timsilvers>`_
+- Kangwook Lee `@pbzweihander <https://github.com/pbzweihander>`_

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -238,11 +238,14 @@ class APISpec:
         ret = deepupdate(ret, self.options)
         return ret
 
-    def to_yaml(self):
-        """Render the spec to YAML. Requires PyYAML to be installed."""
+    def to_yaml(self, yaml_dump_kwargs=None):
+        """Render the spec to YAML. Requires PyYAML to be installed.
+
+        :param dict yaml_dump_kwargs: Additional keyword arguments to pass to `yaml.dump`
+        """
         from .yaml_utils import dict_to_yaml
 
-        return dict_to_yaml(self.to_dict())
+        return dict_to_yaml(self.to_dict(), yaml_dump_kwargs)
 
     def tag(self, tag):
         """ Store information about a tag.

--- a/src/apispec/yaml_utils.py
+++ b/src/apispec/yaml_utils.py
@@ -15,8 +15,10 @@ class YAMLDumper(yaml.Dumper):
 yaml.add_representer(OrderedDict, YAMLDumper._represent_dict, Dumper=YAMLDumper)
 
 
-def dict_to_yaml(dic):
-    return yaml.dump(dic, Dumper=YAMLDumper)
+def dict_to_yaml(dic, yaml_dump_kwargs=None):
+    if yaml_dump_kwargs is None:
+        yaml_dump_kwargs = {}
+    return yaml.dump(dic, Dumper=YAMLDumper, **yaml_dump_kwargs)
 
 
 def load_yaml_from_docstring(docstring):

--- a/tests/test_yaml_utils.py
+++ b/tests/test_yaml_utils.py
@@ -26,3 +26,8 @@ def test_load_yaml_from_docstring_empty_docstring(docstring):
 @pytest.mark.parametrize("docstring", (None, "", "---"))
 def test_load_operations_from_docstring_empty_docstring(docstring):
     assert yaml_utils.load_operations_from_docstring(docstring) == {}
+
+
+def test_dict_to_yaml_unicode():
+    assert yaml_utils.dict_to_yaml({"가": "나"}) == '"\\uAC00": "\\uB098"\n'
+    assert yaml_utils.dict_to_yaml({"가": "나"}, {"allow_unicode": True}) == "가: 나\n"


### PR DESCRIPTION
When generating YAML with unicode, it is very annoying to have escaped unicode like `\uAC00`.

This PR allows `APISpec.to_yaml` method to pass additional options for `yaml.dump`.

With this PR, I can use options like `allow_unicode=True` to resolve the problem mention above.