### PR TITLE
Use set instead of list for `exclude` in `filter_excluded_fields` fucntion

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -85,3 +85,4 @@ Contributors (chronological)
 - `<https://github.com/kolditz-senec >`_
 - Theron Luhn `@luhn <https://github.com/luhn>`_
 - Robert Shepley `@ShepleySound <https://github.com/ShepleySound>`_
+- Robin `@allrob23 <https://github.com/allrob23>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+(unreleased)
+************
+
+- Perf improvement to ``filter_excluded_fields`` (:issue:`972`).
+  Thanks :user:`allrob23` for the PR.
+
 6.8.1 (2025-01-07)
 ******************
 

--- a/src/apispec/ext/marshmallow/common.py
+++ b/src/apispec/ext/marshmallow/common.py
@@ -95,9 +95,9 @@ def filter_excluded_fields(
     :param Meta: the schema's Meta class
     :param bool exclude_dump_only: whether to filter dump_only fields
     """
-    exclude = list(getattr(Meta, "exclude", []))
+    exclude = set(getattr(Meta, "exclude", []))
     if exclude_dump_only:
-        exclude.extend(getattr(Meta, "dump_only", []))
+        exclude.update(getattr(Meta, "dump_only", []))
 
     filtered_fields = {
         key: value


### PR DESCRIPTION
This PR updates the `filter_excluded_fields` function to use a `set` instead of a `list` for the `exclude` variable. While the number of elements in `Meta.exclude` and `Meta.dump_only` may not be large, this change still provides a small optimization by improving membership checks from O(N) to O(1). 

The overall behavior of the function remains unchanged. Fields are still filtered based on `Meta.exclude` and `dump_only` as before. The `exclude` variable, now a `set`, is used in the `if` condition to check field membership, benefiting from the faster lookups without altering the logic.