### PR TITLE
Rework test.utils.get_* methods

### DIFF
--- a/tests/test_ext_marshmallow.py
+++ b/tests/test_ext_marshmallow.py
@@ -68,8 +68,7 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        with pytest.raises(KeyError):
-            get_schemas(spec)
+        assert get_schemas(spec) == {}
 
         spec.components.schema("analysis", schema=schema)
         spec.path(
@@ -103,8 +102,7 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        with pytest.raises(KeyError):
-            get_schemas(spec)
+        assert get_schemas(spec) == {}
 
         spec.components.schema("analysis", schema=schema)
         spec.path(
@@ -135,8 +133,7 @@ class TestDefinitionHelper:
             openapi_version="2.0",
             plugins=(MarshmallowPlugin(schema_name_resolver=resolver),),
         )
-        with pytest.raises(KeyError):
-            get_schemas(spec)
+        assert get_schemas(spec) == {}
 
         with pytest.raises(
             APISpecError, match="Name resolver returned None for schema"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,44 +10,40 @@ from apispec.utils import build_reference
 
 def get_schemas(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["definitions"]
-    return spec.to_dict()["components"]["schemas"]
+        return spec.to_dict().get("definitions", {})
+    return spec.to_dict()["components"].get("schemas", {})
 
 
 def get_responses(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["responses"]
-    return spec.to_dict()["components"]["responses"]
+        return spec.to_dict().get("responses", {})
+    return spec.to_dict()["components"].get("responses", {})
 
 
 def get_parameters(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["parameters"]
-    return spec.to_dict()["components"]["parameters"]
+        return spec.to_dict().get("parameters", {})
+    return spec.to_dict()["components"].get("parameters", {})
 
 
 def get_headers(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["headers"]
-    return spec.to_dict()["components"]["headers"]
+        return spec.to_dict().get("headers", {})
+    return spec.to_dict()["components"].get("headers", {})
 
 
 def get_examples(spec):
-    return spec.to_dict()["components"]["examples"]
+    return spec.to_dict()["components"].get("examples", {})
 
 
 def get_links(spec):
-    spec_dict = spec.to_dict()
-    components = spec_dict.get("components")
-    if not components:
-        return {}
-    return components.get("links", {})
+    return spec.to_dict()["components"].get("links", {})
 
 
 def get_security_schemes(spec):
     if spec.openapi_version.major < 3:
-        return spec.to_dict()["securityDefinitions"]
-    return spec.to_dict()["components"]["securitySchemes"]
+        return spec.to_dict().get("securityDefinitions", {})
+    return spec.to_dict()["components"].get("securitySchemes", {})
 
 
 def get_paths(spec):


### PR DESCRIPTION
The mess in get_links made me realize the other get_* methods work because other *_lazy tests involve two components, one of which being not lazy, so that the component dict actually exists.

This PR changes those get_* methods to ensure they always return an empty dict, and fixes tests that relied on the fact the dict didn't exist.

The downside is that we don't test that no empty component dict is returned. But those modified tests were not meant to test that anyway.

We could add dedicated tests for that if it matters.