### PR TITLE
Correct spelling of 'null'

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -280,7 +280,7 @@ class FieldConverterMixin:
             elif self.openapi_version.minor < 1:
                 attributes["nullable"] = True
             else:
-                attributes["type"] = make_type_list(ret.get("type")) + ["'null'"]
+                attributes["type"] = [*make_type_list(ret.get("type")), "null"]
         return attributes
 
     def field2range(self, field, ret):

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -173,7 +173,7 @@ def test_field_with_allow_none(spec_fixture):
         assert res["nullable"] is True
     else:
         assert "nullable" not in res
-        assert res["type"] == ["string", "'null'"]
+        assert res["type"] == ["string", "null"]
 
 
 def test_field_with_dump_only(spec_fixture):
@@ -211,7 +211,7 @@ def test_field_with_range_string_type(spec_fixture, field):
 
 @pytest.mark.parametrize("spec_fixture", ("3.1.0",), indirect=True)
 def test_field_with_range_type_list_with_number(spec_fixture):
-    @spec_fixture.openapi.map_to_openapi_type(["integer", "'null'"], None)
+    @spec_fixture.openapi.map_to_openapi_type(["integer", "null"], None)
     class NullableInteger(fields.Field):
         """Nullable integer"""
 
@@ -219,12 +219,12 @@ def test_field_with_range_type_list_with_number(spec_fixture):
     res = spec_fixture.openapi.field2property(field)
     assert res["minimum"] == 1
     assert res["maximum"] == 10
-    assert res["type"] == ["integer", "'null'"]
+    assert res["type"] == ["integer", "null"]
 
 
 @pytest.mark.parametrize("spec_fixture", ("3.1.0",), indirect=True)
 def test_field_with_range_type_list_without_number(spec_fixture):
-    @spec_fixture.openapi.map_to_openapi_type(["string", "'null'"], None)
+    @spec_fixture.openapi.map_to_openapi_type(["string", "null"], None)
     class NullableInteger(fields.Field):
         """Nullable integer"""
 
@@ -232,7 +232,7 @@ def test_field_with_range_type_list_without_number(spec_fixture):
     res = spec_fixture.openapi.field2property(field)
     assert res["x-minimum"] == 1
     assert res["x-maximum"] == 10
-    assert res["type"] == ["string", "'null'"]
+    assert res["type"] == ["string", "null"]
 
 
 def test_field_with_str_regex(spec_fixture):


### PR DESCRIPTION
In OpenAPI 3.1, a nullable type has multiple values for the `type` field; the
base type string, and the string value `'null'`. The quotes are not part of the
value however, they are part of the serialisation format (so, `"null"` in
JSON).

Remove the extraneous quotes.

This fixes #689
