### PR TITLE
Add pip-wheel-metadata/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+pip-wheel-metadata/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
Not sure where it comes from, it appears after executed `pip install -e ".[dev]"`.