### PR TITLE
Drop Python 3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
   rev: v2.29.0
   hooks:
   - id: pyupgrade
-    args: [--py36-plus]
+    args: [--py37-plus]
 - repo: https://github.com/python/black
   rev: 21.10b0
   hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ jobs:
     toxenvs:
       - lint
 
-      - py36-marshmallow3
+      - py37-marshmallow3
       - py310-marshmallow3
       - py310-marshmallowdev
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,8 +1,6 @@
 Install
 =======
 
-**apispec** requires Python >= 3.6.
-
 From the PyPI
 -------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -72,8 +72,8 @@ To output your OpenAPI spec, invoke the `to_dict <apispec.APISpec.to_dict>` meth
     #           'title': 'Gisty',
     #           'version': '1.0.0'},
     #  'openapi': '3.0.2',
-    #  'paths': OrderedDict([('/gist/{gist_id}',
-    #                         {'get': {'responses': {'200': {'content': {'application/json': {'schema': {'$ref': '#/definitions/Gist'}}}}}}})]),
+    #  'paths': {'/gist/{gist_id}':
+    #               {'get': {'responses': {'200': {'content': {'application/json': {'schema': {'$ref': '#/definitions/Gist'}}}}}}}},
     #  'tags': []}
 
 Use `to_yaml <apispec.APISpec.to_yaml>` to export your spec to YAML.

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -100,7 +100,7 @@ The schema is now added to the spec.
     #           'title': 'Gisty',
     #           'version': '1.0.0'},
     #  'openapi': '3.0.2',
-    #  'paths': OrderedDict(),
+    #  'paths': {},
     #  'tags': []}
 
 Our application will have a Flask route for the gist detail endpoint.
@@ -156,14 +156,12 @@ Our OpenAPI spec now looks like this:
     #           'title': 'Gisty',
     #           'version': '1.0.0'},
     #  'openapi': '3.0.2',
-    #  'paths': OrderedDict([('/gists/{gist_id}',
-    #                         OrderedDict([('get',
-    #                                       {'parameters': [{'in': 'path',
+    #  'paths': {'/gists/{gist_id}': {'get': {'parameters': [{'in': 'path',
     #                                                        'name': 'gist_id',
     #                                                        'required': True,
     #                                                        'schema': {'format': 'int32',
     #                                                                   'type': 'integer'}}],
-    #                                        'responses': {200: {'content': {'application/json': {'schema': {'$ref': '#/components/schemas/Gist'}}}}}})]))]),
+    #                                         'responses': {200: {'content': {'application/json': {'schema': {'$ref': '#/components/schemas/Gist'}}}}}}}},
     #  'tags': []}
 
 If your API uses `method-based dispatching <http://flask.pocoo.org/docs/0.12/views/#method-based-dispatching>`_, the process is similar. Note that the method no longer needs to be included in the docstring.

--- a/docs/writing_plugins.rst
+++ b/docs/writing_plugins.rst
@@ -147,7 +147,7 @@ To use the plugin:
 
     spec.path(path="/gists/{gist_id}", func=gist_detail)
     print(dict(spec.to_dict()["paths"]))
-    # {'/gists/{gist_id}': OrderedDict([('get', {'responses': {200: {'content': {'application/json': {'schema': '#/definitions/Gist'}}}}})])}
+    # {'/gists/{gist_id}': {'get': {'responses': {200: {'content': {'application/json': {'schema': '#/definitions/Gist'}}}}}}}
 
 
 Next Steps

