### PR TITLE
Add support for marshmallow.fields.Number.as_string

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -76,3 +76,4 @@ Contributors (chronological)
 - `<https://github.com/kasium>`_
 - Edwin Erdmanis `@vorticity <https://github.com/vorticity>`_
 - Mounier Florian `@paradoxxxzero <https://github.com/paradoxxxzero>`_
+- Timotheus Roeck `@rockTA <https://github.com/rockTA>`

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -439,3 +439,12 @@ def test_field2property_with_non_string_metadata_keys(spec_fixture):
     field.metadata[_DesertSentinel()] = "to be ignored"
     result = spec_fixture.openapi.field2property(field)
     assert result == {"description": "A description", "type": "boolean"}
+
+
+def test_number_as_string_is_converted_as_expected(spec_fixture):
+    field = fields.Number(
+        as_string=True,
+        metadata={"description": "A number field that is serialized as a string"},
+    )
+    result = spec_fixture.openapi.field2property(field)
+    assert result["type"] == "string"


### PR DESCRIPTION
Some applications serialize decimal numbers as strings, as binary representation of floats can't be precise. However, when the OpenAPI documentation is created, this is currently not being taken into account if the `Decimal` type is used with the `as_string` option. With this change the documentation accurately represents what is being returned.