### PR TITLE
Pin openapi_spec_validator<0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 EXTRAS_REQUIRE = {
     "marshmallow": ["marshmallow>=3.13.0"],
     "yaml": ["PyYAML>=3.10"],
-    "validation": ["prance[osv]>=0.11"],
+    "validation": ["prance[osv]>=0.11", "openapi_spec_validator<0.5"],
     "lint": [
         "flake8==5.0.4",
         "flake8-bugbear==22.8.22",


### PR DESCRIPTION
Current prance version is not compatible with openapi_spec_validator 0.5 ([issue](https://github.com/RonnyPfannschmidt/prance/issues/131), [PR](https://github.com/RonnyPfannschmidt/prance/pull/132)).

This fixes CI issues and the validation feature for now. We may update versions or just revert this change when prance is fixed.