### PR TITLE
test: preserve anonymous security alternatives

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -161,6 +161,32 @@ class TestMetadata:
             assert metadata["info"]["version"] == "1.0.0"
             assert metadata["info"]["description"] == description
 
+    def test_openapi_metadata_preserves_anonymous_security_alternative(self):
+        spec = APISpec(
+            title="Xquik API",
+            version="1.0.0",
+            openapi_version="3.1.0",
+            security=[{}, {"ApiKeyAuth": []}],
+            components={
+                "securitySchemes": {
+                    "ApiKeyAuth": {
+                        "type": "apiKey",
+                        "in": "header",
+                        "name": "X-API-Key",
+                    }
+                }
+            },
+        )
+
+        metadata = spec.to_dict()
+
+        assert metadata["security"] == [{}, {"ApiKeyAuth": []}]
+        assert metadata["components"]["securitySchemes"]["ApiKeyAuth"] == {
+            "type": "apiKey",
+            "in": "header",
+            "name": "X-API-Key",
+        }
+
     @pytest.mark.parametrize("spec", ("3.0.0",), indirect=True)
     def test_openapi_metadata_merge_v3(self, spec):
         properties = {


### PR DESCRIPTION
Summary
- Add regression coverage for OpenAPI 3.1 metadata with an anonymous security alternative and an API key alternative.
- Use a compact Xquik-style security array to ensure APISpec preserves both entries.

Validation
- Python 3.11: pytest tests/test_core.py -q, 155 passed.
- Diff whitespace check passed.