### PR TITLE
Set additionnalProperties to False if unknown is not set / support setting unknown at schema instantiation

### DIFF
--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -258,7 +258,9 @@ class OpenAPIConverter(FieldConverterMixin):
             jsonschema["title"] = Meta.title
         if hasattr(Meta, "description"):
             jsonschema["description"] = Meta.description
-        if hasattr(Meta, "unknown") and Meta.unknown != marshmallow.EXCLUDE:
+        if not hasattr(Meta, "unknown"):
+            jsonschema["additionalProperties"] = False
+        elif Meta.unknown != marshmallow.EXCLUDE:
             jsonschema["additionalProperties"] = Meta.unknown == marshmallow.INCLUDE
 
         return jsonschema

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -240,7 +240,7 @@ class OpenAPIConverter(FieldConverterMixin):
 
     def schema2jsonschema(self, schema):
         """Return the JSON Schema Object for a given marshmallow
-        :class:`Schema <marshmallow.Schema>` instance. Schema may optionally
+        :class:`Schema <marshmallow.Schema>`. Schema may optionally
         provide the ``title`` and ``description`` class Meta options.
 
         https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#schemaObject
@@ -254,14 +254,16 @@ class OpenAPIConverter(FieldConverterMixin):
 
         jsonschema = self.fields2jsonschema(fields, partial=partial)
 
+        schema_instance = resolve_schema_instance(schema)
+
         if hasattr(Meta, "title"):
             jsonschema["title"] = Meta.title
         if hasattr(Meta, "description"):
             jsonschema["description"] = Meta.description
-        if not hasattr(Meta, "unknown"):
-            jsonschema["additionalProperties"] = False
-        elif Meta.unknown != marshmallow.EXCLUDE:
-            jsonschema["additionalProperties"] = Meta.unknown == marshmallow.INCLUDE
+        elif schema_instance.unknown != marshmallow.EXCLUDE:
+            jsonschema["additionalProperties"] = (
+                schema_instance.unknown == marshmallow.INCLUDE
+            )
 
         return jsonschema
 

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -133,6 +133,13 @@ class TestMarshmallowSchemaToModelDefinition:
         res = openapi.schema2jsonschema(WhiteStripesSchema)
         assert set(res["properties"].keys()) == {"guitarist", "drummer"}
 
+    def test_unknown_values_default_disallow(self, openapi):
+        class UnknownDefaultSchema(Schema):
+            first = fields.Str()
+
+        res = openapi.schema2jsonschema(UnknownDefaultSchema)
+        assert res["additionalProperties"] is False
+
     def test_unknown_values_disallow(self, openapi):
         class UnknownRaiseSchema(Schema):
             class Meta:

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 from datetime import datetime
 
 import pytest
@@ -9,6 +10,8 @@ from apispec.ext.marshmallow import MarshmallowPlugin, OpenAPIConverter
 
 from .schemas import CustomList, CustomStringField
 from .utils import build_ref, get_schemas, validate_spec
+
+MA_VERSION = Version(importlib.metadata.version("marshmallow"))
 
 
 class TestMarshmallowFieldToOpenAPI:
@@ -191,6 +194,9 @@ class TestMarshmallowSchemaToModelDefinition:
         else:
             assert res["additionalProperties"] is expected
 
+    @pytest.mark.skipif(
+        MA_VERSION.major >= 4, reason="marshmallow 4 drop inferred fields"
+    )
     def test_only_explicitly_declared_fields_are_translated(self, openapi):
         class UserSchema(Schema):
             _id = fields.Int()

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -170,6 +170,27 @@ class TestMarshmallowSchemaToModelDefinition:
         res = openapi.schema2jsonschema(UnknownExcludeSchema)
         assert "additionalProperties" not in res
 
+    @pytest.mark.parametrize("meta_unknown", (RAISE, INCLUDE, EXCLUDE, None))
+    @pytest.mark.parametrize(
+        "instance_unknown,expected", ((RAISE, False), (INCLUDE, True), (EXCLUDE, None))
+    )
+    def test_unknown_values_instance_override_meta(
+        self, openapi, instance_unknown, expected, meta_unknown
+    ):
+        class UnknownSchema(Schema):
+            if meta_unknown is not None:
+
+                class Meta:
+                    unknown = meta_unknown
+
+            first = fields.Str()
+
+        res = openapi.schema2jsonschema(UnknownSchema(unknown=instance_unknown))
+        if expected is None:
+            assert "additionalProperties" not in res
+        else:
+            assert res["additionalProperties"] is expected
+
     def test_only_explicitly_declared_fields_are_translated(self, openapi):
         class UserSchema(Schema):
             _id = fields.Int()


### PR DESCRIPTION
- Fixes #821: Set `additionnalProperties` to `False` if `unknown` is not set
- Set `additionnalProperties` according to instance `unknown` rather than class `Meta`, to support setting it at instantiation

This could be wrong if `unknown` is set as `load` parameter, but I don't think we can address this.