### PR TITLE
Add support for marshmallow.fields.Pluck()

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -96,6 +96,7 @@ class FieldConverterMixin:
             self.field2pattern,
             self.metadata2properties,
             self.nested2properties,
+            self.pluck2properties,
             self.list2properties,
             self.dict2properties,
         ]
@@ -402,13 +403,32 @@ class FieldConverterMixin:
         :param Field field: A marshmallow field.
         :rtype: dict
         """
-        if isinstance(field, marshmallow.fields.Nested):
+        # Pluck is a subclass of Nested but is in essence a single field; it
+        # is treated separately by pluck2properties.
+        if isinstance(field, marshmallow.fields.Nested) and not isinstance(
+            field, marshmallow.fields.Pluck
+        ):
             schema_dict = self.resolve_nested_schema(field.schema)
             if ret and "$ref" in schema_dict:
                 ret.update({"allOf": [schema_dict]})
             else:
                 ret.update(schema_dict)
         return ret
+
+    def pluck2properties(self, field, **kwargs):
+        """Return a dictionary of properties from :class:`Pluck <marshmallow.fields.Pluck` fields.
+
+        Pluck effectively trans-includes a field from another schema into this,
+        possibly wrapped in an array (`many=True`).
+
+        :param Field field: A marshmallow field.
+        :rtype: dict
+        """
+        if isinstance(field, marshmallow.fields.Pluck):
+            plucked_field = field.schema.fields[field.field_name]
+            ret = self.field2property(plucked_field)
+            return {"type": "array", "items": ret} if field.many else ret
+        return {}
 
     def list2properties(self, field, **kwargs):
         """Return a dictionary of properties from :class:`List <marshmallow.fields.List>` fields.

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -5,7 +5,7 @@ import pytest
 from marshmallow import fields, validate
 
 from .schemas import CategorySchema, CustomList, CustomStringField, CustomIntegerField
-from .utils import build_ref
+from .utils import build_ref, get_schemas
 
 
 def test_field2choices_preserving_order(openapi):
@@ -316,6 +316,52 @@ def test_nested_field_with_property(spec_fixture):
         "readOnly": True,
         "type": "array",
     }
+
+
+class TestField2PropertyPluck:
+    @pytest.fixture(autouse=True)
+    def _setup(self, spec_fixture):
+        self.field2property = spec_fixture.openapi.field2property
+
+        self.spec = spec_fixture.spec
+        self.spec.components.schema("Category", schema=CategorySchema)
+        self.unplucked = get_schemas(self.spec)["Category"]["properties"]["breed"]
+
+    def test_spec(self, spec_fixture):
+        breed = fields.Pluck(CategorySchema, "breed")
+        assert self.field2property(breed) == self.unplucked
+
+    def test_with_property(self):
+        breed = fields.Pluck(CategorySchema, "breed", dump_only=True)
+        assert self.field2property(breed) == {**self.unplucked, "readOnly": True}
+
+    def test_metadata(self):
+        breed = fields.Pluck(
+            CategorySchema,
+            "breed",
+            metadata={
+                "description": "Category breed",
+                "invalid_property": "not in the result",
+                "x_extension": "A great extension",
+            },
+        )
+        assert self.field2property(breed) == {
+            **self.unplucked,
+            "description": "Category breed",
+            "x-extension": "A great extension",
+        }
+
+    def test_many(self):
+        breed = fields.Pluck(CategorySchema, "breed", many=True)
+        assert self.field2property(breed) == {"type": "array", "items": self.unplucked}
+
+    def test_many_with_property(self):
+        breed = fields.Pluck(CategorySchema, "breed", many=True, dump_only=True)
+        assert self.field2property(breed) == {
+            "items": self.unplucked,
+            "type": "array",
+            "readOnly": True,
+        }
 
 
 def test_custom_properties_for_custom_fields(spec_fixture):


### PR DESCRIPTION
Pluck is essentially a transplanted field from another schema.

This PR extends the nested2properties method to special-case Pluck fields, and
should fix #459.
