### PR TITLE
Update TimeDelta field type to float for Marshmallow v4

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -87,3 +87,4 @@ Contributors (chronological)
 - Robert Shepley `@ShepleySound <https://github.com/ShepleySound>`_
 - Robin `@allrob23 <https://github.com/allrob23>`_
 - Xingang Zhang `@0x0400 <https://github.com/0x0400>`_
+- Lewis Haley `@LewisHaley <https://github.com/LewisHaley>`_

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -31,7 +31,7 @@ DEFAULT_FIELD_MAPPING: dict[type, tuple[str | None, str | None]] = {
     marshmallow.fields.DateTime: ("string", "date-time"),
     marshmallow.fields.Date: ("string", "date"),
     marshmallow.fields.Time: ("string", None),
-    marshmallow.fields.TimeDelta: ("integer", None),
+    marshmallow.fields.TimeDelta: ("number", None),
     marshmallow.fields.Email: ("string", "email"),
     marshmallow.fields.URL: ("string", "url"),
     marshmallow.fields.Dict: ("object", None),
@@ -538,6 +538,13 @@ class FieldConverterMixin:
         ret = {}
         if isinstance(field, marshmallow.fields.TimeDelta):
             ret["x-unit"] = field.precision
+            # Required for Marshmallow <4. Can be removed when support for Marshmallow 3 is dropped.
+            # This overrides the type set in field2type_and_format (from DEFAULT_FIELD_MAPPING)
+            if hasattr(field, "serialization_type"):
+                ret["type"] = {
+                    int: "integer",
+                    float: "number",
+                }.get(field.serialization_type, "number")
         return ret
 
     def enum2properties(self, field, **kwargs: typing.Any) -> dict:

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -1,12 +1,16 @@
 import datetime as dt
+import importlib.metadata
 import re
 from enum import Enum
 
 import pytest
 from marshmallow import Schema, fields, validate
+from packaging.version import Version
 
 from .schemas import CategorySchema, CustomIntegerField, CustomList, CustomStringField
 from .utils import build_ref, get_schemas
+
+MA_VERSION = Version(importlib.metadata.version("marshmallow"))
 
 
 def test_field2choices_preserving_order(openapi):
@@ -28,7 +32,7 @@ def test_field2choices_preserving_order(openapi):
         (fields.DateTime, "string"),
         (fields.Date, "string"),
         (fields.Time, "string"),
-        (fields.TimeDelta, "integer"),
+        (fields.TimeDelta, "number" if MA_VERSION.major >= 4 else "integer"),
         (fields.Email, "string"),
         (fields.URL, "string"),
         (fields.IP, "string"),
@@ -43,6 +47,26 @@ def test_field2property_type(FieldClass, jsontype, spec_fixture):
     field = FieldClass()
     res = spec_fixture.openapi.field2property(field)
     assert res["type"] == jsontype
+
+
+@pytest.mark.skipif(
+    MA_VERSION.major >= 4, reason="Marshmallow 4 removed serialization_type attribute"
+)
+@pytest.mark.parametrize(
+    ("serialization_type", "expected_type"),
+    [
+        (int, "integer"),
+        (float, "number"),
+    ],
+)
+def test_field2property_type_for_timedelta_marshmallow_3(
+    spec_fixture,
+    serialization_type,
+    expected_type,
+):
+    field = fields.TimeDelta(serialization_type=serialization_type)
+    res = spec_fixture.openapi.field2property(field)
+    assert res["type"] == expected_type
 
 
 def test_field2property_no_type(spec_fixture):


### PR DESCRIPTION
In Marshmallow v3.17.0, up until v4, the `TimeDelta` field could be serialized into either an integer or a float, depending on user specification of the field. [1] In the case the user set `serialization_type=float`, apispec would generate the wrong JSON type in the API docs.

With Marshmallow v4, this was removed and `TimeDelta` fields *always* serialize to floats, in which case apispec always generates the wrong docs.

This commit updates the default field mapping anticipating Marshmallow v4's float serialization, with some additional support added for <v4 by looking for the deprecated and removed `serialization_type` attribute on the field object.

[1] https://marshmallow.readthedocs.io/en/stable/marshmallow.fields.html#marshmallow.fields.TimeDelta