### PR TITLE
fix: various spelling mistakes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -584,7 +584,7 @@ Features:
 
 - ``apispec.core.Components`` is added. Each ``APISpec`` instance has a
   ``Components`` object used to define components such as schemas, parameters
-  or reponses. "Components" is the OpenAPI v3 terminology for those reusable
+  or responses. "Components" is the OpenAPI v3 terminology for those reusable
   top-level objects.
 - ``apispec.core.Components.parameter`` and ``apispec.core.Components.response``
   are added.

--- a/docs/special_topics.rst
+++ b/docs/special_topics.rst
@@ -67,7 +67,7 @@ The ``APISpec`` object contains helpers to add top-level components:
    * - Parameter
      - `spec.components.parameter <apispec.core.Components.parameter>`
      - 2, 3
-   * - Reponse
+   * - Response
      - `spec.components.response <apispec.core.Components.response>`
      - 2, 3
    * - Header

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -149,7 +149,7 @@ class FieldConverterMixin:
             merged with the return values of all other attribute functions called on the field.
             User added attribute functions will be called after all built-in attribute
             functions in the order they were added. The merged results of all
-            previously called attribute functions are accessable via the `ret`
+            previously called attribute functions are accessible via the `ret`
             argument.
         """
         bound_func = func.__get__(self)

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -102,7 +102,7 @@ class OpenAPIConverter(FieldConverterMixin):
 
         Typically will return a dictionary with the reference to the schema's
         path in the spec unless the `schema_name_resolver` returns `None`, in
-        which case the returned dictoinary will contain a JSON Schema Object
+        which case the returned dictionary will contain a JSON Schema Object
         representation of the schema.
 
         :param schema: schema to add to the spec

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -526,8 +526,8 @@ class TestComponents(RefsSchemaTestMixin):
         assert schemas["Pet_2"]["properties"] == self.properties
 
     def test_response_lazy(self, spec):
-        response_1 = {"description": "Reponse 1"}
-        response_2 = {"description": "Reponse 2"}
+        response_1 = {"description": "Response 1"}
+        response_2 = {"description": "Response 2"}
         spec.components.response("Response_1", response_1, lazy=False)
         spec.components.response("Response_2", response_2, lazy=True)
         responses = get_responses(spec)


### PR DESCRIPTION
This pull request addresses various spelling errors in the apispec codebase and documentation.