### PR TITLE
Lazy component registration

### DIFF
--- a/docs/special_topics.rst
+++ b/docs/special_topics.rst
@@ -76,6 +76,13 @@ The ``APISpec`` object contains helpers to add top-level components:
    * - Example
      - `spec.components.response <apispec.core.Components.example>`
      - 3
+   * - Security scheme
+     - `spec.components.response <apispec.core.Components.security_scheme>`
+     - 2, 3
+
+Most component registration methods provide a ``lazy`` keyword argument,
+allowing to define a component but only publish it in the generated
+documentation if it is actually referenced.
 
 To add other top-level objects, pass them to the ``APISpec`` as keyword arguments.
 
@@ -121,11 +128,6 @@ Here is an example that includes a `Server Object <https://github.com/OAI/OpenAP
 
     validate_spec(spec)
 
-
-When adding components, the main advantage of using dedicated methods over
-passing them as kwargs is the ability to use plugin helpers. For instance,
-`MarshmallowPlugin <apispec.ext.marshmallow.MarshmallowPlugin>` has helpers to
-resolve schemas in parameters and responses.
 
 Documenting Security Schemes
 ----------------------------


### PR DESCRIPTION
Add lazy component registration feature.

Allows to register components only if they are actually referenced in the spec.

This can be useful for a framework that defines headers (pagination, ETag header) before knowing if the feature is actually used in the code. It avoids defining useless components. E.g. https://github.com/marshmallow-code/flask-smorest/issues/236.

Security schemes are not included in the feature because they are a bit more tricky and I though it was not critical. But I wouldn't object to including them if someone is willing to implement that.