### PR TITLE
feat: support marshmallow-oneofschema OneOfSchema in schema2jsonschema

### DIFF
--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -285,7 +285,7 @@ class OpenAPIConverter(FieldConverterMixin):
         :rtype: dict, a JSON Schema Object
         """
         one_of = []
-        for type_name, type_schema_class in schema.type_schemas.items():
+        for _type_name, type_schema_class in schema.type_schemas.items():
             type_schema = resolve_schema_instance(type_schema_class)
             ref = self.resolve_nested_schema(type_schema)
             one_of.append(ref)

--- a/src/apispec/ext/marshmallow/openapi.py
+++ b/src/apispec/ext/marshmallow/openapi.py
@@ -27,6 +27,13 @@ from .common import (
 )
 from .field_converter import FieldConverterMixin
 
+try:
+    from marshmallow_oneofschema import OneOfSchema as MarshmallowOneOfSchema
+
+    ONEOFSCHEMA_AVAILABLE = True
+except ImportError:
+    ONEOFSCHEMA_AVAILABLE = False
+
 __location_map__ = {
     "match_info": "path",
     "query": "query",
@@ -248,6 +255,9 @@ class OpenAPIConverter(FieldConverterMixin):
         :param Schema schema: A marshmallow Schema instance
         :rtype: dict, a JSON Schema Object
         """
+        if ONEOFSCHEMA_AVAILABLE and isinstance(schema, MarshmallowOneOfSchema):
+            return self._oneof_schema2jsonschema(schema)
+
         fields = get_fields(schema)
         Meta = getattr(schema, "Meta", None)
         partial = getattr(schema, "partial", None)
@@ -266,6 +276,20 @@ class OpenAPIConverter(FieldConverterMixin):
             )
 
         return jsonschema
+
+    def _oneof_schema2jsonschema(self, schema):
+        """Return a JSON Schema Object with ``oneOf`` for a marshmallow-oneofschema
+        :class:`OneOfSchema <marshmallow_oneofschema.OneOfSchema>`.
+
+        :param OneOfSchema schema: A marshmallow_oneofschema OneOfSchema instance
+        :rtype: dict, a JSON Schema Object
+        """
+        one_of = []
+        for type_name, type_schema_class in schema.type_schemas.items():
+            type_schema = resolve_schema_instance(type_schema_class)
+            ref = self.resolve_nested_schema(type_schema)
+            one_of.append(ref)
+        return {"oneOf": one_of}
 
     def fields2jsonschema(self, fields, *, partial=None):
         """Return the JSON Schema Object given a mapping between field names and

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -717,3 +717,32 @@ class TestFieldValidation:
         for attr, expected_value in properties.items():
             assert attr in result
             assert result[attr] == expected_value
+
+
+# https://github.com/marshmallow-code/apispec/issues/1012
+@pytest.mark.skipif(
+    not __import__("importlib").util.find_spec("marshmallow_oneofschema"),
+    reason="marshmallow-oneofschema not installed",
+)
+class TestOneOfSchema:
+    def test_schema2jsonschema_with_oneofschema(self, spec_fixture):
+        from marshmallow_oneofschema import OneOfSchema
+
+        class CatSchema(Schema):
+            indoor = fields.Bool()
+
+        class DogSchema(Schema):
+            breed = fields.Str()
+
+        class PetSchema(OneOfSchema):
+            type_field = "pet_type"
+            type_schemas = {"cat": CatSchema, "dog": DogSchema}
+
+        spec_fixture.spec.components.schema("Pet", schema=PetSchema)
+        schemas = get_schemas(spec_fixture.spec)
+
+        assert "oneOf" in schemas["Pet"]
+        assert len(schemas["Pet"]["oneOf"]) == 2
+        # The sub-schemas should be registered as separate components
+        assert "Cat" in schemas
+        assert "Dog" in schemas


### PR DESCRIPTION
When a schema class inherits from marshmallow_oneofschema.OneOfSchema, apispec previously produced an empty {"type": "object", "properties": {}} because OneOfSchema has no fields of its own.

Fix: at module load time, optionally import marshmallow_oneofschema. In schema2jsonschema(), if the schema is a OneOfSchema instance, delegate to the new _oneof_schema2jsonschema() helper which builds a proper {"oneOf": [{"\": ...}, ...]} by resolving each type_schema entry via resolve_nested_schema(). Falls back to the normal path when marshmallow-oneofschema is not installed.

Closes #1012