### PR TITLE
Add OpenAPI Links support (#615)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -90,3 +90,4 @@ Contributors (chronological)
 - Lewis Haley `@LewisHaley <https://github.com/LewisHaley>`_
 - Felix Claessen `@Flix6x <https://github.com/Flix6x>`_
 - Karthik Ramadugu `@karthiksai109 <https://github.com/karthiksai109>`_
+- Amir Kahriman `@kingdomOfIT <https://github.com/kingdomOfIT>`_

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -51,12 +51,14 @@ class Components:
         self.parameters: dict[str, dict] = {}
         self.headers: dict[str, dict] = {}
         self.examples: dict[str, dict] = {}
+        self.links: dict[str, dict] = {}
         self.security_schemes: dict[str, dict] = {}
         self.schemas_lazy: dict[str, dict] = {}
         self.responses_lazy: dict[str, dict] = {}
         self.parameters_lazy: dict[str, dict] = {}
         self.headers_lazy: dict[str, dict] = {}
         self.examples_lazy: dict[str, dict] = {}
+        self.links_lazy: dict[str, dict] = {}
 
         self._subsections = {
             "schema": self.schemas,
@@ -64,6 +66,7 @@ class Components:
             "parameter": self.parameters,
             "header": self.headers,
             "example": self.examples,
+            "link": self.links,
             "security_scheme": self.security_schemes,
         }
         self._subsections_lazy = {
@@ -72,6 +75,7 @@ class Components:
             "parameter": self.parameters_lazy,
             "header": self.headers_lazy,
             "example": self.examples_lazy,
+            "link": self.links_lazy,
         }
 
     def to_dict(self) -> dict[str, dict]:
@@ -294,6 +298,24 @@ class Components:
         self._register_component("example", component_id, component, lazy=lazy)
         return self
 
+    def link(
+        self, component_id: str, component: dict, *, lazy: bool = False
+    ) -> Components:
+        """Add a link which can be referenced
+
+        :param str component_id: identifier by which link may be referenced
+        :param dict component: link fields
+        :param bool lazy: register component only when referenced in the spec
+
+        https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#linkObject
+        """
+        if component_id in self.links:
+            raise DuplicateComponentNameError(
+                f'Another link with name "{component_id}" is already registered.'
+            )
+        self._register_component("link", component_id, component, lazy=lazy)
+        return self
+
     def security_scheme(self, component_id: str, component: dict) -> Components:
         """Add a security scheme which can be referenced.
 
@@ -363,7 +385,8 @@ class Components:
             for name, header in response.get("headers", {}).items():
                 response["headers"][name] = self.get_ref("header", header)
                 self._resolve_refs_in_parameter_or_header(response["headers"][name])
-            # TODO: Resolve link refs when Components supports links
+            for name, link in response.get("links", {}).items():
+                response["links"][name] = self.get_ref("link", link)
 
     def _resolve_refs_in_operation(self, operation) -> None:
         if "parameters" in operation:
@@ -537,6 +560,10 @@ class APISpec:
 
         self._clean_operations(operations)
 
+        # Process links if provided (OpenAPI 3+ only)
+        if "links" in kwargs and self.openapi_version.major >= 3:
+            self._process_links(operations, kwargs["links"])
+
         self._paths.setdefault(path, operations).update(operations)
         if summary is not None:
             self._paths[path]["summary"] = summary
@@ -629,3 +656,69 @@ class APISpec:
                             )
                     responses[str(code)] = response
                 operation["responses"] = responses
+
+    def _process_links(
+        self,
+        operations: dict[str, dict],
+        links_spec: dict[str, tuple],
+    ) -> None:
+        """Process links specification and inject into operation responses.
+
+        :param dict operations: Dict mapping HTTP methods to operation objects
+        :param dict links_spec: Dict mapping link names to (route, method) or (route, method, parameters) tuples
+        """
+        # Convert link tuples to proper link objects
+        link_objects = {}
+        for link_name, link_tuple in links_spec.items():
+            if (
+                not isinstance(link_tuple, tuple)
+                or len(link_tuple) < 2
+                or len(link_tuple) > 3
+            ):
+                raise APISpecError(
+                    f"Link '{link_name}' must be a tuple of (route, method) or (route, method, parameters)"
+                )
+
+            route = link_tuple[0]
+            method = link_tuple[1]
+            parameters = link_tuple[2] if len(link_tuple) == 3 else {}
+
+            if not isinstance(route, str):
+                raise APISpecError(f"Link '{link_name}' route must be a string")
+            if not isinstance(method, str):
+                raise APISpecError(f"Link '{link_name}' method must be a string")
+            if not isinstance(parameters, dict):
+                raise APISpecError(f"Link '{link_name}' parameters must be a dict")
+
+            # Validate method
+            method = method.lower()
+            valid_methods = set(VALID_METHODS[self.openapi_version.major])
+            if method not in valid_methods:
+                raise APISpecError(
+                    f"Link '{link_name}' has invalid HTTP method: {method}"
+                )
+
+            # Prefer operationId if target operation already registered
+            operation_id = (
+                self._paths.get(route, {}).get(method.lower(), {}).get("operationId")
+            )
+            link_obj = (
+                {"operationId": operation_id}
+                if operation_id
+                else {
+                    "operationRef": f"#/paths/{route.replace('~', '~0').replace('/', '~1')}/{method}"
+                }
+            )
+            if parameters:
+                link_obj["parameters"] = parameters
+
+            link_objects[link_name] = link_obj
+
+        # Inject links into all responses of all operations
+        for operation in operations.values():
+            if isinstance(operation, dict) and "responses" in operation:
+                for response in operation["responses"].values():
+                    if isinstance(response, dict):
+                        if "links" not in response:
+                            response["links"] = {}
+                        response["links"].update(deepcopy(link_objects))

--- a/src/apispec/core.py
+++ b/src/apispec/core.py
@@ -685,10 +685,6 @@ class APISpec:
 
             if not isinstance(route, str):
                 raise APISpecError(f"Link '{link_name}' route must be a string")
-            if not isinstance(method, str):
-                raise APISpecError(f"Link '{link_name}' method must be a string")
-            if not isinstance(parameters, dict):
-                raise APISpecError(f"Link '{link_name}' parameters must be a dict")
 
             # Validate method
             method = method.lower()
@@ -698,7 +694,7 @@ class APISpec:
                     f"Link '{link_name}' has invalid HTTP method: {method}"
                 )
 
-            # Prefer operationId if target operation already registered
+            # Prefer operationId if defined
             operation_id = (
                 self._paths.get(route, {}).get(method.lower(), {}).get("operationId")
             )

--- a/src/apispec/utils.py
+++ b/src/apispec/utils.py
@@ -19,6 +19,7 @@ COMPONENT_SUBSECTIONS = {
         "parameter": "parameters",
         "header": "headers",
         "example": "examples",
+        "link": "links",
         "security_scheme": "securitySchemes",
     },
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,6 +16,7 @@ from .utils import (
     build_ref,
     get_examples,
     get_headers,
+    get_links,
     get_parameters,
     get_paths,
     get_responses,
@@ -340,6 +341,24 @@ class TestComponents(RefsSchemaTestMixin):
         ):
             spec.components.example("test_example", {})
 
+    @pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
+    def test_links(self, spec):
+        link = {
+            "operationRef": "#/paths/~1users~1{user_id}/get",
+            "parameters": {"user_id": "$response.body#/id"},
+        }
+        spec.components.link("GetUser", link)
+        links = get_links(spec)
+        assert "GetUser" in links
+        assert links["GetUser"] == link
+
+    @pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
+    def test_links_duplicate_name(self, spec):
+        link = {"operationRef": "#/paths/~1users/get"}
+        spec.components.link("GetUser", link)
+        with pytest.raises(APISpecError, match='Another link with name "GetUser"'):
+            spec.components.link("GetUser", link)
+
     def test_security_scheme(self, spec):
         sec_scheme = {"type": "apiKey", "in": "header", "name": "X-API-Key"}
         spec.components.security_scheme("ApiKeyAuth", sec_scheme)
@@ -594,6 +613,34 @@ class TestComponents(RefsSchemaTestMixin):
             },
         )
         assert "Example_2" in examples
+
+    @pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
+    def test_links_lazy(self, spec):
+        link = {"operationRef": "#/paths/~1users~1{user_id}/get"}
+        spec.components.link("GetUser", link, lazy=True)
+        # Should not appear until referenced
+        links = get_links(spec)
+        assert "GetUser" not in links
+
+        # Reference the link and verify it appears
+        spec.path(
+            path="/path",
+            operations={
+                "get": {
+                    "responses": {
+                        "201": {
+                            "description": "Created",
+                            "links": {
+                                "GetUser": "GetUser",  # Reference by name
+                            },
+                        }
+                    }
+                }
+            },
+        )
+        links = get_links(spec)
+        assert "GetUser" in links
+        assert links["GetUser"] == link
 
 
 class TestPath(RefsSchemaTestMixin):

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -2,33 +2,7 @@ import pytest
 
 from apispec.exceptions import APISpecError
 
-from .utils import build_ref, get_links, get_paths
-
-
-@pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
-class TestLinksComponent:
-    def test_link_component_registration(self, spec):
-        link = {
-            "operationRef": "#/paths/~1users~1{user_id}/get",
-            "parameters": {"user_id": "$response.body#/id"},
-        }
-        spec.components.link("GetUser", link)
-        links = get_links(spec)
-        assert "GetUser" in links
-        assert links["GetUser"] == link
-
-    def test_link_component_lazy_registration(self, spec):
-        link = {"operationRef": "#/paths/~1users~1{user_id}/get"}
-        spec.components.link("GetUser", link, lazy=True)
-        # Should not appear until referenced
-        links = get_links(spec)
-        assert "GetUser" not in links
-
-    def test_link_component_duplicate_error(self, spec):
-        link = {"operationRef": "#/paths/~1users/get"}
-        spec.components.link("GetUser", link)
-        with pytest.raises(APISpecError, match='Another link with name "GetUser"'):
-            spec.components.link("GetUser", link)
+from .utils import build_ref, get_paths
 
 
 @pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
@@ -237,13 +211,20 @@ class TestLinksOpenAPI2:
 
 @pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
 class TestLinksErrorHandling:
-    def test_invalid_tuple_length(self, spec):
+    @pytest.mark.parametrize(
+        "invalid_tuple",
+        [
+            ("/posts/{id}",),
+            ("/posts/{id}", "GET", {}, "extra"),
+        ],
+    )
+    def test_invalid_tuple_length(self, spec, invalid_tuple):
         with pytest.raises(APISpecError, match="must be a tuple of"):
             spec.path(
                 path="/posts",
                 operations={"post": {"responses": {"201": {"description": "Created"}}}},
                 links={
-                    "GetPost": ("/posts/{id}",),  # Only one element
+                    "GetPost": invalid_tuple,
                 },
             )
 
@@ -267,16 +248,6 @@ class TestLinksErrorHandling:
                 },
             )
 
-    def test_invalid_method_type(self, spec):
-        with pytest.raises(APISpecError, match="method must be a string"):
-            spec.path(
-                path="/posts",
-                operations={"post": {"responses": {"201": {"description": "Created"}}}},
-                links={
-                    "GetPost": ("/posts/{id}", 123),  # Method is not a string
-                },
-            )
-
     def test_invalid_http_method(self, spec):
         with pytest.raises(APISpecError, match="invalid HTTP method"):
             spec.path(
@@ -284,16 +255,6 @@ class TestLinksErrorHandling:
                 operations={"post": {"responses": {"201": {"description": "Created"}}}},
                 links={
                     "GetPost": ("/posts/{id}", "INVALID"),
-                },
-            )
-
-    def test_invalid_parameters_type(self, spec):
-        with pytest.raises(APISpecError, match="parameters must be a dict"):
-            spec.path(
-                path="/posts",
-                operations={"post": {"responses": {"201": {"description": "Created"}}}},
-                links={
-                    "GetPost": ("/posts/{id}", "GET", "not-a-dict"),
                 },
             )
 

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,385 @@
+import pytest
+
+from apispec.exceptions import APISpecError
+
+from .utils import build_ref, get_links, get_paths
+
+
+@pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
+class TestLinksComponent:
+    def test_link_component_registration(self, spec):
+        link = {
+            "operationRef": "#/paths/~1users~1{user_id}/get",
+            "parameters": {"user_id": "$response.body#/id"},
+        }
+        spec.components.link("GetUser", link)
+        links = get_links(spec)
+        assert "GetUser" in links
+        assert links["GetUser"] == link
+
+    def test_link_component_lazy_registration(self, spec):
+        link = {"operationRef": "#/paths/~1users~1{user_id}/get"}
+        spec.components.link("GetUser", link, lazy=True)
+        # Should not appear until referenced
+        links = get_links(spec)
+        assert "GetUser" not in links
+
+    def test_link_component_duplicate_error(self, spec):
+        link = {"operationRef": "#/paths/~1users/get"}
+        spec.components.link("GetUser", link)
+        with pytest.raises(APISpecError, match='Another link with name "GetUser"'):
+            spec.components.link("GetUser", link)
+
+
+@pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
+class TestLinksInPath:
+    def test_basic_two_element_tuple(self, spec):
+        spec.path(
+            path="/posts",
+            operations={
+                "post": {
+                    "responses": {
+                        "201": {
+                            "description": "Created",
+                        }
+                    }
+                }
+            },
+            links={
+                "GetPost": ("/posts/{post_id}", "GET"),
+            },
+        )
+        paths = get_paths(spec)
+        post_response = paths["/posts"]["post"]["responses"]["201"]
+        assert "links" in post_response
+        assert "GetPost" in post_response["links"]
+        link = post_response["links"]["GetPost"]
+        assert link["operationRef"] == "#/paths/~1posts~1{post_id}/get"
+        assert "parameters" not in link
+
+    def test_three_element_tuple_with_parameters(self, spec):
+        spec.path(
+            path="/posts",
+            operations={
+                "post": {
+                    "responses": {
+                        "201": {
+                            "description": "Created",
+                        }
+                    }
+                }
+            },
+            links={
+                "GetPost": (
+                    "/posts/{post_id}",
+                    "GET",
+                    {"post_id": "$response.body#/postIdentifier"},
+                ),
+            },
+        )
+        paths = get_paths(spec)
+        post_response = paths["/posts"]["post"]["responses"]["201"]
+        link = post_response["links"]["GetPost"]
+        assert link["operationRef"] == "#/paths/~1posts~1{post_id}/get"
+        assert link["parameters"] == {"post_id": "$response.body#/postIdentifier"}
+
+    def test_multiple_links_on_single_endpoint(self, spec):
+        spec.path(
+            path="/users",
+            operations={
+                "post": {
+                    "responses": {
+                        "201": {
+                            "description": "Created",
+                        }
+                    }
+                }
+            },
+            links={
+                "GetUser": ("/users/{user_id}", "GET"),
+                "UpdateUser": ("/users/{user_id}", "PUT"),
+                "DeleteUser": ("/users/{user_id}", "DELETE"),
+            },
+        )
+        paths = get_paths(spec)
+        post_response = paths["/users"]["post"]["responses"]["201"]
+        assert "links" in post_response
+        assert len(post_response["links"]) == 3
+        assert "GetUser" in post_response["links"]
+        assert "UpdateUser" in post_response["links"]
+        assert "DeleteUser" in post_response["links"]
+
+    def test_links_added_to_multiple_operations(self, spec):
+        spec.path(
+            path="/posts",
+            operations={
+                "get": {
+                    "responses": {
+                        "200": {"description": "Success"},
+                    }
+                },
+                "post": {
+                    "responses": {
+                        "201": {"description": "Created"},
+                    }
+                },
+            },
+            links={
+                "GetPost": ("/posts/{post_id}", "GET"),
+            },
+        )
+        paths = get_paths(spec)
+        # Both operations should have the link in their responses
+        assert "GetPost" in paths["/posts"]["get"]["responses"]["200"]["links"]
+        assert "GetPost" in paths["/posts"]["post"]["responses"]["201"]["links"]
+
+    def test_links_not_shared_between_paths(self, spec):
+        spec.path(
+            path="/users",
+            operations={"post": {"responses": {"201": {"description": "Created"}}}},
+            links={"GetUser": ("/users/{user_id}", "GET")},
+        )
+        spec.path(
+            path="/posts",
+            operations={"post": {"responses": {"201": {"description": "Created"}}}},
+            links={"GetPost": ("/posts/{post_id}", "GET")},
+        )
+        paths = get_paths(spec)
+        # Each path should only have its own links
+        assert "GetPost" not in paths["/users"]["post"]["responses"]["201"]["links"]
+        assert "GetUser" not in paths["/posts"]["post"]["responses"]["201"]["links"]
+
+    def test_path_escaping_for_json_pointer(self, spec):
+        spec.path(
+            path="/posts",
+            operations={
+                "post": {
+                    "responses": {
+                        "201": {"description": "Created"},
+                    }
+                }
+            },
+            links={
+                "GetPost": ("/posts/{id}", "GET"),
+            },
+        )
+        paths = get_paths(spec)
+        link = paths["/posts"]["post"]["responses"]["201"]["links"]["GetPost"]
+        # Forward slashes should be escaped as ~1
+        assert link["operationRef"] == "#/paths/~1posts~1{id}/get"
+
+    def test_path_escaping_with_tilde(self, spec):
+        spec.path(
+            path="/posts",
+            operations={
+                "post": {
+                    "responses": {
+                        "201": {"description": "Created"},
+                    }
+                }
+            },
+            links={
+                "GetItem": ("/items/~special", "GET"),
+            },
+        )
+        paths = get_paths(spec)
+        link = paths["/posts"]["post"]["responses"]["201"]["links"]["GetItem"]
+        # Tildes should be escaped as ~0, then slashes as ~1
+        assert link["operationRef"] == "#/paths/~1items~1~0special/get"
+
+    def test_prefers_operationId_when_target_registered(self, spec):
+        """If the target operation is already registered with an operationId,
+        the link should use `operationId` instead of `operationRef`.
+        """
+        # Register the target operation first
+        spec.path(
+            path="/posts/{post_id}",
+            operations={
+                "get": {
+                    "operationId": "getPost",
+                    "responses": {"200": {"description": "Success"}},
+                }
+            },
+        )
+
+        # Add a different path that links to the registered operation
+        spec.path(
+            path="/comments",
+            operations={"post": {"responses": {"201": {"description": "Created"}}}},
+            links={"GetPost": ("/posts/{post_id}", "GET")},
+        )
+
+        paths = get_paths(spec)
+        link = paths["/comments"]["post"]["responses"]["201"]["links"]["GetPost"]
+        assert link == {"operationId": "getPost"}
+
+
+@pytest.mark.parametrize("spec", ("2.0",), indirect=True)
+class TestLinksOpenAPI2:
+    def test_links_ignored_in_openapi_2(self, spec):
+        spec.path(
+            path="/posts",
+            operations={
+                "post": {
+                    "responses": {
+                        "201": {"description": "Created"},
+                    }
+                }
+            },
+            links={
+                "GetPost": ("/posts/{post_id}", "GET"),
+            },
+        )
+        paths = get_paths(spec)
+        post_response = paths["/posts"]["post"]["responses"]["201"]
+        assert "links" not in post_response
+
+
+@pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
+class TestLinksErrorHandling:
+    def test_invalid_tuple_length(self, spec):
+        with pytest.raises(APISpecError, match="must be a tuple of"):
+            spec.path(
+                path="/posts",
+                operations={"post": {"responses": {"201": {"description": "Created"}}}},
+                links={
+                    "GetPost": ("/posts/{id}",),  # Only one element
+                },
+            )
+
+    def test_invalid_tuple_type(self, spec):
+        with pytest.raises(APISpecError, match="must be a tuple of"):
+            spec.path(
+                path="/posts",
+                operations={"post": {"responses": {"201": {"description": "Created"}}}},
+                links={
+                    "GetPost": "/posts/{id}",  # String instead of tuple
+                },
+            )
+
+    def test_invalid_route_type(self, spec):
+        with pytest.raises(APISpecError, match="route must be a string"):
+            spec.path(
+                path="/posts",
+                operations={"post": {"responses": {"201": {"description": "Created"}}}},
+                links={
+                    "GetPost": (123, "GET"),  # Route is not a string
+                },
+            )
+
+    def test_invalid_method_type(self, spec):
+        with pytest.raises(APISpecError, match="method must be a string"):
+            spec.path(
+                path="/posts",
+                operations={"post": {"responses": {"201": {"description": "Created"}}}},
+                links={
+                    "GetPost": ("/posts/{id}", 123),  # Method is not a string
+                },
+            )
+
+    def test_invalid_http_method(self, spec):
+        with pytest.raises(APISpecError, match="invalid HTTP method"):
+            spec.path(
+                path="/posts",
+                operations={"post": {"responses": {"201": {"description": "Created"}}}},
+                links={
+                    "GetPost": ("/posts/{id}", "INVALID"),
+                },
+            )
+
+    def test_invalid_parameters_type(self, spec):
+        with pytest.raises(APISpecError, match="parameters must be a dict"):
+            spec.path(
+                path="/posts",
+                operations={"post": {"responses": {"201": {"description": "Created"}}}},
+                links={
+                    "GetPost": ("/posts/{id}", "GET", "not-a-dict"),
+                },
+            )
+
+    def test_case_insensitive_method(self, spec):
+        spec.path(
+            path="/posts",
+            operations={"post": {"responses": {"201": {"description": "Created"}}}},
+            links={
+                "GetPost": ("/posts/{id}", "GeT"),  # Mixed case
+            },
+        )
+        paths = get_paths(spec)
+        link = paths["/posts"]["post"]["responses"]["201"]["links"]["GetPost"]
+        # Method should be lowercased in the operationRef
+        assert link["operationRef"] == "#/paths/~1posts~1{id}/get"
+
+
+@pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
+class TestLinksWithReferences:
+    def test_link_component_reference_in_response(self, spec):
+        # Register a link component
+        link_def = {
+            "operationRef": "#/paths/~1users~1{user_id}/get",
+            "parameters": {"user_id": "$response.body#/id"},
+        }
+        spec.components.link("GetUserLink", link_def)
+
+        # Use the link as a reference in a response
+        spec.path(
+            path="/posts",
+            operations={
+                "post": {
+                    "responses": {
+                        "201": {
+                            "description": "Created",
+                            "links": {
+                                "GetUser": "GetUserLink",
+                            },
+                        }
+                    }
+                }
+            },
+        )
+
+        paths = get_paths(spec)
+        post_response = paths["/posts"]["post"]["responses"]["201"]
+        # The reference should be resolved to $ref
+        assert post_response["links"]["GetUser"] == build_ref(
+            spec, "link", "GetUserLink"
+        )
+
+    def test_mixed_direct_and_reference_links(self, spec):
+        # Register a link component
+        spec.components.link(
+            "GetUserLink", {"operationRef": "#/paths/~1users~1{user_id}/get"}
+        )
+
+        expected_operation_ref = "#/paths/~1posts~1{id}/get"
+        # Use both direct links and references
+        spec.path(
+            path="/posts",
+            operations={
+                "post": {
+                    "responses": {
+                        "201": {
+                            "description": "Created",
+                            "links": {
+                                "GetUser": "GetUserLink",  # Reference
+                                "DirectLink": {  # Direct object
+                                    "operationRef": expected_operation_ref
+                                },
+                            },
+                        }
+                    }
+                }
+            },
+        )
+
+        paths = get_paths(spec)
+        post_response = paths["/posts"]["post"]["responses"]["201"]
+        # Reference should be $ref
+        assert post_response["links"]["GetUser"] == build_ref(
+            spec, "link", "GetUserLink"
+        )
+        # Direct object should remain as is
+        assert (
+            post_response["links"]["DirectLink"]["operationRef"]
+            == expected_operation_ref
+        )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,9 +38,10 @@ def get_examples(spec):
 
 def get_links(spec):
     spec_dict = spec.to_dict()
-    if "components" not in spec_dict:
+    components = spec_dict.get("components")
+    if not components:
         return {}
-    return spec_dict["components"]["links"]
+    return components.get("links", {})
 
 
 def get_security_schemes(spec):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,6 +36,13 @@ def get_examples(spec):
     return spec.to_dict()["components"]["examples"]
 
 
+def get_links(spec):
+    spec_dict = spec.to_dict()
+    if "components" not in spec_dict:
+        return {}
+    return spec_dict["components"]["links"]
+
+
 def get_security_schemes(spec):
     if spec.openapi_version.major < 3:
         return spec.to_dict()["securityDefinitions"]


### PR DESCRIPTION
Closes #615

Adds support for defining OpenAPI Links on path operations via the `links` 
kwarg on `APISpec.path()`, as discussed in the issue with @zedrdave.

Links accept a dictionary of tuples in the format agreed with @lafrech:

links={
    "GetUser": ("/users/{user_id}", "GET"),
    "UpdateUser": ("/users/{user_id}", "PUT"),
    "GetUserCustomParam": ("/users/{user_id}", "GET", {"user_id": "$response.body#/id"})
}

Implementation automatically uses `operationId` when the target operation 
has one registered, falling back to `operationRef` with JSON Pointer escaping 
when not. Links are only processed for OpenAPI 3+.