### PR TITLE
Remove validate_spec from public API

### DIFF
--- a/src/apispec/utils.py
+++ b/src/apispec/utils.py
@@ -5,13 +5,6 @@ the OpenAPI spec.
 from __future__ import annotations
 
 import re
-import json
-import typing
-
-from apispec import exceptions
-
-if typing.TYPE_CHECKING:
-    from apispec.core import APISpec
 
 
 COMPONENT_SUBSECTIONS = {
@@ -48,37 +41,6 @@ def build_reference(
             component_name,
         )
     }
-
-
-def validate_spec(spec: APISpec) -> bool:
-    """Validate the output of an :class:`APISpec` object against the
-    OpenAPI specification.
-
-    Note: Requires installing apispec with the ``[validation]`` extras.
-    ::
-
-        pip install 'apispec[validation]'
-
-    :raise: apispec.exceptions.OpenAPIError if validation fails.
-    """
-    try:
-        import prance
-    except ImportError as error:  # re-raise with a more verbose message
-        exc_class = type(error)
-        raise exc_class(
-            "validate_spec requires prance to be installed. "
-            "You can install all validation requirements using:\n"
-            "    pip install 'apispec[validation]'"
-        ) from error
-    parser_kwargs = {}
-    if spec.openapi_version.major == 3:
-        parser_kwargs["backend"] = "openapi-spec-validator"
-    try:
-        prance.BaseParser(spec_string=json.dumps(spec.to_dict()), **parser_kwargs)
-    except prance.ValidationError as err:
-        raise exceptions.OpenAPIError(*err.args) from err
-    else:
-        return True
 
 
 # from django.contrib.admindocs.utils

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -1,13 +1,14 @@
-import pytest
 from datetime import datetime
+
+import pytest
 
 from marshmallow import EXCLUDE, fields, INCLUDE, RAISE, Schema, validate
 
 from apispec.ext.marshmallow import MarshmallowPlugin
-from apispec import exceptions, utils, APISpec
+from apispec import exceptions, APISpec
 
 from .schemas import CustomList, CustomStringField
-from .utils import get_schemas, build_ref
+from .utils import get_schemas, build_ref, validate_spec
 
 
 class TestMarshmallowFieldToOpenAPI:
@@ -533,7 +534,7 @@ def test_openapi_tools_validate_v2():
         },
     )
     try:
-        utils.validate_spec(spec)
+        validate_spec(spec)
     except exceptions.OpenAPIError as error:
         pytest.fail(str(error))
 
@@ -602,7 +603,7 @@ def test_openapi_tools_validate_v3():
         },
     )
     try:
-        utils.validate_spec(spec)
+        validate_spec(spec)
     except exceptions.OpenAPIError as error:
         pytest.fail(str(error))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,8 @@
 """Utilities to get elements of generated spec"""
+import json
 
+from apispec.core import APISpec
+from apispec import exceptions
 from apispec.utils import build_reference
 
 
@@ -43,3 +46,34 @@ def get_paths(spec):
 
 def build_ref(spec, component_type, obj):
     return build_reference(component_type, spec.openapi_version.major, obj)
+
+
+def validate_spec(spec: APISpec) -> bool:
+    """Validate the output of an :class:`APISpec` object against the
+    OpenAPI specification.
+
+    Note: Requires installing apispec with the ``[validation]`` extras.
+    ::
+
+        pip install 'apispec[validation]'
+
+    :raise: apispec.exceptions.OpenAPIError if validation fails.
+    """
+    try:
+        import prance
+    except ImportError as error:  # re-raise with a more verbose message
+        exc_class = type(error)
+        raise exc_class(
+            "validate_spec requires prance to be installed. "
+            "You can install all validation requirements using:\n"
+            "    pip install 'apispec[validation]'"
+        ) from error
+    parser_kwargs = {}
+    if spec.openapi_version.major == 3:
+        parser_kwargs["backend"] = "openapi-spec-validator"
+    try:
+        prance.BaseParser(spec_string=json.dumps(spec.to_dict()), **parser_kwargs)
+    except prance.ValidationError as err:
+        raise exceptions.OpenAPIError(*err.args) from err
+    else:
+        return True


### PR DESCRIPTION
Closes #308.

No one stood up to keep this feature. The same validator is still used for the tests. The difference is we don't offer that abstraction layer above the validator.

The rationale is to minimize API surface and maintenance burden. TBH, the cost has been low up till now but recently a change in openapi-spec-validator broke prance. Pinning dependencies there might technically be seen as a breaking change and I don't want to engage in too much trouble overthinking what is best to fix this everything something breaks.

Users are free to install the validator that fits their needs and exposing a validator here adds little value.

Hint. Users wanting to keep using the validator may call it directly like this:

```py
    parser_kwargs = {}
    if spec.openapi_version.major == 3:
        parser_kwargs["backend"] = "openapi-spec-validator"
    prance.BaseParser(spec_string=json.dumps(spec.to_dict()), **parser_kwargs)
```