### PR TITLE
Update field2pattern doc-string

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -68,3 +68,4 @@ Contributors (chronological)
 - Andrea Ghensi `@sanzoghenzo <https://github.com/sanzoghenzo>`_
 - `@timsilvers <https://github.com/timsilvers>`_
 - Kangwook Lee `@pbzweihander <https://github.com/pbzweihander>`_
+- Martijn Pieters `@mjpieters <https://github.com/mjpieters>`_

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -330,8 +330,11 @@ class FieldConverterMixin:
         return make_min_max_attributes(validators, min_attr, max_attr)
 
     def field2pattern(self, field, **kwargs):
-        """Return the dictionary of OpenAPI field attributes for a set of
-        :class:`Range <marshmallow.validators.Regexp>` validators.
+        """Return the dictionary of OpenAPI field attributes for a
+        :class:`Regexp <marshmallow.validators.Regexp>` validator.
+        
+        If there is more than one such validator, only the first
+        is used in the output spec.
 
         :param Field field: A marshmallow field.
         :rtype: dict

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -332,7 +332,7 @@ class FieldConverterMixin:
     def field2pattern(self, field, **kwargs):
         """Return the dictionary of OpenAPI field attributes for a
         :class:`Regexp <marshmallow.validators.Regexp>` validator.
-        
+
         If there is more than one such validator, only the first
         is used in the output spec.
 


### PR DESCRIPTION
The old doc-string is confusing:

- this applies to Regexp, not Range validators (the link is correct but the label is not)
- it only handles one Regexp per field, not a set.

This was probably a copy-paste error, this is the `field2pattern` doc-string with only the class reference updated and nothing else.