### PR TITLE
Add x-minimum/x-maximum to Date and DateTime fields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -91,3 +91,4 @@ Contributors (chronological)
 - Felix Claessen `@Flix6x <https://github.com/Flix6x>`_
 - Karthik Ramadugu `@karthiksai109 <https://github.com/karthiksai109>`_
 - Amir Kahriman `@kingdomOfIT <https://github.com/kingdomOfIT>`_
+- Louis Deconinck `@LouisDeconinck <https://github.com/LouisDeconinck>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 unreleased
 **********
 
+Features:
+
+- ``MarshmallowPlugin``: Document the inherent bounds of ``Date`` and
+  ``DateTime`` fields (``datetime.date.min``/``max``,
+  ``datetime.datetime.min``/``max``) as ``x-minimum``/``x-maximum``
+  when no ``Range`` validator sets stricter ones (:issue:`440`).
+
 Other changes:
 
 - Drop support for marshmallow 3, which is EOL.

--- a/src/apispec/ext/marshmallow/field_converter.py
+++ b/src/apispec/ext/marshmallow/field_converter.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import functools
 import operator
 import re
@@ -327,6 +328,11 @@ class FieldConverterMixin:
         """Return the dictionary of OpenAPI field attributes for a set of
         :class:`Range <marshmallow.validators.Range>` validators.
 
+        Also documents the inherent bounds of temporal fields
+        (:class:`Date <marshmallow.fields.Date>` and
+        :class:`DateTime <marshmallow.fields.DateTime>`) when no
+        ``Range`` validator sets stricter ones.
+
         :param Field field: A marshmallow field.
         :rtype: dict
         """
@@ -346,11 +352,22 @@ class FieldConverterMixin:
             else ("x-minimum", "x-maximum")
         )
 
+        attributes = make_min_max_attributes(validators, min_attr, max_attr)
+
+        # Date and DateTime fields have inherent bounds
+        # (datetime.date.min/max, datetime.datetime.min/max).
+        # Timestamp formats are skipped as serializing naive datetimes
+        # to POSIX timestamps is timezone-dependent.
+        if getattr(field, "format", None) not in ("timestamp", "timestamp_ms"):
+            if isinstance(field, marshmallow.fields.DateTime):
+                attributes.setdefault(min_attr, dt.datetime.min)
+                attributes.setdefault(max_attr, dt.datetime.max)
+            elif isinstance(field, marshmallow.fields.Date):
+                attributes.setdefault(min_attr, dt.date.min)
+                attributes.setdefault(max_attr, dt.date.max)
+
         # Serialize min/max values with the field to which the validator is applied
-        return {
-            k: field._serialize(v, None, None)
-            for k, v in make_min_max_attributes(validators, min_attr, max_attr).items()
-        }
+        return {k: field._serialize(v, None, None) for k, v in attributes.items()}
 
     def field2length(
         self, field: marshmallow.fields.Field, **kwargs: typing.Any

--- a/tests/test_ext_marshmallow_field.py
+++ b/tests/test_ext_marshmallow_field.py
@@ -383,6 +383,51 @@ def test_field_with_range_datetime_type(spec_fixture):
     assert isinstance(res["type"], str)
 
 
+def test_date_field_min_max(spec_fixture):
+    field = fields.Date()
+    res = spec_fixture.openapi.field2property(field)
+    assert res["x-minimum"] == "0001-01-01"
+    assert res["x-maximum"] == "9999-12-31"
+
+
+def test_datetime_field_min_max(spec_fixture):
+    field = fields.DateTime()
+    res = spec_fixture.openapi.field2property(field)
+    assert res["x-minimum"] == "0001-01-01T00:00:00"
+    assert res["x-maximum"] == "9999-12-31T23:59:59.999999"
+
+
+def test_datetime_field_min_max_with_range(spec_fixture):
+    # Range validator bounds take precedence over the field's inherent bounds
+    field = fields.DateTime(
+        validate=validate.Range(
+            min=dt.datetime(1900, 1, 1),
+            max=dt.datetime(2000, 1, 1),
+        )
+    )
+    res = spec_fixture.openapi.field2property(field)
+    assert res["x-minimum"] == "1900-01-01T00:00:00"
+    assert res["x-maximum"] == "2000-01-01T00:00:00"
+
+
+def test_datetime_field_min_max_with_partial_range(spec_fixture):
+    # The field's inherent bounds fill in the side a Range validator doesn't set
+    field = fields.DateTime(validate=validate.Range(max=dt.datetime(2000, 1, 1)))
+    res = spec_fixture.openapi.field2property(field)
+    assert res["x-minimum"] == "0001-01-01T00:00:00"
+    assert res["x-maximum"] == "2000-01-01T00:00:00"
+
+
+@pytest.mark.parametrize("fmt", ("timestamp", "timestamp_ms"))
+def test_datetime_field_timestamp_no_min_max(spec_fixture, fmt):
+    # No bounds are documented for timestamp formats: serializing the naive
+    # datetime bounds to POSIX timestamps would be timezone-dependent
+    field = fields.DateTime(format=fmt)
+    res = spec_fixture.openapi.field2property(field)
+    assert "x-minimum" not in res
+    assert "x-maximum" not in res
+
+
 def test_field_with_str_regex(spec_fixture):
     regex_str = "^[a-zA-Z0-9]$"
     field = fields.Str(validate=validate.Regexp(regex_str))
@@ -547,6 +592,8 @@ def test_datetime2property_iso(spec_fixture):
     assert res == {
         "type": "string",
         "format": "date-time",
+        "x-minimum": "0001-01-01T00:00:00",
+        "x-maximum": "9999-12-31T23:59:59.999999",
     }
 
 
@@ -556,6 +603,8 @@ def test_datetime2property_iso8601(spec_fixture):
     assert res == {
         "type": "string",
         "format": "date-time",
+        "x-minimum": "0001-01-01T00:00:00",
+        "x-maximum": "9999-12-31T23:59:59.999999",
     }
 
 
@@ -569,6 +618,8 @@ def test_datetime2property_rfc(spec_fixture):
         "pattern": r"((Mon|Tue|Wed|Thu|Fri|Sat|Sun), ){0,1}\d{2} "
         + r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} "
         + r"(UT|GMT|EST|EDT|CST|CDT|MST|MDT|PST|PDT|(Z|A|M|N)|(\+|-)\d{4})",
+        "x-minimum": "Mon, 01 Jan 0001 00:00:00 -0000",
+        "x-maximum": "Fri, 31 Dec 9999 23:59:59 -0000",
     }
 
 
@@ -582,6 +633,8 @@ def test_datetime2property_rfc822(spec_fixture):
         "pattern": r"((Mon|Tue|Wed|Thu|Fri|Sat|Sun), ){0,1}\d{2} "
         + r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} "
         + r"(UT|GMT|EST|EDT|CST|CDT|MST|MDT|PST|PDT|(Z|A|M|N)|(\+|-)\d{4})",
+        "x-minimum": "Mon, 01 Jan 0001 00:00:00 -0000",
+        "x-maximum": "Fri, 31 Dec 9999 23:59:59 -0000",
     }
 
 
@@ -608,8 +661,9 @@ def test_datetime2property_timestamp_ms(spec_fixture):
 
 
 def test_datetime2property_custom_format(spec_fixture):
+    fmt = "%d-%m%Y %H:%M:%S"
     field = fields.DateTime(
-        format="%d-%m%Y %H:%M:%S",
+        format=fmt,
         metadata={
             "pattern": r"^((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)$"
         },
@@ -619,16 +673,21 @@ def test_datetime2property_custom_format(spec_fixture):
         "type": "string",
         "format": None,
         "pattern": r"^((?:(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}(?:\.\d+)?))(Z|[\+-]\d{2}:\d{2})?)$",
+        "x-minimum": dt.datetime.min.strftime(fmt),
+        "x-maximum": dt.datetime.max.strftime(fmt),
     }
 
 
 def test_datetime2property_custom_format_missing_regex(spec_fixture):
-    field = fields.DateTime(format="%d-%m%Y %H:%M:%S")
+    fmt = "%d-%m%Y %H:%M:%S"
+    field = fields.DateTime(format=fmt)
     res = spec_fixture.openapi.field2property(field)
     assert res == {
         "type": "string",
         "format": None,
         "pattern": None,
+        "x-minimum": dt.datetime.min.strftime(fmt),
+        "x-maximum": dt.datetime.max.strftime(fmt),
     }
 
 

--- a/tests/test_ext_marshmallow_openapi.py
+++ b/tests/test_ext_marshmallow_openapi.py
@@ -707,7 +707,13 @@ class TestFieldValidation:
             ("custom_field_length", {"minLength": 1, "maxLength": 10}),
             ("multiple_lengths", {"minLength": 3, "maxLength": 7}),
             ("equal_length", {"minLength": 5, "maxLength": 5}),
-            ("date_range", {"x-minimum": "1900-01-01T00:00:00"}),
+            (
+                "date_range",
+                {
+                    "x-minimum": "1900-01-01T00:00:00",
+                    "x-maximum": "9999-12-31T23:59:59.999999",
+                },
+            ),
         ],
     )
     def test_properties(self, field, properties, spec):


### PR DESCRIPTION
Closes #440.

`fields.Date` and `fields.DateTime` now document their inherent bounds (`datetime.date.min`/`max`, `datetime.datetime.min`/`max`) as `x-minimum`/`x-maximum` extensions, following the convention established for non-numeric ranges in #616 (plain `minimum`/`maximum` are not valid on string-typed schema objects).

Bounds are serialized with the field itself, so `iso`, `rfc`, and custom `strftime` formats each emit bounds in the field's own format. Explicit `Range` validators take precedence; the implicit bound fills in whichever side a validator doesn't constrain.

`timestamp`/`timestamp_ms` formats are skipped: serializing the naive `datetime.min`/`max` bounds to POSIX timestamps is timezone-dependent, so the emitted value would not be reproducible.

`fields.Time` (`time.min`/`max`) could be covered the same way — left out here to match the issue's date/datetime scope; happy to add it if wanted.

_Disclosure: implemented with AI assistance; reviewed and verified locally (`uv run pytest`: 630 passed)._