### PR TITLE
Document TimeDelta field

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -29,6 +29,7 @@ DEFAULT_FIELD_MAPPING = {
     marshmallow.fields.DateTime: ("string", "date-time"),
     marshmallow.fields.Date: ("string", "date"),
     marshmallow.fields.Time: ("string", None),
+    marshmallow.fields.TimeDelta: ("integer", None),
     marshmallow.fields.Email: ("string", "email"),
     marshmallow.fields.URL: ("string", "url"),
     marshmallow.fields.Dict: ("object", None),

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -100,6 +100,7 @@ class FieldConverterMixin:
             self.pluck2properties,
             self.list2properties,
             self.dict2properties,
+            self.timedelta2properties,
         ]
 
     def map_to_openapi_type(self, *args):
@@ -458,6 +459,19 @@ class FieldConverterMixin:
             value_field = field.value_field
             if value_field:
                 ret["additionalProperties"] = self.field2property(value_field)
+        return ret
+
+    def timedelta2properties(self, field, **kwargs):
+        """Return a dictionary of properties from :class:`TimeDelta <marshmallow.fields.TimeDelta>` fields.
+
+        Adds a `x-unit` vendor property based on the field's `precision` attribute
+
+        :param Field field: A marshmallow field.
+        :rtype: dict
+        """
+        ret = {}
+        if isinstance(field, marshmallow.fields.TimeDelta):
+            ret["x-unit"] = field.precision
         return ret
 
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from marshmallow.fields import Field, DateTime, Dict, String, Nested, List
+from marshmallow.fields import Field, DateTime, Dict, String, Nested, List, TimeDelta
 from marshmallow import Schema
 
 from apispec import APISpec
@@ -1197,3 +1197,21 @@ class TestList:
 
         result = get_schemas(spec)["SchemaWithList"]["properties"]["list_field"]
         assert result == {"items": build_ref(spec, "schema", "Pet"), "type": "array"}
+
+
+class TestTimeDelta:
+    def test_timedelta_x_unit(self, spec):
+        class SchemaWithTimeDelta(Schema):
+            sec = TimeDelta("seconds")
+            day = TimeDelta("days")
+
+        spec.components.schema("SchemaWithTimeDelta", schema=SchemaWithTimeDelta)
+
+        assert (
+            get_schemas(spec)["SchemaWithTimeDelta"]["properties"]["sec"]["x-unit"]
+            == "seconds"
+        )
+        assert (
+            get_schemas(spec)["SchemaWithTimeDelta"]["properties"]["day"]["x-unit"]
+            == "days"
+        )

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -28,6 +28,7 @@ def test_field2choices_preserving_order(openapi):
         (fields.DateTime, "string"),
         (fields.Date, "string"),
         (fields.Time, "string"),
+        (fields.TimeDelta, "integer"),
         (fields.Email, "string"),
         (fields.URL, "string"),
         # Custom fields inherit types from their parents


### PR DESCRIPTION
Closes #631.

This adds a "x-unit" vendor attribute to document precision. I was reluctant to add a vendor attribute, but this is when vendor attributes are meant to, and the doc is relatively useless without it, unless the user adds a manual description. It shouldn't hurt anyway.