### PR TITLE
Support passing `deprecated` in the metadata dict

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -71,6 +71,7 @@ _VALID_PROPERTIES = {
     "xml",
     "externalDocs",
     "example",
+    "deprecated",
 }
 
 


### PR DESCRIPTION
I didn't add the test since it's a manual field like `description`, `example`, and `externalDocs`.

By the way, it's a new field in OAS 3, should we do some special process for it? Maybe something like this:

```python
def field2deprecated(self, field, **kwargs):
    attributes = {}
    if "deprecated" in field.metadata and self.openapi_version.major >= 3:
        attributes["deprecated"] = True
    return attributes
```

If needed, I will add this method and the tests for it.