### PR TITLE
Set the `format` of `marshmallow.fields.Float` fields to `float`

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -22,7 +22,7 @@ from marshmallow.orderedset import OrderedSet
 DEFAULT_FIELD_MAPPING: dict[type, tuple[str | None, str | None]] = {
     marshmallow.fields.Integer: ("integer", None),
     marshmallow.fields.Number: ("number", None),
-    marshmallow.fields.Float: ("number", None),
+    marshmallow.fields.Float: ("number", "float"),
     marshmallow.fields.Decimal: ("number", None),
     marshmallow.fields.String: ("string", None),
     marshmallow.fields.Boolean: ("boolean", None),

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -66,6 +66,7 @@ def test_formatted_field_translates_to_array(ListClass, spec_fixture):
         (fields.Date, "date"),
         (fields.Email, "email"),
         (fields.URL, "url"),
+        (fields.Float, "float"),
     ],
 )
 def test_field2property_formats(FieldClass, expected_format, spec_fixture):

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -56,6 +56,7 @@ class TestMarshmallowSchemaToModelDefinition:
             _id = fields.Int()
             email = fields.Email(metadata={"description": "email address of the user"})
             name = fields.Str()
+            my_float = fields.Float()
 
             class Meta:
                 title = "User"
@@ -65,6 +66,7 @@ class TestMarshmallowSchemaToModelDefinition:
         assert res["type"] == "object"
         props = res["properties"]
         assert props["_id"]["type"] == "integer"
+        assert props["my_float"]["format"] == "float"
         assert props["email"]["type"] == "string"
         assert props["email"]["format"] == "email"
         assert props["email"]["description"] == "email address of the user"


### PR DESCRIPTION
See `float` format for number data types https://swagger.io/docs/specification/data-models/data-types/