### PR TITLE
fix: use OpenAPI 'minimum' for timestamp DateTime formats

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,12 @@ Changelog
 unreleased
 **********
 
+Bug fixes:
+
+- ``MarshmallowPlugin``: Emit ``minimum: 0`` rather than the non-standard
+  ``min: "0"`` for ``DateTime`` fields with the ``"timestamp"`` and
+  ``"timestamp_ms"`` formats (:issue:`1064`).
+
 Other changes:
 
 - Drop support for marshmallow 3, which is EOL.

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -592,14 +592,14 @@ class FieldConverterMixin:
                     "type": "number",
                     "format": "float",
                     "example": "1676451245.596",
-                    "min": "0",
+                    "minimum": 0,
                 }
             elif field.format == "timestamp_ms":
                 ret = {
                     "type": "number",
                     "format": "float",
                     "example": "1676451277514.654",
-                    "min": "0",
+                    "minimum": 0,
                 }
             else:
                 ret = {

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -591,7 +591,7 @@ def test_datetime2property_timestamp(spec_fixture):
     assert res == {
         "type": "number",
         "format": "float",
-        "min": "0",
+        "minimum": 0,
         "example": "1676451245.596",
     }
 
@@ -602,7 +602,7 @@ def test_datetime2property_timestamp_ms(spec_fixture):
     assert res == {
         "type": "number",
         "format": "float",
-        "min": "0",
+        "minimum": 0,
         "example": "1676451277514.654",
     }
 


### PR DESCRIPTION
Closes #1064

`DateTime(format="timestamp")` / `format="timestamp_ms"` produced `"min": "0"`, which is not an OpenAPI Schema Object keyword, so the generated spec failed `openapi-spec-validator` with `Property 'min' is not allowed`. Emits the standard numeric `minimum: 0` instead; the two existing timestamp tests are updated to match.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
