### PR TITLE
Fix conversion of deprecated flag on parameters

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -77,3 +77,4 @@ Contributors (chronological)
 - Edwin Erdmanis `@vorticity <https://github.com/vorticity>`_
 - Mounier Florian `@paradoxxxzero <https://github.com/paradoxxxzero>`_
 - Renato Damas `@codectl <https://github.com/codectl>`_
+- Tayler Sokalski `@tsokalski <https://github.com/tsokalski>`_

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -197,6 +197,8 @@ class OpenAPIConverter(FieldConverterMixin):
         else:
             if "description" in prop:
                 ret["description"] = prop.pop("description")
+            if "deprecated" in prop:
+                ret["deprecated"] = prop.pop("deprecated")
             ret["schema"] = prop
 
         for param_attr_func in self.parameter_attribute_functions:

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -245,6 +245,11 @@ class TestMarshmallowSchemaToParameters:
         res = openapi._field2parameter(field, name="field", location="query")
         assert res["required"] is True
 
+    def test_field_deprecated(self, openapi):
+        field = fields.Str(metadata={"deprecated": True})
+        res = openapi._field2parameter(field, name="field", location="query")
+        assert res["deprecated"] is True
+
     def test_schema_partial(self, openapi):
         class UserSchema(Schema):
             field = fields.Str(required=True)


### PR DESCRIPTION
Fixes #850. This promotes the `deprecated` value on to the main parameter object rather than setting it on the contained `schema` object.