### PR TITLE
Make the build reproducible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import os
 import sys
+import time
 
 sys.path.insert(0, os.path.abspath(os.path.join("..", "src")))
 import apispec  # noqa: E402
@@ -23,10 +24,14 @@ intersphinx_mapping = {
 
 issues_github_path = "marshmallow-code/apispec"
 
+build_date = dt.datetime.utcfromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+)
+
 source_suffix = ".rst"
 master_doc = "index"
 project = "apispec"
-copyright = f"Steven Loria {dt.datetime.utcnow():%Y}"
+copyright = f"Steven Loria {build_date:%Y}"
 
 version = release = apispec.__version__
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) I noticed that `apispec` could not be built reproducibly. This is due to the copyright message (configured in `docs/conf.py`) including the current build date. (I originally filed this in Debian as bug [#988978](https://bugs.debian.org/988978).)