### PR TITLE
Allow flit_core 4.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ default-groups = ["dev"]
 exclude-newer = "1 week"
 
 [build-system]
-requires = ["flit_core<4"]
+requires = ["flit_core<5"]
 build-backend = "flit_core.buildapi"
 
 [tool.flit.sdist]


### PR DESCRIPTION
Verified that the package builds successfully with new flit_core.