### PR TITLE
Support marshmallow Tuple field (#399)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -91,3 +91,4 @@ Contributors (chronological)
 - Felix Claessen `@Flix6x <https://github.com/Flix6x>`_
 - Karthik Ramadugu `@karthiksai109 <https://github.com/karthiksai109>`_
 - Amir Kahriman `@kingdomOfIT <https://github.com/kingdomOfIT>`_
+- Sai Asish Y `@SAY-5 <https://github.com/SAY-5>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 unreleased
 **********
 
+Features:
+
+- Support the marshmallow ``Tuple`` field (:issue:`399`).
+
 Other changes:
 
 - Drop support for marshmallow 3, which is EOL.

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -38,6 +38,7 @@ DEFAULT_FIELD_MAPPING: dict[type, tuple[str | None, str | None]] = {
     marshmallow.fields.Field: (None, None),
     marshmallow.fields.Raw: (None, None),
     marshmallow.fields.List: ("array", None),
+    marshmallow.fields.Tuple: ("array", None),
     marshmallow.fields.IP: ("string", "ip"),
     marshmallow.fields.IPv4: ("string", "ipv4"),
     marshmallow.fields.IPv6: ("string", "ipv6"),
@@ -69,6 +70,7 @@ _VALID_PROPERTIES = {
     "enum",
     "type",
     "items",
+    "prefixItems",
     "allOf",
     "oneOf",
     "anyOf",
@@ -112,6 +114,7 @@ class FieldConverterMixin:
             self.nested2properties,
             self.pluck2properties,
             self.list2properties,
+            self.tuple2properties,
             self.dict2properties,
             self.timedelta2properties,
             self.datetime2properties,
@@ -508,6 +511,26 @@ class FieldConverterMixin:
         ret = {}
         if isinstance(field, marshmallow.fields.List):
             ret["items"] = self.field2property(field.inner)
+        return ret
+
+    def tuple2properties(self, field, **kwargs: typing.Any) -> dict:
+        """Return a dictionary of properties from :class:`Tuple <marshmallow.fields.Tuple>` fields.
+
+        A tuple is a fixed-length, ordered array. For OpenAPI 3.1 the contained
+        fields are described with ``prefixItems``; for earlier versions they are
+        described with ``items`` using ``oneOf``.
+
+        :param Field field: A marshmallow field.
+        :rtype: dict
+        """
+        ret = {}
+        if isinstance(field, marshmallow.fields.Tuple):
+            tuple_fields = [self.field2property(f) for f in field.tuple_fields]
+            ret["minItems"] = ret["maxItems"] = len(tuple_fields)
+            if self.openapi_version.major >= 3 and self.openapi_version.minor >= 1:
+                ret["prefixItems"] = tuple_fields
+            else:
+                ret["items"] = {"oneOf": tuple_fields}
         return ret
 
     def dict2properties(self, field, **kwargs: typing.Any) -> dict:

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -523,7 +523,7 @@ class FieldConverterMixin:
         :param Field field: A marshmallow field.
         :rtype: dict
         """
-        ret = {}
+        ret: dict = {}
         if isinstance(field, marshmallow.fields.Tuple):
             tuple_fields = [self.field2property(f) for f in field.tuple_fields]
             ret["minItems"] = ret["maxItems"] = len(tuple_fields)

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -715,3 +715,34 @@ def test_field2property_examples(spec_fixture):
     assert res == {
         "examples": ["foo", "bar"],
     }
+
+
+def test_tuple_field_translates_to_array(spec_fixture):
+    field = fields.Tuple((fields.String, fields.Integer))
+    res = spec_fixture.openapi.field2property(field)
+    assert res["type"] == "array"
+    assert res["minItems"] == res["maxItems"] == 2
+
+
+@pytest.mark.parametrize("spec_fixture", ("3.1.0",), indirect=True)
+def test_tuple_field_uses_prefix_items_on_openapi_31(spec_fixture):
+    field = fields.Tuple((fields.String, fields.Integer))
+    res = spec_fixture.openapi.field2property(field)
+    assert res["prefixItems"] == [
+        spec_fixture.openapi.field2property(fields.String()),
+        spec_fixture.openapi.field2property(fields.Integer()),
+    ]
+    assert "items" not in res
+
+
+@pytest.mark.parametrize("spec_fixture", ("2.0", "3.0.0"), indirect=True)
+def test_tuple_field_uses_items_one_of_before_openapi_31(spec_fixture):
+    field = fields.Tuple((fields.String, fields.Integer))
+    res = spec_fixture.openapi.field2property(field)
+    assert res["items"] == {
+        "oneOf": [
+            spec_fixture.openapi.field2property(fields.String()),
+            spec_fixture.openapi.field2property(fields.Integer()),
+        ]
+    }
+    assert "prefixItems" not in res


### PR DESCRIPTION
Adds OpenAPI conversion for the marshmallow `Tuple` field, which was requested in #399 ("Yes! Absolutely. Would you like to submit the change?"). The fixed-length contained fields are described with `prefixItems` on OpenAPI 3.1 and with `items`/`oneOf` on earlier versions, and `minItems`/`maxItems` are set to the tuple length. Closes #399.