### PR TITLE
Keep date-time/date format for DateTime/Date custom formats

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -91,3 +91,4 @@ Contributors (chronological)
 - Felix Claessen `@Flix6x <https://github.com/Flix6x>`_
 - Karthik Ramadugu `@karthiksai109 <https://github.com/karthiksai109>`_
 - Amir Kahriman `@kingdomOfIT <https://github.com/kingdomOfIT>`_
+- `@ATOM00blue <https://github.com/ATOM00blue>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Bug fixes:
 
 - ``MarshmallowPlugin``: Handle ``DateTime`` and ``Date`` fields that use a
   custom ``format``. The generated ``format`` is no longer set to ``null`` but
-  keeps ``"date-time"``/``"date"`` (:issue:`938`).
+  keeps ``"date-time"``/``"date"`` (:issue:`938`, :pr:`1047`).
 
 Other changes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 unreleased
 **********
 
+Bug fixes:
+
+- ``MarshmallowPlugin``: Handle ``DateTime`` and ``Date`` fields that use a
+  custom ``format``. The generated ``format`` is no longer set to ``null`` but
+  keeps ``"date-time"``/``"date"`` (:issue:`938`).
+
 Other changes:
 
 - Drop support for marshmallow 3, which is EOL.

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -602,15 +602,11 @@ class FieldConverterMixin:
                     "min": "0",
                 }
             else:
-                ret = {
-                    "type": "string",
-                    "format": None,
-                    "pattern": (
-                        field.metadata["pattern"]
-                        if field.metadata.get("pattern")
-                        else None
-                    ),
-                }
+                # Custom strftime format string. Keep the "type" and "format"
+                # from DEFAULT_FIELD_MAPPING (e.g. "date-time" or "date") rather
+                # than overriding "format" with None. A "pattern" passed in the
+                # field metadata is already handled by metadata2properties.
+                pass
         return ret
 
 

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -617,7 +617,7 @@ def test_datetime2property_custom_format(spec_fixture):
     res = spec_fixture.openapi.field2property(field)
     assert res == {
         "type": "string",
-        "format": None,
+        "format": "date-time",
         "pattern": r"^((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)$",
     }
 
@@ -627,8 +627,16 @@ def test_datetime2property_custom_format_missing_regex(spec_fixture):
     res = spec_fixture.openapi.field2property(field)
     assert res == {
         "type": "string",
-        "format": None,
-        "pattern": None,
+        "format": "date-time",
+    }
+
+
+def test_date2property_custom_format(spec_fixture):
+    field = fields.Date(format="%d-%m-%Y")
+    res = spec_fixture.openapi.field2property(field)
+    assert res == {
+        "type": "string",
+        "format": "date",
     }
 
 


### PR DESCRIPTION
Fixes #938.

## Problem

When a `DateTime` or `Date` field uses a custom strftime `format` string, the
generated OpenAPI property has `format: null` instead of the expected
`format: date-time` / `format: date`.

```python
from marshmallow import Schema, fields
from apispec import APISpec
from apispec.ext.marshmallow import MarshmallowPlugin

class S(Schema):
    dt = fields.DateTime(format="%Y-%m-%dT%H:%M:%S")

ma = MarshmallowPlugin()
APISpec(title="t", version="1", openapi_version="3.0.0", plugins=[ma])
print(ma.converter.schema2jsonschema(S())["properties"]["dt"])
# before: {'type': 'string', 'format': None, 'pattern': None}
# after:  {'type': 'string', 'format': 'date-time'}
```

This is a regression from the change that added support for multiple
`DateTime` formats (#815, released in 6.4): the `else` branch of
`datetime2properties` (custom format) overrode `format` with `None`,
discarding the value coming from `DEFAULT_FIELD_MAPPING`.

## Fix

For a custom format, leave the `type`/`format` set by `field2type_and_format`
(from `DEFAULT_FIELD_MAPPING`) untouched instead of overriding `format` with
`None`. A `pattern` passed through field metadata is already emitted by
`metadata2properties`, so that redundant handling is dropped.

## Tests

- Updated `test_datetime2property_custom_format` and
  `test_datetime2property_custom_format_missing_regex` to assert
  `format: "date-time"`.
- Added `test_date2property_custom_format` covering `Date` with a custom format.

Full test suite passes on both marshmallow 3 and 4.