### PR TITLE
Datetime support for multiple format

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -78,3 +78,4 @@ Contributors (chronological)
 - Mounier Florian `@paradoxxxzero <https://github.com/paradoxxxzero>`_
 - Renato Damas `@codectl <https://github.com/codectl>`_
 - Tayler Sokalski `@tsokalski <https://github.com/tsokalski>`_
+- Sebastien Lovergne `@TheBigRoomXXL <https://github.com/TheBigRoomXXL>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 6.4.0 (unreleased)
 ******************
 
+Features:
+
+- ``MarshmallowPlugin``: Support different datetime formats
+  for ``marshmallow.fields.DateTime`` fields (:issue:`814`).
+  Thanks :user:`TheBigRoomXXL` for the suggestion and PR.
+
 Other changes:
 
 - Support Python 3.12.

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -236,13 +236,13 @@ Schema Modifiers
 
 apispec will respect schema modifiers such as ``exclude`` and ``partial`` in the generated schema definition. If a schema is initialized with modifiers, apispec will treat each combination of modifiers as a unique schema definition.
 
-Custom DateTime format
-*************
+Custom DateTime formats
+***********************
 
-apispec support all four basic formats of `marshmallow.fields.DateTime`: ``"rfc"`` (for RFC822), ``"iso"`` (for ISO8601), 
+apispec supports all four basic formats of `marshmallow.fields.DateTime`: ``"rfc"`` (for RFC822), ``"iso"`` (for ISO8601), 
 ``"timestamp"``, ``"timestamp_ms"`` (for a POSIX timestamp).
 
-If you are using a custom DateTime format you should pass a regex string to the ``pattern`` parametter in your field ``metadata``. 
+If you are using a custom DateTime format you should pass a regex string to the ``pattern`` parameter in your field ``metadata`` so that it is included as documentation. 
 
 .. code-block:: python
 

--- a/docs/using_plugins.rst
+++ b/docs/using_plugins.rst
@@ -235,6 +235,22 @@ Schema Modifiers
 
 apispec will respect schema modifiers such as ``exclude`` and ``partial`` in the generated schema definition. If a schema is initialized with modifiers, apispec will treat each combination of modifiers as a unique schema definition.
 
+Custom DateTime format
+*************
+
+apispec support all four basic formats of `marshmallow.fields.DateTime`: ``"rfc"`` (for RFC822), ``"iso"`` (for ISO8601), 
+``"timestamp"``, ``"timestamp_ms"`` (for a POSIX timestamp).
+
+If you are using a custom DateTime format you should pass a regex string to the ``pattern`` parametter in your field ``metadata``. 
+
+.. code-block:: python
+
+    class SchemaWithCustomDate(Schema):
+        french_date = ma.DateTime(
+            format="%d-%m%Y %H:%M:%S",
+            metadata={"pattern": r"^\d{2}-\d{2}-\d{4} \d{2}:\d{2}:\d{2}$"},
+        )
+
 Custom Fields
 *************
 

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -549,7 +549,7 @@ class FieldConverterMixin:
                     "example": "1676451245.596",
                     "min": "0",
                 }
-            elif field.format ==  "timestamp_ms":
+            elif field.format == "timestamp_ms":
                 ret = {
                     "type": "number",
                     "format": "float",

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -110,6 +110,7 @@ class FieldConverterMixin:
             self.list2properties,
             self.dict2properties,
             self.timedelta2properties,
+            self.datetime2properties,
         ]
 
     def map_to_openapi_type(self, field_cls, *args):
@@ -516,6 +517,53 @@ class FieldConverterMixin:
             else:
                 choices = (m.value for m in field.enum)
             ret["enum"] = [field.field._serialize(v, None, None) for v in choices]
+        return ret
+
+    def datetime2properties(self, field, **kwargs: typing.Any) -> dict:
+        """Return a dictionary of properties from :class:`DateTime <marshmallow.fields.DateTime` fields.
+
+        :param Field field: A marshmallow field.
+        :rtype: dict
+        """
+        ret = {}
+        if isinstance(field, marshmallow.fields.DateTime) and not isinstance(
+            field, marshmallow.fields.Date
+        ):
+            if field.format == "iso" or field.format is None:
+                # Will return { "type": "string", "format": "date-time" }
+                # as specified inside DEFAULT_FIELD_MAPPING
+                pass
+            elif field.format == "rfc":
+                ret = {
+                    "type": "string",
+                    "format": None,
+                    "example": "Wed, 02 Oct 2002 13:00:00 GMT",
+                    "pattern": r"((Mon|Tue|Wed|Thu|Fri|Sat|Sun), ){0,1}\d{2} "
+                    + r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} "
+                    + r"(UT|GMT|EST|EDT|CST|CDT|MST|MDT|PST|PDT|(Z|A|M|N)|(\+|-)\d{4})",
+                }
+            elif field.format == "timestamp":
+                ret = {
+                    "type": "number",
+                    "format": "float",
+                    "example": "1676451245.596",
+                    "min": "0",
+                }
+            elif field.format ==  "timestamp_ms":
+                ret = {
+                    "type": "number",
+                    "format": "float",
+                    "example": "1676451277514.654",
+                    "min": "0",
+                }
+            else:
+                ret = {
+                    "type": "string",
+                    "format": None,
+                    "pattern": field.metadata["pattern"]
+                    if field.metadata.get("pattern")
+                    else None,
+                }
         return ret
 
 

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -377,6 +377,76 @@ def test_nested_field_with_property(spec_fixture):
     }
 
 
+def test_datetime2property_iso(spec_fixture):
+    field = fields.DateTime(format="iso")
+    res = spec_fixture.openapi.field2property(field)
+    print(test_datetime2property_iso)
+    assert res == {
+        "type": "string",
+        "format": "date-time",
+    }
+
+
+def test_datetime2property_rfc(spec_fixture):
+    field = fields.DateTime(format="rfc")
+    res = spec_fixture.openapi.field2property(field)
+    assert res == {
+        "type": "string",
+        "format": None,
+        "example": "Wed, 02 Oct 2002 13:00:00 GMT",
+        "pattern": r"((Mon|Tue|Wed|Thu|Fri|Sat|Sun), ){0,1}\d{2} "
+        + r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} "
+        + r"(UT|GMT|EST|EDT|CST|CDT|MST|MDT|PST|PDT|(Z|A|M|N)|(\+|-)\d{4})",
+    }
+
+
+def test_datetime2property_timestamp(spec_fixture):
+    field = fields.DateTime(format="timestamp")
+    res = spec_fixture.openapi.field2property(field)
+    assert res == {
+        "type": "number",
+        "format": "float",
+        "min": "0",
+        "example": "1676451245.596",
+    }
+
+
+def test_datetime2property_timestamp_ms(spec_fixture):
+    field = fields.DateTime(format="timestamp_ms")
+    res = spec_fixture.openapi.field2property(field)
+    assert res == {
+        "type": "number",
+        "format": "float",
+        "min": "0",
+        "example": "1676451277514.654",
+    }
+
+
+def test_datetime2property_custom_format(spec_fixture):
+    field = fields.DateTime(
+        format="%d-%m%Y %H:%M:%S",
+        metadata={
+            "pattern": r"^((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)$"
+        },
+    )
+    res = spec_fixture.openapi.field2property(field)
+    assert res == {
+        "type": "string",
+        "format": None,
+        "pattern": r"^((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)$",
+    }
+
+
+def test_datetime2property_custom_format_missing_regex(spec_fixture):
+    field = fields.DateTime(format="%d-%m%Y %H:%M:%S")
+    res = spec_fixture.openapi.field2property(field)
+    assert res == {
+        "type": "string",
+        "format": None,
+        "pattern": None,
+    }
+
+
 class TestField2PropertyPluck:
     @pytest.fixture(autouse=True)
     def _setup(self, spec_fixture):

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -380,7 +380,6 @@ def test_nested_field_with_property(spec_fixture):
 def test_datetime2property_iso(spec_fixture):
     field = fields.DateTime(format="iso")
     res = spec_fixture.openapi.field2property(field)
-    print(test_datetime2property_iso)
     assert res == {
         "type": "string",
         "format": "date-time",


### PR DESCRIPTION
Adding a function `datetime2properties` to support the differents formats of `marshamllow.field.DateTime`. 
An exemple for custom DateTime format has been added to the doc in `Using Plugins / Marshmallow Plugin`

The support for `timestamp` and `timestamp_ms` mean that DateTime type can be either "string" or "integer". Format can also have multiple values.  Because of that 2 test where modified to account for that variability: 
- `test_field2property_type`
- `test_field2property_formats`

Then 6 tests were added to test the different output of `datetime2properties`.