### PR TITLE
Fix schema name that has end with space for redoc ui and elements ui

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -78,3 +78,4 @@ Contributors (chronological)
 - Mounier Florian `@paradoxxxzero <https://github.com/paradoxxxzero>`_
 - Renato Damas `@codectl <https://github.com/codectl>`_
 - Tayler Sokalski `@tsokalski <https://github.com/tsokalski>`_
+- Luna Lovegood `@duchuyvp <https://github.com/duchuyvp>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Features:
 - ``MarshmallowPlugin``: Support different datetime formats
   for ``marshmallow.fields.DateTime`` fields (:issue:`814`).
   Thanks :user:`TheBigRoomXXL` for the suggestion and PR.
+- ``MarshmallowPlugin``: Handle resolving names of schemas with spaces in the name (:pr:`856`).
+  Thanks :user:`duchuyvp` for the PR.
 
 Other changes:
 

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -89,8 +89,9 @@ def resolver(schema: type[Schema]) -> str:
     schema_cls = resolve_schema_cls(schema)
     name = schema_cls.__name__
     if name.endswith("Schema"):
-        return name[:-6] or name
-    return name
+        name_ = name[:-6] or name
+        return name_.strip()
+    return name.strip()
 
 
 class MarshmallowPlugin(BasePlugin):

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -89,8 +89,7 @@ def resolver(schema: type[Schema]) -> str:
     schema_cls = resolve_schema_cls(schema)
     name = schema_cls.__name__
     if name.endswith("Schema"):
-        name_ = name[:-6] or name
-        return name_.strip()
+        name = name[:-6] or name
     return name.strip()
 
 


### PR DESCRIPTION
I strip `component_id` before register a new schema when to prevent its name has some bad space, generated spec has schama name that end with space like 'Schema name ' doesn't work with `redoc` ui (by ReDoc) and `elements` ui (by Stoplight)