### PR TITLE
Set default yaml.dump sort_keys to False to respect dictionary order

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -74,4 +74,4 @@ Contributors (chronological)
 - François Magimel `<https://github.com/Linkid>`_
 - Stefan van der Walt `<https://github.com/stefanv>`_
 - `<https://github.com/kasium>`_
-- Edwin Erdmanis `@vorticity <https://github.com/vorticity>`
+- Edwin Erdmanis `@vorticity <https://github.com/vorticity>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -74,3 +74,4 @@ Contributors (chronological)
 - François Magimel `<https://github.com/Linkid>`_
 - Stefan van der Walt `<https://github.com/stefanv>`_
 - `<https://github.com/kasium>`_
+- Edwin Erdmanis `@vorticity <https://github.com/vorticity>`

--- a/src/apispec/yaml_utils.py
+++ b/src/apispec/yaml_utils.py
@@ -9,8 +9,11 @@ from apispec.utils import trim_docstring, dedent
 
 
 def dict_to_yaml(dic: dict, yaml_dump_kwargs: typing.Any | None = None) -> str:
-    if yaml_dump_kwargs is None:
-        yaml_dump_kwargs = {}
+    """Serializes a dictionary to YAML."""
+    yaml_dump_kwargs = yaml_dump_kwargs or {}
+
+    # By default, don't sort alphabetically to respect schema field ordering
+    yaml_dump_kwargs.setdefault("sort_keys", False)
     return yaml.dump(dic, **yaml_dump_kwargs)
 
 

--- a/tests/test_yaml_utils.py
+++ b/tests/test_yaml_utils.py
@@ -31,3 +31,16 @@ def test_load_operations_from_docstring_empty_docstring(docstring):
 def test_dict_to_yaml_unicode():
     assert yaml_utils.dict_to_yaml({"가": "나"}) == '"\\uAC00": "\\uB098"\n'
     assert yaml_utils.dict_to_yaml({"가": "나"}, {"allow_unicode": True}) == "가: 나\n"
+
+
+def test_dict_to_yaml_keys_are_not_sorted_by_default():
+    assert yaml_utils.dict_to_yaml({"herp": 1, "derp": 2}) == "herp: 1\nderp: 2\n"
+
+
+def test_dict_to_yaml_keys_can_be_sorted_with_yaml_dump_kwargs():
+    assert (
+        yaml_utils.dict_to_yaml(
+            {"herp": 1, "derp": 2}, yaml_dump_kwargs={"sort_keys": True}
+        )
+        == "derp: 2\nherp: 1\n"
+    )


### PR DESCRIPTION
Implemented fix proposed by @lafrech https://github.com/marshmallow-code/apispec/issues/768#issuecomment-1123292470