### PR TITLE
docs: remove reference to removed validate_spec utility

### DIFF
--- a/docs/special_topics.rst
+++ b/docs/special_topics.rst
@@ -93,7 +93,6 @@ Here is an example that includes a `Server Object <https://github.com/OAI/OpenAP
     import yaml
     from apispec import APISpec
     from apispec.ext.marshmallow import MarshmallowPlugin
-    from apispec.utils import validate_spec
 
     OPENAPI_SPEC = """
     openapi: 3.0.2
@@ -125,8 +124,6 @@ Here is an example that includes a `Server Object <https://github.com/OAI/OpenAP
         plugins=(MarshmallowPlugin(),),
         **settings
     )
-
-    validate_spec(spec)
 
 
 Documenting Security Schemes


### PR DESCRIPTION
## Summary

Remove the import and call to `validate_spec` from the special_topics documentation example. This function was removed from the public API (see #308) but the docs still referenced it, causing confusion for new users.

Closes #969

For spec validation, users can use the [openapi-spec-validator](https://pypi.org/project/openapi-spec-validator/) package directly.