### PR TITLE
Add IP fields to DEFAULT_FIELD_MAPPING

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -81,3 +81,4 @@ Contributors (chronological)
 - Sebastien Lovergne `@TheBigRoomXXL <https://github.com/TheBigRoomXXL>`_
 - Luna Lovegood `@duchuyvp <https://github.com/duchuyvp>`_
 - Tobias Kolditz `@kolditz-senec <https://github.com/kolditz-senec>`_
+- Christian Proud `@cjproud https://github.com/cjproud`

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -81,4 +81,4 @@ Contributors (chronological)
 - Sebastien Lovergne `@TheBigRoomXXL <https://github.com/TheBigRoomXXL>`_
 - Luna Lovegood `@duchuyvp <https://github.com/duchuyvp>`_
 - Tobias Kolditz `@kolditz-senec <https://github.com/kolditz-senec>`_
-- Christian Proud `@cjproud https://github.com/cjproud`
+- Christian Proud `@cjproud <https://github.com/cjproud>`

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -81,4 +81,4 @@ Contributors (chronological)
 - Sebastien Lovergne `@TheBigRoomXXL <https://github.com/TheBigRoomXXL>`_
 - Luna Lovegood `@duchuyvp <https://github.com/duchuyvp>`_
 - Tobias Kolditz `@kolditz-senec <https://github.com/kolditz-senec>`_
-- Christian Proud `@cjproud <https://github.com/cjproud>`
+- Christian Proud `@cjproud <https://github.com/cjproud>`_

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -38,6 +38,9 @@ DEFAULT_FIELD_MAPPING: dict[type, tuple[str | None, str | None]] = {
     marshmallow.fields.Field: (None, None),
     marshmallow.fields.Raw: (None, None),
     marshmallow.fields.List: ("array", None),
+    marshmallow.fields.IP: ("string", "ip"),
+    marshmallow.fields.IPv4: ("string", "ipv4"),
+    marshmallow.fields.IPv6: ("string", "ipv6"),
 }
 
 

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -32,6 +32,9 @@ def test_field2choices_preserving_order(openapi):
         (fields.TimeDelta, "integer"),
         (fields.Email, "string"),
         (fields.URL, "string"),
+        (fields.IP, "string"),
+        (fields.IPv4, "string"),
+        (fields.IPv6, "string"),
         # Custom fields inherit types from their parents
         (CustomStringField, "string"),
         (CustomIntegerField, "integer"),
@@ -66,6 +69,9 @@ def test_formatted_field_translates_to_array(ListClass, spec_fixture):
         (fields.Date, "date"),
         (fields.Email, "email"),
         (fields.URL, "url"),
+        (fields.IP, "ip"),
+        (fields.IPv4, "ipv4"),
+        (fields.IPv6, "ipv6"),
     ],
 )
 def test_field2property_formats(FieldClass, expected_format, spec_fixture):


### PR DESCRIPTION
This relates to https://github.com/marshmallow-code/flask-smorest/issues/623 where Swagger was not obeying `required=True` for the `IPv4` field. This adds the different IP fields to the DEFAULT_FIELD_MAPPING where the type is string the format is the IP address format.