### PR TITLE
Avoid overwriting `additionalProperties` with the default `{}`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -86,3 +86,4 @@ Contributors (chronological)
 - Theron Luhn `@luhn <https://github.com/luhn>`_
 - Robert Shepley `@ShepleySound <https://github.com/ShepleySound>`_
 - Robin `@allrob23 <https://github.com/allrob23>`_
+- Xingang Zhang `@0x0400 <https://github.com/0x0400>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 (unreleased)
 ************
 
+Bug fixes:
+
+- ``MarshmallowPlugin`` doesn't override ``additionalProperties`` explicitly
+  passed to ``fields.Dict`` (:pr:`976`).
+  Thanks :user:`0x0400` for the PR.
+
 - Perf improvement to ``filter_excluded_fields`` (:issue:`972`).
   Thanks :user:`allrob23` for the PR.
 

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -523,6 +523,8 @@ class FieldConverterMixin:
             value_field = field.value_field
             if value_field:
                 ret["additionalProperties"] = self.field2property(value_field)
+            elif kwargs.get("ret") and "additionalProperties" in kwargs["ret"]:
+                pass
             else:
                 ret["additionalProperties"] = {}
         return ret

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -523,9 +523,7 @@ class FieldConverterMixin:
             value_field = field.value_field
             if value_field:
                 ret["additionalProperties"] = self.field2property(value_field)
-            elif kwargs.get("ret") and "additionalProperties" in kwargs["ret"]:
-                pass
-            else:
+            elif "additionalProperties" not in kwargs.get("ret", {}):
                 ret["additionalProperties"] = {}
         return ret
 

--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -1296,6 +1296,14 @@ class TestDictValues:
         result = get_schemas(spec)["SchemaWithDict"]["properties"]["dict_field"]
         assert result == {"type": "object", "additionalProperties": {}}
 
+    def test_dict_with_empty_values_field_and_metadata(self, spec):
+        class SchemaWithDict(Schema):
+            dict_field = Dict(metadata={"additionalProperties": True})
+
+        spec.components.schema("SchemaWithDict", schema=SchemaWithDict)
+        result = get_schemas(spec)["SchemaWithDict"]["properties"]["dict_field"]
+        assert result == {"type": "object", "additionalProperties": True}
+
     def test_dict_with_nested(self, spec):
         class SchemaWithDict(Schema):
             dict_field = Dict(values=Nested(PetSchema))


### PR DESCRIPTION
A few versions ago, the output of `Dict()` omitted `additionalProperties` entirely and I used `Dict(metadata={"additionalProperties": True})` as a workaround. Now the output of `additionalProperties: {}` will breakdown our internal tools.
Although `additionalProperties: {}` is equivalent to `additionalProperties: true`, I think it's better not to overwrite the manually set value.