### PR TITLE
fix: recognize iso8601 and rfc822 as valid DateTime format aliases

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -89,3 +89,4 @@ Contributors (chronological)
 - Xingang Zhang `@0x0400 <https://github.com/0x0400>`_
 - Lewis Haley `@LewisHaley <https://github.com/LewisHaley>`_
 - Felix Claessen `@Flix6x <https://github.com/Flix6x>`_
+- Karthik Ramadugu `@karthiksai109 <https://github.com/karthiksai109>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+unreleased
+**********
+
+Bug fixes:
+
+- ``MarshmallowPlugin``: Handle `DateTime` fields with the `"iso8601"` and `"rfc822"`
+  formats (:issue:`970`). Thanks :user:`matejsp` for reporting and `karthiksai109`
+  for the PR (:pr:`1013`).
+
 6.9.0 (2025-11-30)
 ******************
 

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -574,11 +574,11 @@ class FieldConverterMixin:
         """
         ret = {}
         if isinstance(field, marshmallow.fields.DateTime):
-            if field.format == "iso" or field.format is None:
+            if field.format in ("iso", "iso8601") or field.format is None:
                 # Will return { "type": "string", "format": "date-time" }
                 # as specified inside DEFAULT_FIELD_MAPPING
                 pass
-            elif field.format == "rfc":
+            elif field.format in ("rfc", "rfc822"):
                 ret = {
                     "type": "string",
                     "format": None,

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -550,8 +550,30 @@ def test_datetime2property_iso(spec_fixture):
     }
 
 
+def test_datetime2property_iso8601(spec_fixture):
+    field = fields.DateTime(format="iso8601")
+    res = spec_fixture.openapi.field2property(field)
+    assert res == {
+        "type": "string",
+        "format": "date-time",
+    }
+
+
 def test_datetime2property_rfc(spec_fixture):
     field = fields.DateTime(format="rfc")
+    res = spec_fixture.openapi.field2property(field)
+    assert res == {
+        "type": "string",
+        "format": None,
+        "example": "Wed, 02 Oct 2002 13:00:00 GMT",
+        "pattern": r"((Mon|Tue|Wed|Thu|Fri|Sat|Sun), ){0,1}\d{2} "
+        + r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} "
+        + r"(UT|GMT|EST|EDT|CST|CDT|MST|MDT|PST|PDT|(Z|A|M|N)|(\+|-)\d{4})",
+    }
+
+
+def test_datetime2property_rfc822(spec_fixture):
+    field = fields.DateTime(format="rfc822")
     res = spec_fixture.openapi.field2property(field)
     assert res == {
         "type": "string",


### PR DESCRIPTION
Fixes #970
 
Marshmallow's DateTime field accepts both short and long format names
(iso/iso8601, rfc/rfc822) in its SERIALIZATION_FUNCS and
DESERIALIZATION_FUNCS. However, datetime2properties only checked for
the short forms, causing iso8601 and rfc822 to fall through to the
custom format branch — producing incorrect OpenAPI output.
 
- iso8601 → was missing "format": "date-time", got "format": None
- rfc822 → was missing the RFC pattern/example, got "format": None
 
Added the long-form aliases to the existing checks and tests for both.
Full test suite: 598 passed, 6 skipped.