### PR TITLE
Add `additionalProperties: {}` for Dict with the default `values`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -83,3 +83,4 @@ Contributors (chronological)
 - Tobias Kolditz `@kolditz-senec <https://github.com/kolditz-senec>`_
 - Christian Proud `@cjproud <https://github.com/cjproud>`_
 - `<https://github.com/kolditz-senec >`_
+- Theron Luhn `@luhn <https://github.com/luhn>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 6.7.0 (unreleased)
 ******************
 
+Bug fixes:
+
+- Fix handling of ``fields.Dict()`` with ``values`` unset (:issue:`949`).
+  Thanks :user:`luhn` for the catch and patch.
+
 Other changes:
 
 - Officially support Python 3.13 (:pr:`948`).

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -504,6 +504,8 @@ class FieldConverterMixin:
             value_field = field.value_field
             if value_field:
                 ret["additionalProperties"] = self.field2property(value_field)
+            else:
+                ret["additionalProperties"] = {}
         return ret
 
     def timedelta2properties(self, field, **kwargs: typing.Any) -> dict:

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -1294,7 +1294,7 @@ class TestDictValues:
 
         spec.components.schema("SchemaWithDict", schema=SchemaWithDict)
         result = get_schemas(spec)["SchemaWithDict"]["properties"]["dict_field"]
-        assert result == {"type": "object"}
+        assert result == {"type": "object", "additionalProperties": {}}
 
     def test_dict_with_nested(self, spec):
         class SchemaWithDict(Schema):


### PR DESCRIPTION
Fixes #949