--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,10 @@ setup(
     license="MIT",
     zip_safe=False,
     keywords="apispec swagger openapi specification oas documentation spec rest api",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -1,5 +1,4 @@
 """Core apispec classes and functions."""
-from collections import OrderedDict
 from copy import deepcopy
 import warnings
 
@@ -312,7 +311,7 @@ class Components:
         if "requestBody" in operation:
             self._resolve_refs_in_request_body(operation["requestBody"])
         if "responses" in operation:
-            responses = OrderedDict()
+            responses = {}
             for code, response in operation["responses"].items():
                 response = self.get_ref("response", response)
                 self._resolve_refs_in_response(response)
@@ -363,7 +362,7 @@ class APISpec:
 
         # Metadata
         self._tags = []
-        self._paths = OrderedDict()
+        self._paths = {}
 
         # Components
         self.components = Components(self.plugins, self.openapi_version)
@@ -430,7 +429,7 @@ class APISpec:
         """
         # operations and parameters must be deepcopied because they are mutated
         # in _clean_operations and operation helpers and path may be called twice
-        operations = deepcopy(operations) or OrderedDict()
+        operations = deepcopy(operations) or {}
         parameters = deepcopy(parameters) or []
 
         # Execute path helpers
@@ -529,7 +528,7 @@ class APISpec:
                     operation["parameters"]
                 )
             if "responses" in operation:
-                responses = OrderedDict()
+                responses = {}
                 for code, response in operation["responses"].items():
                     try:
                         code = int(code)  # handles IntEnums like http.HTTPStatus

--- a/src/apispec/ext/marshmallow/common.py
+++ b/src/apispec/ext/marshmallow/common.py
@@ -2,7 +2,6 @@
 
 import copy
 import warnings
-from collections import OrderedDict
 
 import marshmallow
 
@@ -83,11 +82,11 @@ def filter_excluded_fields(fields, Meta, *, exclude_dump_only):
     if exclude_dump_only:
         exclude.extend(getattr(Meta, "dump_only", []))
 
-    filtered_fields = OrderedDict(
-        (key, value)
+    filtered_fields = {
+        key: value
         for key, value in fields.items()
         if key not in exclude and not (exclude_dump_only and value.dump_only)
-    )
+    }
 
     return filtered_fields
 

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -6,8 +6,6 @@ marshmallow :class:`Schemas <marshmallow.Schema>` and :class:`Fields <marshmallo
     This module is treated as private API.
     Users should not need to use this module directly.
 """
-from collections import OrderedDict
-
 import marshmallow
 from marshmallow.utils import is_collection
 
@@ -177,9 +175,8 @@ class OpenAPIConverter(FieldConverterMixin):
         fields = get_fields(schema)
         Meta = getattr(schema, "Meta", None)
         partial = getattr(schema, "partial", None)
-        ordered = getattr(Meta, "ordered", False)
 
-        jsonschema = self.fields2jsonschema(fields, partial=partial, ordered=ordered)
+        jsonschema = self.fields2jsonschema(fields, partial=partial)
 
         if hasattr(Meta, "title"):
             jsonschema["title"] = Meta.title
@@ -190,18 +187,17 @@ class OpenAPIConverter(FieldConverterMixin):
 
         return jsonschema
 
-    def fields2jsonschema(self, fields, *, ordered=False, partial=None):
+    def fields2jsonschema(self, fields, *, partial=None):
         """Return the JSON Schema Object given a mapping between field names and
         :class:`Field <marshmallow.Field>` objects.
 
         :param dict fields: A dictionary of field name field object pairs
-        :param bool ordered: Whether to preserve the order in which fields were declared
         :param bool|tuple partial: Whether to override a field's required flag.
             If `True` no fields will be set as required. If an iterable fields
             in the iterable will not be marked as required.
         :rtype: dict, a JSON Schema Object
         """
-        jsonschema = {"type": "object", "properties": OrderedDict() if ordered else {}}
+        jsonschema = {"type": "object", "properties": {}}
 
         for field_name, field_obj in fields.items():
             observed_field_name = field_obj.data_key or field_name

--- a/src/apispec/yaml_utils.py
+++ b/src/apispec/yaml_utils.py
@@ -1,24 +1,14 @@
 """YAML utilities"""
 
-from collections import OrderedDict
 import yaml
 
 from apispec.utils import trim_docstring, dedent
 
 
-class YAMLDumper(yaml.Dumper):
-    @staticmethod
-    def _represent_dict(dumper, instance):
-        return dumper.represent_mapping("tag:yaml.org,2002:map", instance.items())
-
-
-yaml.add_representer(OrderedDict, YAMLDumper._represent_dict, Dumper=YAMLDumper)
-
-
 def dict_to_yaml(dic, yaml_dump_kwargs=None):
     if yaml_dump_kwargs is None:
         yaml_dump_kwargs = {}
-    return yaml.dump(dic, Dumper=YAMLDumper, **yaml_dump_kwargs)
+    return yaml.dump(dic, **yaml_dump_kwargs)
 
 
 def load_yaml_from_docstring(docstring):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
 import copy
-from collections import OrderedDict
 from http import HTTPStatus
 
 import pytest
@@ -667,7 +666,7 @@ class TestPath(RefsSchemaTestMixin):
     def test_path_methods_maintain_order(self, spec):
         methods = ["get", "post", "put", "patch", "delete", "head", "options"]
         for method in methods:
-            spec.path(path="/path", operations=OrderedDict({method: {}}))
+            spec.path(path="/path", operations={method: {}})
         assert list(spec.to_dict()["paths"]["/path"]) == methods
 
     def test_path_merges_paths(self, spec):

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -1,5 +1,4 @@
 import pytest
-from collections import OrderedDict
 from datetime import datetime
 
 from marshmallow import EXCLUDE, fields, INCLUDE, RAISE, Schema, validate
@@ -102,21 +101,6 @@ class TestMarshmallowSchemaToModelDefinition:
 
         res = openapi.schema2jsonschema(BandSchema(partial=("drummer",)))
         assert res["required"] == ["bassist"]
-
-    @pytest.mark.parametrize("ordered_schema", (True, False))
-    def test_ordered(self, openapi, ordered_schema):
-        class BandSchema(Schema):
-            class Meta:
-                ordered = ordered_schema
-
-            drummer = fields.Str()
-            bassist = fields.Str()
-
-        res = openapi.schema2jsonschema(BandSchema)
-        assert isinstance(res["properties"], OrderedDict) == ordered_schema
-
-        res = openapi.schema2jsonschema(BandSchema())
-        assert isinstance(res["properties"], OrderedDict) == ordered_schema
 
     def test_no_required_fields(self, openapi):
         class BandSchema(Schema):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     lint
-    py{36,37,38,39,310}-marshmallow3
+    py{37,38,39,310}-marshmallow3
     py38-marshmallowdev
     docs
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     lint
     py{37,38,39,310}-marshmallow3
-    py38-marshmallowdev
+    py310-marshmallowdev
     docs
 
 [testenv]


### PR DESCRIPTION
- Drop Python 3.6.
- Don't use OrdereDict anymore since dict is ordered.

Python 3.6 EOLs on December 23rd 2021: https://endoflife.date/python