### PR TITLE
fix: resolve refs for callbacks

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -76,3 +76,4 @@ Contributors (chronological)
 - `<https://github.com/kasium>`_
 - Edwin Erdmanis `@vorticity <https://github.com/vorticity>`_
 - Mounier Florian `@paradoxxxzero <https://github.com/paradoxxxzero>`_
+- Renato Damas `@codectl <https://github.com/codectl>`_

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -370,6 +370,11 @@ class Components:
                 self._resolve_refs_in_parameter_or_header(parameter)
                 parameters.append(parameter)
             operation["parameters"] = parameters
+        if "callbacks" in operation:
+            for callback in operation["callbacks"].values():
+                if isinstance(callback, dict):
+                    for path in callback.values():
+                        self.resolve_refs_in_path(path)
         if "requestBody" in operation:
             self._resolve_refs_in_request_body(operation["requestBody"])
         if "responses" in operation:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,7 +23,6 @@ from .utils import (
     build_ref,
 )
 
-
 description = "This is a sample Petstore server.  You can find out more "
 'about Swagger at <a href="http://swagger.wordnik.com">http://swagger.wordnik.com</a> '
 "or on irc.freenode.net, #swagger.  For this sample, you can use the api "
@@ -898,6 +897,35 @@ class TestPath(RefsSchemaTestMixin):
         else:
             schema = resp["content"]["application/json"]["schema"]
         assert schema == build_ref(spec, "schema", "PetSchema")
+
+    # callbacks only exists in OAS 3
+    @pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
+    def test_path_resolve_callbacks(self, spec):
+        spec.path(
+            "/pet/{petId}",
+            operations={
+                "get": {
+                    "callbacks": {
+                        "event": {
+                            "/callback": {
+                                "post": {
+                                    "requestBody": {
+                                        "content": {
+                                            "application/json": {"schema": "PetSchema"}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        )
+        assert get_paths(spec)["/pet/{petId}"]["get"]["callbacks"]["event"][
+            "/callback"
+        ]["post"]["requestBody"]["content"]["application/json"]["schema"] == build_ref(
+            spec, "schema", "PetSchema"
+        )
 
     # requestBody only exists in OAS 3
     @pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)


### PR DESCRIPTION
Schemas present in ```callbacks``` property in OAS3 should also be resolved to refs