### PR TITLE
feat: add `list_as_array` flag to MarshmallowPlugin for array-root requestBody

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -87,3 +87,4 @@ Contributors (chronological)
 - Robert Shepley `@ShepleySound <https://github.com/ShepleySound>`_
 - Robin `@allrob23 <https://github.com/allrob23>`_
 - Xingang Zhang `@0x0400 <https://github.com/0x0400>`_
+- nomi3 `@nomi3 <https://github.com/nomi3>`_

--- a/src/apispec/ext/marshmallow/__init__.py
+++ b/src/apispec/ext/marshmallow/__init__.py
@@ -120,6 +120,7 @@ class MarshmallowPlugin(BasePlugin):
     def __init__(
         self,
         schema_name_resolver: typing.Callable[[type[Schema]], str] | None = None,
+        list_as_array: bool = False,
     ) -> None:
         super().__init__()
         self.schema_name_resolver = schema_name_resolver or resolver
@@ -127,6 +128,7 @@ class MarshmallowPlugin(BasePlugin):
         self.openapi_version: Version | None = None
         self.converter: OpenAPIConverter | None = None
         self.resolver: SchemaResolver | None = None
+        self.list_as_array = list_as_array
 
     def init_spec(self, spec: APISpec) -> None:
         super().init_spec(spec)
@@ -136,6 +138,7 @@ class MarshmallowPlugin(BasePlugin):
             openapi_version=spec.openapi_version,
             schema_name_resolver=self.schema_name_resolver,
             spec=spec,
+            list_as_array=self.list_as_array,
         )
         self.resolver = self.Resolver(
             openapi_version=spec.openapi_version, converter=self.converter

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -56,6 +56,7 @@ class OpenAPIConverter(FieldConverterMixin):
         openapi_version: Version | str,
         schema_name_resolver,
         spec: APISpec,
+        list_as_array: bool = False,
     ) -> None:
         self.openapi_version = (
             Version(openapi_version)
@@ -66,6 +67,7 @@ class OpenAPIConverter(FieldConverterMixin):
         self.spec = spec
         self.init_attribute_functions()
         self.init_parameter_attribute_functions()
+        self.list_as_array = list_as_array
         # Schema references
         self.refs: dict = {}
 
@@ -108,6 +110,30 @@ class OpenAPIConverter(FieldConverterMixin):
 
         :param schema: schema to add to the spec
         """
+        if isinstance(schema, marshmallow.fields.List) and getattr(
+            self, "list_as_array", False
+        ):
+            return {
+                "type": "array",
+                "items": self.resolve_nested_schema(schema.inner),
+            }
+
+        if getattr(self, "list_as_array", False):
+            if isinstance(schema, marshmallow.Schema):
+                field_dict = schema.fields
+            elif isinstance(schema, type) and issubclass(schema, marshmallow.Schema):
+                field_dict = schema._declared_fields
+            else:
+                field_dict = None
+
+            if field_dict is not None and len(field_dict) == 1:
+                fld = next(iter(field_dict.values()))
+                if isinstance(fld, marshmallow.fields.List) and fld.data_key is None:
+                    return {
+                        "type": "array",
+                        "items": self.resolve_nested_schema(fld.inner),
+                    }
+
         try:
             schema_instance = resolve_schema_instance(schema)
         # If schema is a string and is not found in registry,

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -110,15 +110,13 @@ class OpenAPIConverter(FieldConverterMixin):
 
         :param schema: schema to add to the spec
         """
-        if isinstance(schema, marshmallow.fields.List) and getattr(
-            self, "list_as_array", False
-        ):
+        if isinstance(schema, marshmallow.fields.List) and self.list_as_array:
             return {
                 "type": "array",
                 "items": self.resolve_nested_schema(schema.inner),
             }
 
-        if getattr(self, "list_as_array", False):
+        if self.list_as_array:
             if isinstance(schema, marshmallow.Schema):
                 field_dict = schema.fields
             elif isinstance(schema, type) and issubclass(schema, marshmallow.Schema):

--- a/tests/test_array_requestbody.py
+++ b/tests/test_array_requestbody.py
@@ -1,9 +1,12 @@
 from marshmallow import Schema, fields
+
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 
+
 class UUIDListSchema(Schema):
     uuids = fields.List(fields.UUID(), data_key=None)
+
 
 def _build_schema(list_as_array: bool):
     plugin = MarshmallowPlugin(list_as_array=list_as_array)
@@ -24,7 +27,9 @@ def _build_schema(list_as_array: bool):
             }
         },
     )
-    schema = spec.to_dict()["paths"]["/list"]["post"]["requestBody"]["content"]["application/json"]["schema"]
+    schema = spec.to_dict()["paths"]["/list"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
 
     if "$ref" in schema:
         ref_name = schema["$ref"].split("/")[-1]
@@ -32,9 +37,11 @@ def _build_schema(list_as_array: bool):
 
     return schema
 
+
 def test_default_is_object():
     schema = _build_schema(list_as_array=False)
     assert schema["type"] == "object"
+
 
 def test_list_as_array_flag():
     schema = _build_schema(list_as_array=True)

--- a/tests/test_array_requestbody.py
+++ b/tests/test_array_requestbody.py
@@ -1,0 +1,42 @@
+from marshmallow import Schema, fields
+from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
+
+class UUIDListSchema(Schema):
+    uuids = fields.List(fields.UUID(), data_key=None)
+
+def _build_schema(list_as_array: bool):
+    plugin = MarshmallowPlugin(list_as_array=list_as_array)
+    spec = APISpec(
+        title="Test",
+        version="1.0.0",
+        openapi_version="3.0.2",
+        plugins=[plugin],
+    )
+    spec.path(
+        path="/list",
+        operations={
+            "post": {
+                "requestBody": {
+                    "content": {"application/json": {"schema": UUIDListSchema()}}
+                },
+                "responses": {"200": {}},
+            }
+        },
+    )
+    schema = spec.to_dict()["paths"]["/list"]["post"]["requestBody"]["content"]["application/json"]["schema"]
+
+    if "$ref" in schema:
+        ref_name = schema["$ref"].split("/")[-1]
+        schema = spec.to_dict()["components"]["schemas"][ref_name]
+
+    return schema
+
+def test_default_is_object():
+    schema = _build_schema(list_as_array=False)
+    assert schema["type"] == "object"
+
+def test_list_as_array_flag():
+    schema = _build_schema(list_as_array=True)
+    assert schema["type"] == "array"
+    assert "items" in schema


### PR DESCRIPTION
OpenAPI 3.x fully supports request bodies whose root schema is an array, but apispec + marshmallow currently cannot generate such schemas automatically. Projects must hand-write YAML/dict snippets for every endpoint that needs it.

This PR introduces an opt-in flag—list_as_array—to MarshmallowPlugin that lets the plugin emit type: array schemas automatically when:

- a plain fields.List(...) is supplied as the schema, or
- a Schema (class or instance) contains exactly one fields.List field with data_key=None.
 
The default behaviour remains unchanged (object-root), so the change is non-breaking.