### PR TITLE
Remove unneeded `mock` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ EXTRAS_REQUIRE = {
 EXTRAS_REQUIRE["tests"] = (
     EXTRAS_REQUIRE["yaml"]
     + EXTRAS_REQUIRE["validation"]
-    + ["marshmallow>=3.13.0", "pytest", "mock"]
+    + ["marshmallow>=3.13.0", "pytest"]
 )
 EXTRAS_REQUIRE["dev"] = EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["lint"] + ["tox"]
 


### PR DESCRIPTION
Remove the `mock` dependency.  It seems that its last use was removed in 5293ab11f88f3e3662d18084327eeb697a173184, and all tests pass without it being installed.