### PR TITLE
Don't pass Field metadata as keyword arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ EXTRAS_REQUIRE = {
 EXTRAS_REQUIRE["tests"] = (
     EXTRAS_REQUIRE["yaml"]
     + EXTRAS_REQUIRE["validation"]
-    + ["marshmallow>=3.0.0", "pytest", "mock"]
+    + ["marshmallow>=3.10.0", "pytest", "mock"]
 )
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
 

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -66,8 +66,10 @@ class Components:
 
                 status = fields.String(
                     required=True,
-                    enum=['open', 'closed'],
-                    description='Status (open or closed)',
+                    metadata={
+                        "description": "Status (open or closed)",
+                        "enum": ["open", "closed"],
+                    },
                 )
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -48,9 +48,11 @@ with `"x-"` (vendor extension).
 
     class UserSchema(Schema):
         id = fields.Int(dump_only=True)
-        name = fields.Str(description="The user's name")
+        name = fields.Str(metadata={"description": "The user's name"})
         created = fields.DateTime(
-            dump_only=True, default=dt.datetime.utcnow, doc_default="The current datetime"
+            dump_only=True,
+            default=dt.datetime.utcnow,
+            metadata={"doc_default": "The current datetime"}
         )
 
 

--- a/tests/schemas.py
+++ b/tests/schemas.py
@@ -3,14 +3,18 @@ from marshmallow import Schema, fields
 
 class PetSchema(Schema):
     description = dict(id="Pet id", name="Pet name", password="Password")
-    id = fields.Int(dump_only=True, description=description["id"])
+    id = fields.Int(dump_only=True, metadata={"description": description["id"]})
     name = fields.Str(
         required=True,
-        deprecated=False,
-        allowEmptyValue=False,
-        description=description["name"],
+        metadata={
+            "description": description["name"],
+            "deprecated": False,
+            "allowEmptyValue": False,
+        },
     )
-    password = fields.Str(load_only=True, description=description["password"])
+    password = fields.Str(
+        load_only=True, metadata={"description": description["password"]}
+    )
 
 
 class SampleSchema(Schema):
@@ -32,8 +36,8 @@ class AnalysisWithListSchema(Schema):
 
 
 class PatternedObjectSchema(Schema):
-    count = fields.Int(dump_only=True, **{"x-count": 1})
-    count2 = fields.Int(dump_only=True, x_count2=2)
+    count = fields.Int(dump_only=True, metadata={"x-count": 1})
+    count2 = fields.Int(dump_only=True, metadata={"x_count2": 2})
 
 
 class SelfReferencingSchema(Schema):
@@ -55,9 +59,11 @@ class OrderedSchema(Schema):
 
 class DefaultValuesSchema(Schema):
     number_auto_default = fields.Int(missing=12)
-    number_manual_default = fields.Int(missing=12, doc_default=42)
+    number_manual_default = fields.Int(missing=12, metadata={"doc_default": 42})
     string_callable_default = fields.Str(missing=lambda: "Callable")
-    string_manual_default = fields.Str(missing=lambda: "Callable", doc_default="Manual")
+    string_manual_default = fields.Str(
+        missing=lambda: "Callable", metadata={"doc_default": "Manual"}
+    )
     numbers = fields.List(fields.Int, missing=list)
 
 

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -73,7 +73,7 @@ def test_field2property_formats(FieldClass, expected_format, spec_fixture):
 
 
 def test_field_with_description(spec_fixture):
-    field = fields.Str(description="a username")
+    field = fields.Str(metadata={"description": "a username"})
     res = spec_fixture.openapi.field2property(field)
     assert res["description"] == "a username"
 
@@ -103,13 +103,13 @@ def test_field_with_missing_callable(spec_fixture):
 
 
 def test_field_with_doc_default(spec_fixture):
-    field = fields.Str(doc_default="Manual default")
+    field = fields.Str(metadata={"doc_default": "Manual default"})
     res = spec_fixture.openapi.field2property(field)
     assert res["default"] == "Manual default"
 
 
 def test_field_with_doc_default_and_missing(spec_fixture):
-    field = fields.Int(doc_default=42, missing=12)
+    field = fields.Int(missing=12, metadata={"doc_default": 42})
     res = spec_fixture.openapi.field2property(field)
     assert res["default"] == 42
 
@@ -129,10 +129,12 @@ def test_field_with_equal(spec_fixture):
 def test_only_allows_valid_properties_in_metadata(spec_fixture):
     field = fields.Str(
         missing="foo",
-        description="foo",
-        enum=["red", "blue"],
-        allOf=["bar"],
-        not_valid="lol",
+        metadata={
+            "description": "foo",
+            "not_valid": "lol",
+            "allOf": ["bar"],
+            "enum": ["red", "blue"],
+        },
     )
     res = spec_fixture.openapi.field2property(field)
     assert res["default"] == field.missing
@@ -154,7 +156,7 @@ def test_field_with_choices_multiple(spec_fixture):
 
 
 def test_field_with_additional_metadata(spec_fixture):
-    field = fields.Str(minLength=6, maxLength=100)
+    field = fields.Str(metadata={"minLength": 6, "maxLength": 100})
     res = spec_fixture.openapi.field2property(field)
     assert res["maxLength"] == 100
     assert res["minLength"] == 6
@@ -201,9 +203,11 @@ def test_field2property_nested_spec_metadatas(spec_fixture):
     spec_fixture.spec.components.schema("Category", schema=CategorySchema)
     category = fields.Nested(
         CategorySchema,
-        description="A category",
-        invalid_property="not in the result",
-        x_extension="A great extension",
+        metadata={
+            "description": "A category",
+            "invalid_property": "not in the result",
+            "x_extension": "A great extension",
+        },
     )
     result = spec_fixture.openapi.field2property(category)
     assert result == {
@@ -292,7 +296,7 @@ def test_field2property_with_non_string_metadata_keys(spec_fixture):
     class _DesertSentinel:
         pass
 
-    field = fields.Boolean(description="A description")
+    field = fields.Boolean(metadata={"description": "A description"})
     field.metadata[_DesertSentinel()] = "to be ignored"
     result = spec_fixture.openapi.field2property(field)
     assert result == {"description": "A description", "type": "boolean"}

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -52,7 +52,7 @@ class TestMarshmallowSchemaToModelDefinition:
     def test_schema2jsonschema_with_explicit_fields(self, openapi):
         class UserSchema(Schema):
             _id = fields.Int()
-            email = fields.Email(description="email address of the user")
+            email = fields.Email(metadata={"description": "email address of the user"})
             name = fields.Str()
 
             class Meta:

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist=
 [testenv]
 extras = tests
 deps =
-    marshmallow3: marshmallow>=3.0.0,<4.0.0
+    marshmallow3: marshmallow>=3.10.0,<4.0.0
     marshmallowdev: https://github.com/marshmallow-code/marshmallow/archive/dev.tar.gz
 commands = pytest {posargs}
 


### PR DESCRIPTION
This is deprecated and generates warnings.