### PR TITLE
Fix the type of the `path` arg of `APISpec.path()`

### DIFF
--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -467,7 +467,7 @@ class APISpec:
 
     def path(
         self,
-        path: dict | None = None,
+        path: str | None = None,
         *,
         operations: dict[str, typing.Any] | None = None,
         summary: str | None = None,


### PR DESCRIPTION
dict -> str