### PR TITLE
Allow openapi_version as str in marshmallow OpenAPIConverter

### DIFF
--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -40,7 +40,7 @@ __location_map__ = {
 class OpenAPIConverter(FieldConverterMixin):
     """Adds methods for generating OpenAPI specification from marshmallow schemas and fields.
 
-    :param Version openapi_version: The OpenAPI version to use.
+    :param Version|str openapi_version: The OpenAPI version to use.
         Should be in the form '2.x' or '3.x.x' to comply with the OpenAPI standard.
     :param callable schema_name_resolver: Callable to generate the schema definition name.
         Receives the `Schema` class and returns the name to be used in refs within
@@ -52,11 +52,15 @@ class OpenAPIConverter(FieldConverterMixin):
 
     def __init__(
         self,
-        openapi_version: Version,
+        openapi_version: Version | str,
         schema_name_resolver,
         spec: APISpec,
     ) -> None:
-        self.openapi_version = openapi_version
+        self.openapi_version = (
+            Version(openapi_version)
+            if isinstance(openapi_version, str)
+            else openapi_version
+        )
         self.schema_name_resolver = schema_name_resolver
         self.spec = spec
         self.init_attribute_functions()

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -4,8 +4,9 @@ import pytest
 
 from marshmallow import EXCLUDE, fields, INCLUDE, RAISE, Schema, validate
 
-from apispec.ext.marshmallow import MarshmallowPlugin
+from apispec.ext.marshmallow import MarshmallowPlugin, OpenAPIConverter
 from apispec import exceptions, APISpec
+from packaging.version import Version
 
 from .schemas import CustomList, CustomStringField
 from .utils import get_schemas, build_ref, validate_spec
@@ -606,6 +607,15 @@ def test_openapi_tools_validate_v3():
         validate_spec(spec)
     except exceptions.OpenAPIError as error:
         pytest.fail(str(error))
+
+
+def test_openapi_converter_openapi_version_types():
+    converter_with_version = OpenAPIConverter(Version("3.1"), None, None)
+    converter_with_str_version = OpenAPIConverter("3.1", None, None)
+    assert (
+        converter_with_version.openapi_version
+        == converter_with_str_version.openapi_version
+    )
 
 
 class TestFieldValidation:


### PR DESCRIPTION
Fix #810