### PR TITLE
Fix nested nullable for 3.1.0

### DIFF
--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -206,9 +206,10 @@ def test_nested_nullable(spec_fixture):
 
     field = fields.Nested(Child, allow_none=True)
     res = spec_fixture.openapi.field2property(field)
-    if spec_fixture.openapi.openapi_version.major < 3:
+    version = spec_fixture.openapi.openapi_version
+    if version.major < 3:
         assert res == {"$ref": "#/definitions/Child", "x-nullable": True}
-    elif spec_fixture.openapi.openapi_version.minor < 1:
+    elif version.major == 3 and version.minor < 1:
         assert res == {
             "nullable": True,
             "allOf": [{"$ref": "#/components/schemas/Child"}],
@@ -226,9 +227,10 @@ def test_nullable_pluck(spec_fixture):
 
     field = fields.Pluck(Example, "name", allow_none=True)
     res = spec_fixture.openapi.field2property(field)
-    if spec_fixture.openapi.openapi_version.major < 3:
+    version = spec_fixture.openapi.openapi_version
+    if version.major < 3:
         assert res == {"type": "string", "x-nullable": True}
-    elif spec_fixture.openapi.openapi_version.minor < 1:
+    elif version.major == 3 and version.minor < 1:
         assert res == {"type": "string", "nullable": True}
     else:
         assert res == {"type": ["string", "null"]}


### PR DESCRIPTION
Fixes issue #833. Similar to PR #845, but 

* prevents "nullable" as a sibling of "$ref",
* does not change behavior for versions <3.1.0 (because the [semantics of nullable was ambiguous before 3.0.3](https://github.com/OAI/OpenAPI-Specification/blob/main/proposals/2019-10-31-Clarify-Nullable.md)), and
* does not change the evaluation order of custom attribute functions (custom functions get the results of the built-in functions passed in as an argument and are responsible for generating valid results).
