### PR TITLE
Allow properties on $ref objects for OpenAPI 3.1.

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -460,7 +460,17 @@ class FieldConverterMixin:
             field, marshmallow.fields.Pluck
         ):
             schema_dict = self.resolve_nested_schema(field.schema)  # type:ignore
-            if ret and "$ref" in schema_dict:
+            if (
+                ret
+                and "$ref" in schema_dict
+                and (
+                    self.openapi_version.major < 3
+                    or (
+                        self.openapi_version.major == 3
+                        and self.openapi_version.minor == 0
+                    )
+                )
+            ):
                 ret.update({"allOf": [schema_dict]})
             else:
                 ret.update(schema_dict)


### PR DESCRIPTION
JSON Schema draft 5 (OpenAPI 3.0.4), it specifically says additional properties on a $ref object are ignored.

> All other properties in a "$ref" object MUST be ignored.

https://datatracker.ietf.org/doc/html/draft-wright-json-schema-00#section-7

However, draft 2020-12 (OpenAPI 3.1.0) seems to have changed its tune:

> Its results are the results of the referenced schema.  [[CREF5: Note
> that this definition of how the results are determined means that other
> keywords can appear alongside of "$ref" in the same schema object.  ]]

https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-8.2.3.1

So if I'm understanding correctly, things like this are now valid and meaningful:

```json
{
            "$ref": "#/components/schemas/Child",
            "description": "A category",
            "x-extension": "A great extension",
 }
```