### PR TITLE
Setting Meta.unknown=EXCLUDE should leave additionalProperties unset. #659

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -63,9 +63,10 @@ Contributors (chronological)
 - Ashutosh Chaudhary `@codeasashu <https://github.com/codeasashu>`_
 - Fedor Fominykh `@fedorfo <https://github.com/fedorfo>`_
 - Colin Bounouar `@Colin-b <https://github.com/Colin-b>`_
-- Mikko Kortelainen `@kortsi <https://github.com/kortsi>
+- Mikko Kortelainen `@kortsi <https://github.com/kortsi>`_
 - David Bishop `@teancom <https://github.com/teancom>`_
 - Andrea Ghensi `@sanzoghenzo <https://github.com/sanzoghenzo>`_
 - `@timsilvers <https://github.com/timsilvers>`_
 - Kangwook Lee `@pbzweihander <https://github.com/pbzweihander>`_
 - Martijn Pieters `@mjpieters <https://github.com/mjpieters>`_
+- Duncan Booth `@kupuguy <https://github.com/kupuguy>`_

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -180,7 +180,7 @@ class OpenAPIConverter(FieldConverterMixin):
             jsonschema["title"] = Meta.title
         if hasattr(Meta, "description"):
             jsonschema["description"] = Meta.description
-        if hasattr(Meta, "unknown"):
+        if hasattr(Meta, "unknown") and Meta.unknown != marshmallow.EXCLUDE:
             jsonschema["additionalProperties"] = Meta.unknown == marshmallow.INCLUDE
 
         return jsonschema

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -1,7 +1,7 @@
 import pytest
 from datetime import datetime
 
-from marshmallow import fields, INCLUDE, RAISE, Schema, validate
+from marshmallow import EXCLUDE, fields, INCLUDE, RAISE, Schema, validate
 
 from apispec.ext.marshmallow import MarshmallowPlugin
 from apispec import exceptions, utils, APISpec
@@ -151,6 +151,16 @@ class TestMarshmallowSchemaToModelDefinition:
 
         res = openapi.schema2jsonschema(UnknownIncludeSchema)
         assert res["additionalProperties"] is True
+
+    def test_unknown_values_ignore(self, openapi):
+        class UnknownExcludeSchema(Schema):
+            class Meta:
+                unknown = EXCLUDE
+
+            first = fields.Str()
+
+        res = openapi.schema2jsonschema(UnknownExcludeSchema)
+        assert "additionalProperties" not in res
 
     def test_only_explicitly_declared_fields_are_translated(self, openapi):
         class UserSchema(Schema):


### PR DESCRIPTION
Meta.unknown has three states:

* INCLUDE permits additional properties so in openapi `additionalProperties: true`
* RAISE rejects additional properties so in openapi `additionalProperties: false`
* EXCLUDE allows additional properties to be present but ignores them so leaving additionalProperties unset is the nearest equivalent.

This PR adds support for the EXCLUDE state.
