### PR TITLE
Feat/support `examples` property

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -88,3 +88,4 @@ Contributors (chronological)
 - Robin `@allrob23 <https://github.com/allrob23>`_
 - Xingang Zhang `@0x0400 <https://github.com/0x0400>`_
 - Lewis Haley `@LewisHaley <https://github.com/LewisHaley>`_
+- Felix Claessen `@Flix6x <https://github.com/Flix6x>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Other changes:
 - Officially support Python 3.14 (:pr:`998`).
 - Drop support for Python 3.8 (:pr:`994`).
 - Support ``examples`` property from field metadata (:pr:`999`).
+  Thanks :user:`Flix6x` for the PR.
 
 6.8.4 (2025-09-22)
 ******************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Other changes:
 
 - Officially support Python 3.14 (:pr:`998`).
 - Drop support for Python 3.8 (:pr:`994`).
+- Support ``examples`` property from field metadata (:pr:`999`).
 
 6.8.4 (2025-09-22)
 ******************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,10 +23,10 @@ Bug fixes:
 
 Bug fixes:
 
-- ``MarshmallowPlugin``: set ``additionnalProperties`` to ``False`` if
+- ``MarshmallowPlugin``: set ``additionalProperties`` to ``False`` if
   ``unknown`` is not set (:pr:`988`).
   Thanks :user:`mwgamble` for reporting.
-- ``MarshmallowPlugin``: set ``additionnalProperties`` according to ``unknown``
+- ``MarshmallowPlugin``: set ``additionalProperties`` according to ``unknown``
   value passed at schema instantiation, not only as ``Meta`` attribute
   (:pr:`988`).
 

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -80,6 +80,7 @@ _VALID_PROPERTIES = {
     "xml",
     "externalDocs",
     "example",
+    "examples",
     "nullable",
     "deprecated",
 }

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -685,3 +685,11 @@ def test_field2property_with_non_string_metadata_keys(spec_fixture):
     field.metadata[_DesertSentinel()] = "to be ignored"
     result = spec_fixture.openapi.field2property(field)
     assert result == {"description": "A description", "type": "boolean"}
+
+
+def test_field2property_examples(spec_fixture):
+    field = fields.Raw(metadata={"examples": ["foo", "bar"]})
+    res = spec_fixture.openapi.field2property(field)
+    assert res == {
+        "examples": ["foo", "bar"],
+    }


### PR DESCRIPTION
I realize you did some work yourself on supporting the `examples` property, but I'm not sure if that is still ongoing. The [`examples` branch](https://github.com/marshmallow-code/apispec/tree/examples) hasn't been updated in 3 years.

Related discussion on supporting OpenAPI 3.1: https://github.com/marshmallow-code/apispec/issues/579

The [OpenAPI upgrading docs](https://learn.openapis.org/upgrading/v3.0-to-v3.1.html#change-schema-example-to-examples) suggest moving from `example` to `examples`, but as of now, both seem to be supported, so I haven't removed the singular `example` from the list of valid properties.
