### PR TITLE
Don't build ref in resolve_nested_schema

### DIFF
--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -72,7 +72,7 @@ class OpenAPIConverter(FieldConverterMixin):
         # If schema is a string and is not found in registry,
         # assume it is a schema reference
         except marshmallow.exceptions.RegistryError:
-            return self.spec.components.get_ref("schema", schema)
+            return schema
         schema_key = make_schema_key(schema_instance)
         if schema_key not in self.refs:
             name = self.schema_name_resolver(schema)


### PR DESCRIPTION
This is now done in APISpec core. No need to do this from MarshmallowPlugin.

The exception to this is in `get_ref_dict`. If we remove this here and return a string, we're in trouble in `FieldConverterMixin.nested2properties` because we need to return a dict, not a string, by design of the converter class. It is not that bad. At least, we're using the method from APISpec core.