### PR TITLE
Fix nested nullable

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -146,13 +146,12 @@ class FieldConverterMixin:
             Must return a dictionary of OpenAPI properties that will be shallow
             merged with the return values of all other attribute functions called on the field.
             User added attribute functions will be called after all built-in attribute
-            functions in the order they were added. The merged results of all
-            previously called attribute functions are accessible via the `ret`
-            argument.
+            functions except `field2nullable` in the order they were added. The merged results
+            of all previously called attribute functions are accessible via the `ret` argument.
         """
         bound_func = func.__get__(self)
         setattr(self, func.__name__, bound_func)
-        self.attribute_functions.append(bound_func)
+        self.attribute_functions.insert(-1, bound_func)
 
     def field2property(self, field: marshmallow.fields.Field) -> dict:
         """Return the JSON Schema property definition given a marshmallow

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -5,6 +5,8 @@ from enum import Enum
 import pytest
 from marshmallow import fields, validate
 
+from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
 from .schemas import CategorySchema, CustomList, CustomStringField, CustomIntegerField
 from .utils import build_ref, get_schemas
 
@@ -421,6 +423,38 @@ class TestField2PropertyPluck:
             "type": "array",
             "readOnly": True,
         }
+
+
+def test_pluck_nullable():
+    ma = MarshmallowPlugin()
+    spec = APISpec(
+        title="My API Spec",
+        version="1.0.0",
+        openapi_version="3.1.0",
+        plugins=[ma],
+    )
+    spec.components.schema("Category", schema=CategorySchema)
+    breed = fields.Pluck(CategorySchema, "breed", allow_none=True)
+    assert ma.converter.field2property(breed) == {
+        "type": ["string", "null"],
+        "readOnly": True,
+    }
+
+
+def test_pluck_nullable_many():
+    ma = MarshmallowPlugin()
+    spec = APISpec(
+        title="My API Spec",
+        version="1.0.0",
+        openapi_version="3.1.0",
+        plugins=[ma],
+    )
+    spec.components.schema("Category", schema=CategorySchema)
+    breed = fields.Pluck(CategorySchema, "breed", many=True, allow_none=True)
+    assert ma.converter.field2property(breed) == {
+        "items": {"readOnly": True, "type": "string"},
+        "type": ["array", "null"],
+    }
 
 
 def test_custom_properties_for_custom_fields(spec_fixture):

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -478,6 +478,28 @@ def test_custom_properties_for_custom_fields(spec_fixture):
     )
 
 
+@pytest.mark.parametrize("spec_fixture", ("3.1.0",), indirect=True)
+def test_custom_properties_nullable_in_3_dot_one(spec_fixture):
+    class CustomNested(fields.Nested):
+        pass
+
+    def custom_string2properties(self, field, **kwargs):
+        ret = {}
+        if isinstance(field, CustomIntegerField):
+            ret["type"] = "number"
+
+        return ret
+
+    spec_fixture.marshmallow_plugin.converter.add_attribute_function(
+        custom_string2properties
+    )
+    properties = spec_fixture.marshmallow_plugin.converter.field2property(
+        CustomIntegerField(allow_none=True)
+    )
+
+    assert properties == {"type": ["number", "null"]}
+
+
 def test_field2property_with_non_string_metadata_keys(spec_fixture):
     class _DesertSentinel:
         pass


### PR DESCRIPTION
This fixes #833. `field2nullable` executes after other attribute functions including user added attribute functions and now has logic for handling cases with a reference object and an `allOf` object. 