### PR TITLE
pre-commit: update black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
   - id: pyupgrade
     args: [--py36-plus]
 - repo: https://github.com/python/black
-  rev: 21.9b0
+  rev: 21.10b0
   hooks:
   - id: black
     language_version: python3
@@ -18,4 +18,4 @@ repos:
   rev: v1.11.0
   hooks:
   - id: blacken-docs
-    additional_dependencies: [black==20.8b1]
+    additional_dependencies: [black==21.10b0]


### PR DESCRIPTION
Fixes recent CI issues.

```py
Traceback (most recent call last):
  File "/home/vsts/.cache/pre-commit/repowxpdvt1h/py_env-python3/bin/blacken-docs", line 5, in <module>
    from blacken_docs import main
  File "/home/vsts/.cache/pre-commit/repowxpdvt1h/py_env-python3/lib/python3.9/site-packages/blacken_docs.py", line 13, in <module>
    import black
  File "/home/vsts/.cache/pre-commit/repowxpdvt1h/py_env-python3/lib/python3.9/site-packages/black/__init__.py", line 52, in <module>
    from typed_ast import ast3, ast27
  File "/home/vsts/.cache/pre-commit/repowxpdvt1h/py_env-python3/lib/python3.9/site-packages/typed_ast/ast3.py", line 40, in <module>
    from typed_ast import _ast3
ImportError: /home/vsts/.cache/pre-commit/repowxpdvt1h/py_env-python3/lib/python3.9/site-packages/typed_ast/_ast3.cpython-39-x86_64-linux-gnu.so: undefined symbol: _PyUnicode_DecodeUnicodeEscape
```