### PR TITLE
Fix nullable nested schemas with metadata in 3.0

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -306,6 +306,11 @@ class FieldConverterMixin:
                         {"type": "object", "nullable": True},
                         {"$ref": ret.pop("$ref")},
                     ]
+                elif "allOf" in ret:
+                    attributes["anyOf"] = [
+                        *ret.pop("allOf"),
+                        {"type": "object", "nullable": True},
+                    ]
                 else:
                     attributes["nullable"] = True
             else:


### PR DESCRIPTION
Fixes https://github.com/marshmallow-code/apispec/issues/955

Applied the same `allOf` logic seen used in 3.1 (See https://github.com/marshmallow-code/apispec/pull/904)