### PR TITLE
Fix links to PR and issues in the CHANGELOG file

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -71,3 +71,4 @@ Contributors (chronological)
 - Martijn Pieters `@mjpieters <https://github.com/mjpieters>`_
 - Duncan Booth `@kupuguy <https://github.com/kupuguy>`_
 - Luke Whitehorn `<https://github.com/Anti-Distinctlyminty>`_
+- François Magimel `<https://github.com/Linkid>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ Other changes:
 Bug fixes:
 
 - Respect ``partial`` marshmallow schema parameter: don't document the field as
-  required. (:issue: `627`). Thanks :user:`Anti-Distinctlyminty` for the PR.
+  required. (:issue:`627`). Thanks :user:`Anti-Distinctlyminty` for the PR.
 
 4.4.1 (2020-05-07)
 ******************
@@ -53,7 +53,7 @@ Features:
 - Allow ``to_yaml`` to pass kwargs to ``yaml.dump`` (:pr:`648`).
 - Resolve header references in responses (:pr:`650`).
 - Resolve example references in parameters, request bodies and responses
-  (:pr:`#651`).
+  (:pr:`651`).
 
 4.3.0 (2021-02-10)
 ******************


### PR DESCRIPTION
The PR 651 and the issue 627 have now a valid link.

Linkid is added to the AUTHORS file too.