### PR TITLE
fix: intersect OneOf and Equal choices in field2choices

### DIFF
--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -242,21 +242,14 @@ class FieldConverterMixin:
         """
         attributes = {}
 
-        comparable = [
-            validator.comparable
-            for validator in field.validators
-            if hasattr(validator, "comparable")
-        ]
-        if comparable:
-            attributes["enum"] = comparable
-        else:
-            choices = [
-                OrderedSet(validator.choices)
-                for validator in field.validators
-                if hasattr(validator, "choices")
-            ]
-            if choices:
-                attributes["enum"] = list(functools.reduce(operator.and_, choices))
+        choices = []
+        for validator in field.validators:
+            if hasattr(validator, "choices"):
+                choices.append(OrderedSet(validator.choices))
+            elif hasattr(validator, "comparable"):
+                choices.append(OrderedSet([validator.comparable]))
+        if choices:
+            attributes["enum"] = list(functools.reduce(operator.and_, choices))
 
         if field.allow_none:
             enum = attributes.get("enum")

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -198,7 +198,62 @@ def test_field_with_choices_multiple(spec_fixture):
         ]
     )
     res = spec_fixture.openapi.field2property(field)
-    assert set(res["enum"]) == {"brian", "john"}
+    assert res["enum"] == ["brian", "john"]
+
+
+def test_field_with_choices_multiple_non_intersecting(spec_fixture):
+    field = fields.Str(
+        validate=[
+            validate.OneOf(["freddie", "brian"]),
+            validate.OneOf(["john", "roger"]),
+        ]
+    )
+    res = spec_fixture.openapi.field2property(field)
+    assert res["enum"] == []
+
+
+def test_field_with_choices_and_equal(spec_fixture):
+    field = fields.Str(
+        validate=[
+            validate.OneOf(["freddie", "brian", "john"]),
+            validate.Equal("brian"),
+        ]
+    )
+    res = spec_fixture.openapi.field2property(field)
+    assert res["enum"] == ["brian"]
+
+
+def test_field_with_choices_and_equal_non_intersecting(spec_fixture):
+    field = fields.Str(
+        validate=[
+            validate.OneOf(["freddie", "brian"]),
+            validate.Equal("john"),
+        ]
+    )
+    res = spec_fixture.openapi.field2property(field)
+    assert res["enum"] == []
+
+
+def test_field_with_multiple_equal_matching(spec_fixture):
+    field = fields.Str(
+        validate=[
+            validate.Equal("brian"),
+            validate.Equal("brian"),
+        ]
+    )
+    res = spec_fixture.openapi.field2property(field)
+    assert res["enum"] == ["brian"]
+
+
+def test_field_with_multiple_equal_conflicting(spec_fixture):
+    field = fields.Str(
+        validate=[
+            validate.Equal("freddie"),
+            validate.Equal("brian"),
+        ]
+    )
+    res = spec_fixture.openapi.field2property(field)
+    assert res["enum"] == []
 
 
 def test_field_with_additional_metadata(spec_fixture):

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -190,70 +190,79 @@ def test_only_allows_valid_properties_in_metadata(spec_fixture):
     assert "not_valid" not in res
 
 
-def test_field_with_choices_multiple(spec_fixture):
-    field = fields.Str(
-        validate=[
-            validate.OneOf(["freddie", "brian", "john"]),
-            validate.OneOf(["brian", "john", "roger"]),
-        ]
-    )
+@pytest.mark.parametrize(
+    ("validators", "expected_enum"),
+    [
+        (
+            [
+                validate.OneOf(["freddie", "brian", "john"]),
+                validate.OneOf(["brian", "john", "roger"]),
+            ],
+            {"brian", "john"},
+        ),
+        (
+            [
+                validate.OneOf(["freddie", "brian"]),
+                validate.OneOf(["john", "roger"]),
+            ],
+            set(),
+        ),
+    ],
+)
+def test_field_with_multiple_oneof(spec_fixture, validators, expected_enum):
+    field = fields.Str(validate=validators)
     res = spec_fixture.openapi.field2property(field)
-    assert res["enum"] == ["brian", "john"]
+    assert set(res["enum"]) == expected_enum
 
 
-def test_field_with_choices_multiple_non_intersecting(spec_fixture):
-    field = fields.Str(
-        validate=[
-            validate.OneOf(["freddie", "brian"]),
-            validate.OneOf(["john", "roger"]),
-        ]
-    )
+@pytest.mark.parametrize(
+    ("validators", "expected_enum"),
+    [
+        (
+            [
+                validate.Equal("brian"),
+                validate.Equal("brian"),
+            ],
+            {"brian"},
+        ),
+        (
+            [
+                validate.Equal("freddie"),
+                validate.Equal("brian"),
+            ],
+            set(),
+        ),
+    ],
+)
+def test_field_with_multiple_equal(spec_fixture, validators, expected_enum):
+    field = fields.Str(validate=validators)
     res = spec_fixture.openapi.field2property(field)
-    assert res["enum"] == []
+    assert set(res["enum"]) == expected_enum
 
 
-def test_field_with_choices_and_equal(spec_fixture):
-    field = fields.Str(
-        validate=[
-            validate.OneOf(["freddie", "brian", "john"]),
-            validate.Equal("brian"),
-        ]
-    )
+@pytest.mark.parametrize(
+    ("validators", "expected_enum"),
+    [
+        (
+            [
+                validate.OneOf(["freddie", "brian", "john"]),
+                validate.Equal("brian"),
+            ],
+            {"brian"},
+        ),
+        (
+            [
+                validate.OneOf(["freddie", "brian"]),
+                validate.Equal("john"),
+            ],
+            set(),
+        ),
+    ],
+)
+def test_field_with_oneof_and_equal(spec_fixture, validators, expected_enum):
+    field = fields.Str(validate=validators)
     res = spec_fixture.openapi.field2property(field)
-    assert res["enum"] == ["brian"]
-
-
-def test_field_with_choices_and_equal_non_intersecting(spec_fixture):
-    field = fields.Str(
-        validate=[
-            validate.OneOf(["freddie", "brian"]),
-            validate.Equal("john"),
-        ]
-    )
-    res = spec_fixture.openapi.field2property(field)
-    assert res["enum"] == []
-
-
-def test_field_with_multiple_equal_matching(spec_fixture):
-    field = fields.Str(
-        validate=[
-            validate.Equal("brian"),
-            validate.Equal("brian"),
-        ]
-    )
-    res = spec_fixture.openapi.field2property(field)
-    assert res["enum"] == ["brian"]
-
-
-def test_field_with_multiple_equal_conflicting(spec_fixture):
-    field = fields.Str(
-        validate=[
-            validate.Equal("freddie"),
-            validate.Equal("brian"),
-        ]
-    )
-    res = spec_fixture.openapi.field2property(field)
-    assert res["enum"] == []
+    assert set(res["enum"]) == expected_enum
 
 
 def test_field_with_additional_metadata(spec_fixture):


### PR DESCRIPTION
Fixes #198

When multiple choice validators are defined on a field (such as multiple `validate.OneOf`, multiple `validate.Equal`, or a mix of `OneOf` and `Equal`), the allowed choices should be the intersection of the values allowed by each validator.

Previously:
- `validate.Equal` overrode any preceding `validate.OneOf` choices.
- Multiple `validate.Equal` validators concatenated their values rather than intersecting them.

### Changes
- Treat `validate.Equal` comparable values as single-element choice sets and intersect all choice sets via `OrderedSet`.
- Added unit tests for multiple `OneOf`, `OneOf` + `Equal`, and multiple `Equal` validators (both intersecting and non-intersecting).
