### PR TITLE
Drop deprecated distutils.version.LooseVersion in favor of packaging.…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ EXTRAS_REQUIRE["tests"] = (
 )
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
 
+INSTALL_REQUIRES = "packaging>=21.3"
+
 
 def find_version(fname):
     """Attempts to find the version number in the file names fname.
@@ -63,6 +65,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,
+    install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
     license="MIT",
     zip_safe=False,

--- a/src/apispec/utils.py
+++ b/src/apispec/utils.py
@@ -115,16 +115,25 @@ class OpenAPIVersion(Version):
             raise exceptions.APISpecError(
                 f"Not a valid OpenAPI version number: {openapi_version}"
             )
+
+        # Ensure compatibility with distutils.version.LooseVersion
+        self.version = [
+            openapi_version.major,
+            openapi_version.minor,
+            openapi_version.micro,
+        ]
         openapi_version = str(openapi_version)
         super().__init__(openapi_version)
 
     def __eq__(self, version: Version | str):
         return str(self) == str(version)
 
+    # Ensure compatibility with distutils.version.LooseVersion
     @property
     def vstring(self) -> str:
         return str(self)
 
+    # Ensure compatibility with distutils.version.LooseVersion
     @property
     def patch(self) -> str:
         return self.micro

--- a/src/apispec/utils.py
+++ b/src/apispec/utils.py
@@ -8,7 +8,7 @@ import re
 import json
 import typing
 
-from distutils import version
+from packaging.version import Version
 
 from apispec import exceptions
 
@@ -83,7 +83,7 @@ def validate_spec(spec: APISpec) -> bool:
         return True
 
 
-class OpenAPIVersion(version.LooseVersion):
+class OpenAPIVersion(Version):
     """OpenAPI version
 
     :param str|OpenAPIVersion openapi_version: OpenAPI version
@@ -101,11 +101,11 @@ class OpenAPIVersion(version.LooseVersion):
             assert str(ver) == '3.0.2'
     """
 
-    MIN_INCLUSIVE_VERSION = version.LooseVersion("2.0")
-    MAX_EXCLUSIVE_VERSION = version.LooseVersion("4.0")
+    MIN_INCLUSIVE_VERSION = Version("2.0")
+    MAX_EXCLUSIVE_VERSION = Version("4.0")
 
-    def __init__(self, openapi_version: version.LooseVersion | str) -> None:
-        if isinstance(openapi_version, version.LooseVersion):
+    def __init__(self, openapi_version: Version | str) -> None:
+        if isinstance(openapi_version, Version):
             openapi_version = openapi_version.vstring
         if (
             not self.MIN_INCLUSIVE_VERSION

--- a/src/apispec/utils.py
+++ b/src/apispec/utils.py
@@ -73,7 +73,7 @@ def validate_spec(spec: APISpec) -> bool:
             "    pip install 'apispec[validation]'"
         )
     parser_kwargs = {}
-    if spec.openapi_version.version[0] == 3:
+    if spec.openapi_version.major == 3:
         parser_kwargs["backend"] = "openapi-spec-validator"
     try:
         prance.BaseParser(spec_string=json.dumps(spec.to_dict()), **parser_kwargs)
@@ -105,8 +105,8 @@ class OpenAPIVersion(Version):
     MAX_EXCLUSIVE_VERSION = Version("4.0")
 
     def __init__(self, openapi_version: Version | str) -> None:
-        if isinstance(openapi_version, Version):
-            openapi_version = openapi_version.vstring
+        if isinstance(openapi_version, str):
+            openapi_version = Version(openapi_version)
         if (
             not self.MIN_INCLUSIVE_VERSION
             <= openapi_version
@@ -115,19 +115,19 @@ class OpenAPIVersion(Version):
             raise exceptions.APISpecError(
                 f"Not a valid OpenAPI version number: {openapi_version}"
             )
+        openapi_version = str(openapi_version)
         super().__init__(openapi_version)
 
-    @property
-    def major(self) -> int:
-        return int(self.version[0])
+    def __eq__(self, version: Version | str):
+        return str(self) == str(version)
 
     @property
-    def minor(self) -> int:
-        return int(self.version[1])
+    def vstring(self) -> str:
+        return str(self)
 
     @property
-    def patch(self) -> int:
-        return int(self.version[2])
+    def patch(self) -> str:
+        return self.micro
 
 
 # from django.contrib.admindocs.utils


### PR DESCRIPTION
distutils.version.LooseVersion has been deprecated, instead use packaging.version.Version