### PR TITLE
Use packaging.Version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import re
 from setuptools import setup, find_packages
 
+INSTALL_REQUIRES = "packaging>=21.3"
+
 EXTRAS_REQUIRE = {
     "marshmallow": ["marshmallow>=3.13.0"],
     "yaml": ["PyYAML>=3.10"],
@@ -63,6 +65,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,
+    install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
     license="MIT",
     zip_safe=False,

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -74,11 +74,11 @@ from __future__ import annotations
 
 import warnings
 import typing
+from packaging.version import Version
 
 from marshmallow import Schema
 
 from apispec import BasePlugin, APISpec
-from apispec.utils import OpenAPIVersion
 from .common import resolve_schema_instance, make_schema_key, resolve_schema_cls
 from .openapi import OpenAPIConverter
 from .schema_resolver import SchemaResolver
@@ -120,7 +120,7 @@ class MarshmallowPlugin(BasePlugin):
         super().__init__()
         self.schema_name_resolver = schema_name_resolver or resolver
         self.spec: APISpec | None = None
-        self.openapi_version: OpenAPIVersion | None = None
+        self.openapi_version: Version | None = None
         self.converter: OpenAPIConverter | None = None
         self.resolver: SchemaResolver | None = None
 

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -11,11 +11,10 @@ import functools
 import operator
 import typing
 import warnings
+from packaging.version import Version
 
 import marshmallow
 from marshmallow.orderedset import OrderedSet
-
-from apispec.utils import OpenAPIVersion
 
 
 RegexType = type(re.compile(""))
@@ -90,7 +89,7 @@ class FieldConverterMixin:
     """Adds methods for converting marshmallow fields to an OpenAPI properties."""
 
     field_mapping = DEFAULT_FIELD_MAPPING
-    openapi_version: OpenAPIVersion
+    openapi_version: Version
 
     def init_attribute_functions(self):
         self.attribute_functions = [

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -9,12 +9,12 @@ marshmallow :class:`Schemas <marshmallow.Schema>` and :class:`Fields <marshmallo
 
 from __future__ import annotations
 import typing
+from packaging.version import Version
 
 import marshmallow
 from marshmallow.utils import is_collection
 
 from apispec import APISpec
-from apispec.utils import OpenAPIVersion
 from apispec.exceptions import APISpecError
 from .field_converter import FieldConverterMixin
 from .common import (
@@ -40,7 +40,7 @@ __location_map__ = {
 class OpenAPIConverter(FieldConverterMixin):
     """Adds methods for generating OpenAPI specification from marshmallow schemas and fields.
 
-    :param str|OpenAPIVersion openapi_version: The OpenAPI version to use.
+    :param Version openapi_version: The OpenAPI version to use.
         Should be in the form '2.x' or '3.x.x' to comply with the OpenAPI standard.
     :param callable schema_name_resolver: Callable to generate the schema definition name.
         Receives the `Schema` class and returns the name to be used in refs within
@@ -52,11 +52,11 @@ class OpenAPIConverter(FieldConverterMixin):
 
     def __init__(
         self,
-        openapi_version: OpenAPIVersion | str,
+        openapi_version: Version,
         schema_name_resolver,
         spec: APISpec,
     ) -> None:
-        self.openapi_version = OpenAPIVersion(openapi_version)
+        self.openapi_version = openapi_version
         self.schema_name_resolver = schema_name_resolver
         self.spec = spec
         self.init_attribute_functions()

--- a/src/apispec/utils.py
+++ b/src/apispec/utils.py
@@ -8,8 +8,6 @@ import re
 import json
 import typing
 
-from distutils import version
-
 from apispec import exceptions
 
 if typing.TYPE_CHECKING:
@@ -73,7 +71,7 @@ def validate_spec(spec: APISpec) -> bool:
             "    pip install 'apispec[validation]'"
         ) from error
     parser_kwargs = {}
-    if spec.openapi_version.version[0] == 3:
+    if spec.openapi_version.major == 3:
         parser_kwargs["backend"] = "openapi-spec-validator"
     try:
         prance.BaseParser(spec_string=json.dumps(spec.to_dict()), **parser_kwargs)
@@ -81,53 +79,6 @@ def validate_spec(spec: APISpec) -> bool:
         raise exceptions.OpenAPIError(*err.args) from err
     else:
         return True
-
-
-class OpenAPIVersion(version.LooseVersion):
-    """OpenAPI version
-
-    :param str|OpenAPIVersion openapi_version: OpenAPI version
-
-    Parses an OpenAPI version expressed as string. Provides shortcut to digits
-    (major, minor, patch).
-
-        Example: ::
-
-            ver = OpenAPIVersion('3.0.2')
-            assert ver.major == 3
-            assert ver.minor == 0
-            assert ver.patch == 1
-            assert ver.vstring == '3.0.2'
-            assert str(ver) == '3.0.2'
-    """
-
-    MIN_INCLUSIVE_VERSION = version.LooseVersion("2.0")
-    MAX_EXCLUSIVE_VERSION = version.LooseVersion("4.0")
-
-    def __init__(self, openapi_version: version.LooseVersion | str) -> None:
-        if isinstance(openapi_version, version.LooseVersion):
-            openapi_version = openapi_version.vstring
-        if (
-            not self.MIN_INCLUSIVE_VERSION
-            <= openapi_version
-            < self.MAX_EXCLUSIVE_VERSION
-        ):
-            raise exceptions.APISpecError(
-                f"Not a valid OpenAPI version number: {openapi_version}"
-            )
-        super().__init__(openapi_version)
-
-    @property
-    def major(self) -> int:
-        return int(self.version[0])
-
-    @property
-    def minor(self) -> int:
-        return int(self.version[1])
-
-    @property
-    def patch(self) -> int:
-        return int(self.version[2])
 
 
 # from django.contrib.admindocs.utils

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -148,10 +148,10 @@ class TestMetadata:
         assert metadata["info"]["version"] == "1.0.0"
         assert metadata["info"]["description"] == description
         if spec.openapi_version.major < 3:
-            assert metadata["swagger"] == spec.openapi_version.vstring
+            assert metadata["swagger"] == str(spec.openapi_version)
             assert metadata["security"] == [{"apiKey": []}]
         else:
-            assert metadata["openapi"] == spec.openapi_version.vstring
+            assert metadata["openapi"] == str(spec.openapi_version)
             security_schemes = {
                 "bearerAuth": dict(type="http", scheme="bearer", bearerFormat="JWT")
             }

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -398,7 +398,7 @@ def test_custom_properties_for_custom_fields(spec_fixture):
         CustomStringField()
     )
     assert properties["x-customString"] == (
-        spec_fixture.openapi.openapi_version == "2.0"
+        spec_fixture.openapi.openapi_version.major == 2
     )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,27 +1,4 @@
-import pytest
-
 from apispec import utils
-from apispec.exceptions import APISpecError
-
-
-class TestOpenAPIVersion:
-    @pytest.mark.parametrize("version", ("1.0", "4.0"))
-    def test_openapi_version_invalid_version(self, version):
-        message = "Not a valid OpenAPI version number:"
-        with pytest.raises(APISpecError, match=message):
-            utils.OpenAPIVersion(version)
-
-    @pytest.mark.parametrize("version", ("3.0.1", utils.OpenAPIVersion("3.0.1")))
-    def test_openapi_version_string_or_openapi_version_param(self, version):
-        assert utils.OpenAPIVersion(version) == utils.OpenAPIVersion("3.0.1")
-
-    def test_openapi_version_digits(self):
-        ver = utils.OpenAPIVersion("3.0.1")
-        assert ver.major == 3
-        assert ver.minor == 0
-        assert ver.patch == 1
-        assert ver.vstring == "3.0.1"
-        assert str(ver) == "3.0.1"
 
 
 def test_build_reference():


### PR DESCRIPTION
Removes utils.OpenAPIVersion and use of deprecated distutils.version.LooseVersion

Replaces #759.
Closes #739.