### PR TITLE
Improve handling of nullable Raw fields for OAS 3.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,3 @@ venv.bak/
 
 # ruff
 .ruff_cache/
-
-# PyCharm
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 
 # ruff
 .ruff_cache/
+
+# PyCharm
+.idea

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,13 @@
 Changelog
 ---------
 
-6.9.0 (unreleased)
+6.8.1 (unreleased)
 ******************
+
+Bug fixes:
+
+- Fix handling of nullable Raw fields for OAS 3.1.0 (:issue:`960`).
+  Thanks :user:`tsokalski` for reporting and fixing.
 
 Support:
 

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -318,7 +318,7 @@ class FieldConverterMixin:
                     attributes["anyOf"] = [{"$ref": ret.pop("$ref")}, {"type": "null"}]
                 elif "allOf" in ret:
                     attributes["anyOf"] = [*ret.pop("allOf"), {"type": "null"}]
-                else:
+                elif "type" in ret:
                     attributes["type"] = [*make_type_list(ret.get("type")), "null"]
         return attributes
 

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -200,6 +200,20 @@ def test_field_with_allow_none(spec_fixture):
 
 
 @pytest.mark.parametrize("spec_fixture", ("2.0", "3.0.0", "3.1.0"), indirect=True)
+@pytest.mark.parametrize("field_class", [fields.Field, fields.Raw])
+def test_nullable_field_with_no_type(spec_fixture, field_class):
+    field = field_class(allow_none=True)
+    res = spec_fixture.openapi.field2property(field)
+    if spec_fixture.openapi.openapi_version.major < 3:
+        assert res["x-nullable"] is True
+    elif spec_fixture.openapi.openapi_version.minor < 1:
+        assert res["nullable"] is True
+    else:
+        assert "nullable" not in res
+        assert "type" not in res
+
+
+@pytest.mark.parametrize("spec_fixture", ("2.0", "3.0.0", "3.1.0"), indirect=True)
 def test_nested_nullable(spec_fixture):
     class Child(Schema):
         name = fields.Str()


### PR DESCRIPTION
Modified the implementation of `field2nullable` for OAS 3.1.0 to only append `"null"` to the list of types if there is already a type for the field. This prevents issues in which a nullable field with no specific associated OAS type can get bound to `"type": ["null"]`, which is overly restrictive.

Fixes #960.